### PR TITLE
fix: pipeline error caused by filemanager containerized build

### DIFF
--- a/lib/pipeline/orcabus-stateless-pipeline-stack.ts
+++ b/lib/pipeline/orcabus-stateless-pipeline-stack.ts
@@ -25,6 +25,7 @@ export class StatelessPipelineStack extends cdk.Stack {
         //  RUST installation
         `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
         `source $HOME/.cargo/env`,
+        `pip3 install cargo-lambda`,
       ],
       commands: ['yarn install --immutable', 'make suite'],
       input: sourceFile,
@@ -55,6 +56,12 @@ export class StatelessPipelineStack extends cdk.Stack {
     });
 
     const synthAction = new pipelines.CodeBuildStep('Synth', {
+      installCommands: [
+        //  RUST installation
+        `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
+        `source $HOME/.cargo/env`,
+        `pip3 install cargo-lambda`,
+      ],
       commands: ['yarn install --immutable', 'yarn run cdk-stateless-pipeline synth'],
       input: unitTest,
       primaryOutputDirectory: 'cdk.out',

--- a/lib/workload/stateless/filemanager/deploy/constructs/functions/function.ts
+++ b/lib/workload/stateless/filemanager/deploy/constructs/functions/function.ts
@@ -108,11 +108,8 @@ export class Function extends Construct {
           // Avoid permission issues by creating another target directory.
           CARGO_TARGET_DIR: "target-cdk-docker-bundling",
           // The bundling container needs to be able to connect to the container running postgres.
-          DATABASE_URL: "postgresql://filemanager:filemanager@host.docker.internal:4321/filemanager", // pragma: allowlist secret
-        },
-        // This uses docker only to compile the binary. I.e. the Lambda function still runs natively and
-        // is not dockerized.
-        forcedDockerBundling: true,
+          DATABASE_URL: "postgresql://filemanager:filemanager@localhost:4321/filemanager", // pragma: allowlist secret
+        }
       },
       memorySize: 128,
       timeout: Duration.seconds(28),


### PR DESCRIPTION
Related to #154.

### Changes
* Reverts changes made in #152 to build filemanager outside of a docker container.

This removes the containerized filemanager build because the build container is unable to connect to host.docker.internal inside CodeBuild to check queries. I'll have to change the compose/docker networking settings in order to re-enable to containerized build. I've tested this is dev, so for now, this should hopefully allow the build to succeed :crossed_fingers:.