### PR TITLE
fix(filemanager): ingest constraints

### DIFF
--- a/lib/workload/stateless/filemanager/database/migrations/0002_add_s3_object_table.sql
+++ b/lib/workload/stateless/filemanager/database/migrations/0002_add_s3_object_table.sql
@@ -24,6 +24,8 @@ create table s3_object (
     bucket text not null,
     -- The key of the object.
     key text not null,
+    -- The version id of the object.
+    version_id text not null default 'null',
     -- When this object was created. A null value here means that a deleted event has occurred before a created event.
     created_date timestamptz default null,
     -- When this object was deleted, a null value means that the object has not yet been deleted.
@@ -41,8 +43,6 @@ create table s3_object (
     e_tag text default null,
     -- The S3 storage class of the object.
     storage_class storage_class default null,
-    -- The version id of the object, if present.
-    version_id text default null,
     -- A sequencer value for when the object was created. Used to synchronise out of order and duplicate events.
     created_sequencer text default null,
     -- A sequencer value for when the object was deleted. Used to synchronise out of order and duplicate events.
@@ -53,6 +53,6 @@ create table s3_object (
     number_duplicate_events integer not null default 0,
 
     -- The sequencers should be unique with the bucket, key, and its version, otherwise this is a duplicate event.
-    constraint created_sequencer_unique unique nulls not distinct (bucket, key, version_id, created_sequencer),
-    constraint deleted_sequencer_unique unique nulls not distinct (bucket, key, version_id, deleted_sequencer)
+    constraint created_sequencer_unique unique (bucket, key, version_id, created_sequencer),
+    constraint deleted_sequencer_unique unique (bucket, key, version_id, deleted_sequencer)
 );

--- a/lib/workload/stateless/filemanager/database/migrations/0002_add_s3_object_table.sql
+++ b/lib/workload/stateless/filemanager/database/migrations/0002_add_s3_object_table.sql
@@ -24,7 +24,8 @@ create table s3_object (
     bucket text not null,
     -- The key of the object.
     key text not null,
-    -- The version id of the object.
+    -- The version id of the object. A 'null' string is used to indicate no version id. This matches logic in AWS which
+    -- also returns 'null' strings.
     version_id text not null default 'null',
     -- When this object was created. A null value here means that a deleted event has occurred before a created event.
     created_date timestamptz default null,

--- a/lib/workload/stateless/filemanager/database/migrations/0002_add_s3_object_table.sql
+++ b/lib/workload/stateless/filemanager/database/migrations/0002_add_s3_object_table.sql
@@ -25,7 +25,7 @@ create table s3_object (
     -- The key of the object.
     key text not null,
     -- The version id of the object. A 'null' string is used to indicate no version id. This matches logic in AWS which
-    -- also returns 'null' strings.
+    -- also returns 'null' strings. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html
     version_id text not null default 'null',
     -- When this object was created. A null value here means that a deleted event has occurred before a created event.
     created_date timestamptz default null,

--- a/lib/workload/stateless/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
+++ b/lib/workload/stateless/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
@@ -51,7 +51,7 @@ current_objects as (
     join input on
         input.bucket = s3_object.bucket and
         input.key = s3_object.key and
-        input.version_id is not distinct from s3_object.version_id
+        input.version_id = s3_object.version_id
     -- Lock this pre-emptively for the update.
     for update
 ),
@@ -107,7 +107,7 @@ select
     last_modified_date,
     e_tag,
     storage_class as "storage_class?: StorageClass",
-    version_id,
+    version_id as "version_id!",
     created_sequencer as sequencer,
     number_reordered,
     number_duplicate_events,

--- a/lib/workload/stateless/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
+++ b/lib/workload/stateless/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
@@ -36,7 +36,7 @@ current_objects as (
     join input on
         input.bucket = s3_object.bucket and
         input.key = s3_object.key and
-        input.version_id is not distinct from s3_object.version_id
+        input.version_id = s3_object.version_id
     -- Lock this pre-emptively for the update.
     for update
 ),
@@ -82,7 +82,7 @@ select
     last_modified_date,
     e_tag,
     storage_class as "storage_class?: StorageClass",
-    version_id,
+    version_id as "version_id!",
     deleted_sequencer as sequencer,
     number_reordered,
     number_duplicate_events,

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/ingester.rs
@@ -1195,161 +1195,88 @@ pub(crate) mod tests {
 
         // 720 permutations
         run_permutation_test(&pool, event_permutations, 5, |s3_object_results| {
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id")
-                            == FlatS3EventMessage::default_version_id()
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("1".to_string())
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("2".to_string())
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id")
-                            == FlatS3EventMessage::default_version_id()
-                        && object
-                            .get::<Option<String>, _>("created_sequencer")
-                            .is_none()
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("3".to_string())
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id")
-                            == FlatS3EventMessage::default_version_id()
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("4".to_string())
-                        && object
-                            .get::<Option<String>, _>("deleted_sequencer")
-                            .is_none()
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id")
-                            == FlatS3EventMessage::default_version_id()
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("5".to_string())
-                        && object
-                            .get::<Option<String>, _>("deleted_sequencer")
-                            .is_none()
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key1"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id")
-                            == FlatS3EventMessage::default_version_id()
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("1".to_string())
-                        && object
-                            .get::<Option<String>, _>("deleted_sequencer")
-                            .is_none()
-                })
-                .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                &FlatS3EventMessage::default_version_id(),
+                Some("1"),
+                Some("2"),
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                &FlatS3EventMessage::default_version_id(),
+                None,
+                Some("3"),
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                &FlatS3EventMessage::default_version_id(),
+                Some("4"),
+                None,
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                &FlatS3EventMessage::default_version_id(),
+                Some("5"),
+                None,
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key1",
+                "bucket",
+                &FlatS3EventMessage::default_version_id(),
+                Some("1"),
+                None,
+            )
+            .unwrap();
         })
         .await;
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn ingest_permutations_small(pool: PgPool) {
-        let event_permutations = vec![
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Created)
-                .with_sequencer(Some("1".to_string())),
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Deleted)
-                .with_sequencer(Some("2".to_string())),
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Created)
-                .with_sequencer(Some("3".to_string())),
-            // Duplicate
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Created)
-                .with_sequencer(Some("3".to_string())),
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Deleted)
-                .with_sequencer(Some("4".to_string())),
-            // Different version id
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id1".to_string())
-                .with_event_type(Deleted)
-                .with_sequencer(Some("1".to_string())),
-        ];
+        let event_permutations = example_event_permutations();
 
         // 720 permutations
         run_permutation_test(&pool, event_permutations, 3, |s3_object_results| {
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id") == *"version_id"
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("1".to_string())
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("2".to_string())
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id") == *"version_id"
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("3".to_string())
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("4".to_string())
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id") == *"version_id1"
-                        && object
-                            .get::<Option<String>, _>("created_sequencer")
-                            .is_none()
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("1".to_string())
-                })
-                .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                "version_id",
+                Some("1"),
+                Some("2"),
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                "version_id",
+                Some("3"),
+                Some("4"),
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                "version_id1",
+                None,
+                Some("1"),
+            )
+            .unwrap();
         })
         .await;
     }
@@ -1359,38 +1286,8 @@ pub(crate) mod tests {
     async fn ingest_permutations(pool: PgPool) {
         // This primarily tests out of order and duplicate event ingestion, however it could also function
         // as a performance test.
-        let event_permutations = vec![
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Created)
-                .with_sequencer(Some("1".to_string())),
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Deleted)
-                .with_sequencer(Some("2".to_string())),
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Created)
-                .with_sequencer(Some("3".to_string())),
-            // Duplicate
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Created)
-                .with_sequencer(Some("3".to_string())),
-            FlatS3EventMessage::new_with_generated_id()
-                .with_bucket("bucket".to_string())
-                .with_key("key".to_string())
-                .with_version_id("version_id".to_string())
-                .with_event_type(Deleted)
-                .with_sequencer(Some("4".to_string())),
+        let mut event_permutations = example_event_permutations();
+        event_permutations.extend(vec![
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
@@ -1403,6 +1300,83 @@ pub(crate) mod tests {
                 .with_version_id("version_id".to_string())
                 .with_event_type(Deleted)
                 .with_sequencer(Some("6".to_string())),
+        ]);
+
+        // 40320 permutations
+        run_permutation_test(&pool, event_permutations, 4, |s3_object_results| {
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                "version_id",
+                Some("1"),
+                Some("2"),
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                "version_id",
+                Some("3"),
+                Some("4"),
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                "version_id",
+                Some("5"),
+                Some("6"),
+            )
+            .unwrap();
+            find_object_with(
+                &s3_object_results,
+                "key",
+                "bucket",
+                "version_id1",
+                None,
+                Some("1"),
+            )
+            .unwrap();
+        })
+        .await;
+    }
+
+    fn example_event_permutations() -> Vec<FlatS3EventMessage> {
+        vec![
+            FlatS3EventMessage::new_with_generated_id()
+                .with_bucket("bucket".to_string())
+                .with_key("key".to_string())
+                .with_version_id("version_id".to_string())
+                .with_event_type(Created)
+                .with_sequencer(Some("1".to_string())),
+            FlatS3EventMessage::new_with_generated_id()
+                .with_bucket("bucket".to_string())
+                .with_key("key".to_string())
+                .with_version_id("version_id".to_string())
+                .with_event_type(Deleted)
+                .with_sequencer(Some("2".to_string())),
+            FlatS3EventMessage::new_with_generated_id()
+                .with_bucket("bucket".to_string())
+                .with_key("key".to_string())
+                .with_version_id("version_id".to_string())
+                .with_event_type(Created)
+                .with_sequencer(Some("3".to_string())),
+            // Duplicate
+            FlatS3EventMessage::new_with_generated_id()
+                .with_bucket("bucket".to_string())
+                .with_key("key".to_string())
+                .with_version_id("version_id".to_string())
+                .with_event_type(Created)
+                .with_sequencer(Some("3".to_string())),
+            FlatS3EventMessage::new_with_generated_id()
+                .with_bucket("bucket".to_string())
+                .with_key("key".to_string())
+                .with_version_id("version_id".to_string())
+                .with_event_type(Deleted)
+                .with_sequencer(Some("4".to_string())),
             // Different version id
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
@@ -1410,61 +1384,24 @@ pub(crate) mod tests {
                 .with_version_id("version_id1".to_string())
                 .with_event_type(Deleted)
                 .with_sequencer(Some("1".to_string())),
-        ];
+        ]
+    }
 
-        // 40320 permutations
-        run_permutation_test(&pool, event_permutations, 4, |s3_object_results| {
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id") == *"version_id"
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("1".to_string())
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("2".to_string())
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id") == *"version_id"
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("3".to_string())
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("4".to_string())
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id") == *"version_id"
-                        && object.get::<Option<String>, _>("created_sequencer")
-                            == Some("5".to_string())
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("6".to_string())
-                })
-                .unwrap();
-            s3_object_results
-                .iter()
-                .find(|object| {
-                    object.get::<String, _>("key") == "key"
-                        && object.get::<String, _>("bucket") == "bucket"
-                        && object.get::<String, _>("version_id") == *"version_id1"
-                        && object
-                            .get::<Option<String>, _>("created_sequencer")
-                            .is_none()
-                        && object.get::<Option<String>, _>("deleted_sequencer")
-                            == Some("1".to_string())
-                })
-                .unwrap();
+    fn find_object_with<'a>(
+        results: &'a [PgRow],
+        key: &str,
+        bucket: &str,
+        version_id: &str,
+        created_sequencer: Option<&str>,
+        deleted_sequencer: Option<&str>,
+    ) -> Option<&'a PgRow> {
+        results.iter().find(|object| {
+            object.get::<String, _>("key") == key
+                && object.get::<String, _>("bucket") == bucket
+                && object.get::<String, _>("version_id") == version_id
+                && object.get::<Option<&str>, _>("created_sequencer") == created_sequencer
+                && object.get::<Option<&str>, _>("deleted_sequencer") == deleted_sequencer
         })
-        .await;
     }
 
     async fn run_permutation_test<F>(

--- a/lib/workload/stateless/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/events/aws/message.rs
@@ -128,7 +128,7 @@ impl From<Record> for FlatS3EventMessages {
             size,
             e_tag: etag,
             sequencer,
-            version_id,
+            version_id: version_id.unwrap_or_else(FlatS3EventMessage::default_version_id),
             // Head fields are fetched later.
             storage_class: None,
             last_modified_date: None,
@@ -179,7 +179,7 @@ mod tests {
             &Deleted,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
     }
 
@@ -195,7 +195,7 @@ mod tests {
             &Deleted,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
     }
 }

--- a/lib/workload/stateless/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/events/aws/mod.rs
@@ -458,6 +458,12 @@ impl FlatS3EventMessage {
         self
     }
 
+    /// Set the version id.
+    pub fn with_default_version_id(mut self) -> Self {
+        self.version_id = Self::default_version_id();
+        self
+    }
+
     /// Set the size.
     pub fn with_size(mut self, size: Option<i32>) -> Self {
         self.size = size;

--- a/lib/workload/stateless/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/events/aws/mod.rs
@@ -65,7 +65,7 @@ pub struct TransposedS3EventMessages {
     pub event_times: Vec<Option<DateTime<Utc>>>,
     pub buckets: Vec<String>,
     pub keys: Vec<String>,
-    pub version_ids: Vec<Option<String>>,
+    pub version_ids: Vec<String>,
     pub sizes: Vec<Option<i32>>,
     pub e_tags: Vec<Option<String>>,
     pub sequencers: Vec<Option<String>>,
@@ -383,7 +383,7 @@ pub struct FlatS3EventMessage {
     pub sequencer: Option<String>,
     pub bucket: String,
     pub key: String,
-    pub version_id: Option<String>,
+    pub version_id: String,
     pub size: Option<i32>,
     pub e_tag: Option<String>,
     pub storage_class: Option<StorageClass>,
@@ -453,7 +453,7 @@ impl FlatS3EventMessage {
     }
 
     /// Set the version id.
-    pub fn with_version_id(mut self, version_id: Option<String>) -> Self {
+    pub fn with_version_id(mut self, version_id: String) -> Self {
         self.version_id = version_id;
         self
     }
@@ -492,6 +492,10 @@ impl FlatS3EventMessage {
     pub fn with_event_type(mut self, event_type: EventType) -> Self {
         self.event_type = event_type;
         self
+    }
+
+    pub fn default_version_id() -> String {
+        "null".to_string()
     }
 }
 
@@ -533,7 +537,7 @@ pub(crate) mod tests {
             &EventType::Deleted,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
 
         let second = result.next().unwrap();
@@ -542,7 +546,7 @@ pub(crate) mod tests {
             &EventType::Created,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(0),
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
 
         let third = result.next().unwrap();
@@ -551,7 +555,7 @@ pub(crate) mod tests {
             &EventType::Created,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(0),
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
     }
 
@@ -566,7 +570,7 @@ pub(crate) mod tests {
             &EventType::Created,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(0),
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
 
         let second = result.next().unwrap();
@@ -575,7 +579,7 @@ pub(crate) mod tests {
             &EventType::Deleted,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
     }
 
@@ -590,7 +594,7 @@ pub(crate) mod tests {
                 .first()
                 .unwrap()
                 .clone()
-                .with_version_id(Some("version_id".to_string())),
+                .with_version_id("version_id".to_string()),
         );
 
         let result = FlatS3EventMessages(result).sort_and_dedup();
@@ -602,7 +606,7 @@ pub(crate) mod tests {
             &EventType::Created,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(0),
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
 
         let second = result.next().unwrap();
@@ -611,7 +615,7 @@ pub(crate) mod tests {
             &EventType::Deleted,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
         );
 
         let third = result.next().unwrap();
@@ -620,7 +624,7 @@ pub(crate) mod tests {
             &EventType::Deleted,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
-            Some("version_id".to_string()),
+            "version_id".to_string(),
         );
     }
 
@@ -629,7 +633,7 @@ pub(crate) mod tests {
         event_type: &EventType,
         sequencer: Option<String>,
         size: Option<i32>,
-        version_id: Option<String>,
+        version_id: String,
     ) {
         assert_eq!(event.event_time, Some(DateTime::<Utc>::default()));
         assert_eq!(&event.event_type, event_type);
@@ -656,7 +660,7 @@ pub(crate) mod tests {
         assert_eq!(events.sizes[position], size);
         assert_eq!(
             events.version_ids[position],
-            Some(EXPECTED_VERSION_ID.to_string())
+            EXPECTED_VERSION_ID.to_string()
         );
         assert_eq!(events.e_tags[position], Some(EXPECTED_E_TAG.to_string()));
         assert_eq!(events.sequencers[position], Some(sequencer.to_string()));

--- a/lib/workload/stateless/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/handlers/aws.rs
@@ -97,7 +97,9 @@ mod tests {
     use crate::events::aws::collecter::tests::{
         expected_head_object, set_s3_client_expectations, set_sqs_client_expectations,
     };
-    use crate::events::aws::tests::{expected_event_record_simple, EXPECTED_VERSION_ID};
+    use crate::events::aws::tests::{
+        expected_event_record_simple, EXPECTED_SEQUENCER_DELETED_ONE, EXPECTED_VERSION_ID,
+    };
 
     use super::*;
 
@@ -121,7 +123,9 @@ mod tests {
         assert_deleted_with(
             &s3_object_results[0],
             Some(0),
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_SEQUENCER_DELETED_ONE,
+            EXPECTED_VERSION_ID.to_string(),
+            Some(Default::default()),
         );
     }
 
@@ -149,7 +153,9 @@ mod tests {
         assert_deleted_with(
             &s3_object_results[0],
             Some(0),
-            Some(EXPECTED_VERSION_ID.to_string()),
+            EXPECTED_SEQUENCER_DELETED_ONE,
+            EXPECTED_VERSION_ID.to_string(),
+            Some(Default::default()),
         );
     }
 }

--- a/lib/workload/stateless/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/handlers/aws.rs
@@ -92,14 +92,12 @@ mod tests {
     use aws_lambda_events::sqs::SqsMessage;
     use sqlx::PgPool;
 
-    use crate::database::aws::ingester::tests::{assert_deleted_with, fetch_results};
+    use crate::database::aws::ingester::tests::{assert_ingest_events, fetch_results};
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::events::aws::collecter::tests::{
         expected_head_object, set_s3_client_expectations, set_sqs_client_expectations,
     };
-    use crate::events::aws::tests::{
-        expected_event_record_simple, EXPECTED_SEQUENCER_DELETED_ONE, EXPECTED_VERSION_ID,
-    };
+    use crate::events::aws::tests::{expected_event_record_simple, EXPECTED_VERSION_ID};
 
     use super::*;
 
@@ -120,13 +118,7 @@ mod tests {
 
         assert_eq!(object_results.len(), 1);
         assert_eq!(s3_object_results.len(), 1);
-        assert_deleted_with(
-            &s3_object_results[0],
-            Some(0),
-            EXPECTED_SEQUENCER_DELETED_ONE,
-            EXPECTED_VERSION_ID.to_string(),
-            Some(Default::default()),
-        );
+        assert_ingest_events(&s3_object_results[0], EXPECTED_VERSION_ID);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -150,12 +142,6 @@ mod tests {
 
         assert_eq!(object_results.len(), 1);
         assert_eq!(s3_object_results.len(), 1);
-        assert_deleted_with(
-            &s3_object_results[0],
-            Some(0),
-            EXPECTED_SEQUENCER_DELETED_ONE,
-            EXPECTED_VERSION_ID.to_string(),
-            Some(Default::default()),
-        );
+        assert_ingest_events(&s3_object_results[0], EXPECTED_VERSION_ID);
     }
 }


### PR DESCRIPTION
Closes #131 

### Changes
* Make `version_id` required with a default value as the 'null' string.
* Ensure that only one row is returned from the main `current_objects` select query when reordering events.
* Various test fixes:
    * Add tests for missing created/deleted events, missing sequencer values, and multiple matching rows for reordering.
    * Fix permutation tests and add smaller non-ignored tests.