### PR TITLE
fix(filemanager): let docker decide on container names

### DIFF
--- a/lib/workload/stateless/filemanager/Makefile
+++ b/lib/workload/stateless/filemanager/Makefile
@@ -42,7 +42,7 @@ clean: docker-clean
 
 ## Database related targets
 psql:
-	@docker exec -it filemanager_db psql filemanager -U filemanager
+	@docker compose exec postgres psql filemanager -U filemanager
 
 ## Help text
 help:

--- a/lib/workload/stateless/filemanager/compose.yml
+++ b/lib/workload/stateless/filemanager/compose.yml
@@ -3,7 +3,6 @@ version: '3.1'
 services:
   postgres:
     build: database
-    container_name: filemanager_db
     restart: always
     environment:
       - POSTGRES_DATABASE=filemanager


### PR DESCRIPTION
Related to #180

* Fixes container name clash in CodeBuild by allowing docker to automatically name containers.