### PR TITLE
Reinforced DevSecOps setup with scanners TruffleHog & GGShield

### DIFF
--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -1,0 +1,58 @@
+name: Pull Request Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# Actions Used (please keep this documented here as added)
+#  https://github.com/actions/setup-python#usage
+#  https://github.com/marketplace/actions/trufflehog-oss
+
+jobs:
+  build:
+    # Default access (restricted) - https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+
+    steps:
+      - name: Print toolchain versions
+        run: |
+          node -v
+          python3 -V
+          make --version
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@v3.34.0
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          make install
+
+      - name: Lint and code formatting
+        run: |
+          make check
+
+      - name: Run test suite
+        run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test
+.PHONY: test deep scan
 
 install:
 	@yarn install
@@ -11,6 +11,12 @@ check:
 	@yarn lint
 	@yarn prettier
 	@pre-commit run --all-files
+
+scan:
+	@trufflehog --debug --only-verified git file://./ --since-commit main --branch HEAD --fail
+
+deep: scan
+	@ggshield secret scan repo .
 
 test:
 	@yarn test

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 pre-commit
 detect-secrets
 black
+ggshield


### PR DESCRIPTION
* Added GitHub Action workflow for PR Build - pre-stage to CodePipeline
* It will run past check Makefile targets
  * make check -- Any issue lint, formatter
  * make test  -- Run unit test suite
* It also run TruffleHog scanner as last checkpointing
