### PR TITLE
fix: event source name rule should be an array

### DIFF
--- a/lib/workload/stateful/event_source/component.ts
+++ b/lib/workload/stateful/event_source/component.ts
@@ -72,7 +72,7 @@ export class EventSource extends Construct {
           detail: {
             ...(prop.bucket && {
               bucket: {
-                name: prop.bucket,
+                name: [prop.bucket],
               },
             }),
             ...(prop.prefix && {

--- a/test/stateful/eventSourceConstruct.test.ts
+++ b/test/stateful/eventSourceConstruct.test.ts
@@ -26,7 +26,7 @@ function assert_common(template: Template) {
       source: ['aws.s3'],
       detail: {
         bucket: {
-          name: 'bucket',
+          name: ['bucket'],
         },
       },
     },


### PR DESCRIPTION
Closes #111 

### Changes
* Convert `EventSource` name rule to array.