### PR TITLE
fix(pipeline): install Rust for unit tests

### DIFF
--- a/lib/pipeline/orcabus-stateless-pipeline-stack.ts
+++ b/lib/pipeline/orcabus-stateless-pipeline-stack.ts
@@ -21,6 +21,11 @@ export class StatelessPipelineStack extends cdk.Stack {
     });
 
     const unitTest = new pipelines.CodeBuildStep('UnitTest', {
+      installCommands: [
+        //  RUST installation
+        `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
+        `source $HOME/.cargo/env`,
+      ],
       commands: ['yarn install --immutable', 'make suite'],
       input: sourceFile,
       primaryOutputDirectory: '.',


### PR DESCRIPTION
Fixes #153

### Changes
* Add Rust back to pipeline in order to run unit tests.

Potentially another way around this is to dockerize the unit tests? Although not sure if something like that is necessary.