### PR TITLE
build(deps): bump postgres versions to match RDS instance

### DIFF
--- a/lib/workload/stateless/filemanager/database/Dockerfile
+++ b/lib/workload/stateless/filemanager/database/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres:15
+FROM public.ecr.aws/docker/library/postgres:15.4
 
 COPY migrations/ /docker-entrypoint-initdb.d/

--- a/shared/mock-db.yml
+++ b/shared/mock-db.yml
@@ -6,7 +6,7 @@ services:
     # Use version that align with upper bound of AWS Aurora PostgreSQL LTS
     # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.LTS.html
     # See container image doc https://gallery.ecr.aws/docker/library/postgres for more settings
-    image: public.ecr.aws/docker/library/postgres:14
+    image: public.ecr.aws/docker/library/postgres:15.4
     container_name: orcabus_db
     restart: always
     environment:


### PR DESCRIPTION
* Bumps postgres versions to match RDS and fetch from public.ecr.aws.