### PR TITLE
Improved Django Skel by removing base setting as default

### DIFF
--- a/skel/django-api/src/migrate.py
+++ b/skel/django-api/src/migrate.py
@@ -3,11 +3,8 @@
 
 Convenience AWS lambda handler for Django database migration command hook
 """
-import os
 
 from django.core.management import execute_from_command_line
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{project_name}}.settings.base')
 
 
 def handler(event, context) -> str:

--- a/skel/django-api/src/project_name/wsgi.py
+++ b/skel/django-api/src/project_name/wsgi.py
@@ -1,7 +1,3 @@
-import os
-
 from django.core.wsgi import get_wsgi_application
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{project_name}}.settings.base")
 
 application = get_wsgi_application()

--- a/skel/django-api/src/project_name_proc/lambdas/hello_proc.py
+++ b/skel/django-api/src/project_name_proc/lambdas/hello_proc.py
@@ -1,7 +1,5 @@
-import os
 import django
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{project_name}}.settings.base')
 django.setup()
 
 # --- keep ^^^ at top of the module

--- a/skel/django-proc/src/migrate.py
+++ b/skel/django-proc/src/migrate.py
@@ -3,11 +3,8 @@
 
 Convenience AWS lambda handler for Django database migration command hook
 """
-import os
 
 from django.core.management import execute_from_command_line
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{project_name}}.settings.base')
 
 
 def handler(event, context) -> str:

--- a/skel/django-proc/src/project_name_proc/lambdas/hello_proc.py
+++ b/skel/django-proc/src/project_name_proc/lambdas/hello_proc.py
@@ -1,7 +1,5 @@
-import os
 import django
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', '{{project_name}}.settings.base')
 django.setup()
 
 # --- keep ^^^ at top of the module


### PR DESCRIPTION
* Deployed target must set `DJANGO_SETTINGS_MODULE` env var
  to `aws` setting. Else, it is better that let it crash by default.
* See #28 convo.
