### PR TITLE
fix(filemanager): use docker run to get unique containers

### DIFF
--- a/lib/workload/stateless/filemanager/.env.example
+++ b/lib/workload/stateless/filemanager/.env.example
@@ -1,2 +1,4 @@
 # Example env file which sets the DATABASE_URL to a local postgres instance.
-DATABASE_URL=postgresql://filemanager:filemanager@localhost:4321/filemanager #pragma: allowlist secret
+FILEMANAGER_DATABASE_HOST=0.0.0.0
+FILEMANAGER_DATABASE_PORT=4321
+DATABASE_URL=postgresql://filemanager:filemanager@${FILEMANAGER_DATABASE_HOST}:${FILEMANAGER_DATABASE_PORT}/filemanager #pragma: allowlist secret

--- a/lib/workload/stateless/filemanager/Makefile
+++ b/lib/workload/stateless/filemanager/Makefile
@@ -1,4 +1,6 @@
-POSTGRES_DATABASE_URL ?= postgresql://filemanager:filemanager@localhost:4321/filemanager #pragma: allowlist secret
+FILEMANAGER_DATABASE_HOST ?= localhost
+FILEMANAGER_DATABASE_PORT ?= 4321
+POSTGRES_DATABASE_URL ?= postgresql://filemanager:filemanager@${FILEMANAGER_DATABASE_HOST}:${FILEMANAGER_DATABASE_PORT}/filemanager #pragma: allowlist secret
 
 export DATABASE_URL=$(POSTGRES_DATABASE_URL)
 
@@ -17,6 +19,9 @@ docker-postgres:
 	@docker compose up --wait -d postgres
 docker-clean:
 	@docker compose down --volumes
+docker-run:
+	@FILEMANAGER_DATABASE_HOST=0.0.0.0 FILEMANAGER_DATABASE_PORT=0 \
+	docker compose run -d --service-ports postgres | xargs -I {} docker port {} $(FILEMANAGER_DATABASE_PORT)
 
 ## Build related commands
 build: docker-postgres

--- a/lib/workload/stateless/filemanager/compose.yml
+++ b/lib/workload/stateless/filemanager/compose.yml
@@ -10,4 +10,4 @@ services:
       - POSTGRES_PASSWORD=filemanager
       - PGPORT=4321
     ports:
-      - "4321:4321"
+      - "${FILEMANAGER_DATABASE_HOST}:${FILEMANAGER_DATABASE_PORT}:4321"

--- a/lib/workload/stateless/filemanager/deploy/constructs/functions/function.ts
+++ b/lib/workload/stateless/filemanager/deploy/constructs/functions/function.ts
@@ -97,7 +97,8 @@ export class Function extends Construct {
     // This starts the container running postgres in order to compile queries using sqlx.
     // It needs to be executed outside `beforeBundling`, because `beforeBundling` runs inside
     // the container context, and docker compose needs to run outside of this context.
-    exec('make', ['docker-postgres'], { cwd: manifestPath, shell: true });
+    const output = exec('make', ['docker-run'], { cwd: manifestPath, shell: true });
+    const address = output.stdout.toString().trim();
 
     this._function = new RustFunction(this, 'RustFunction', {
       manifestPath,
@@ -108,7 +109,7 @@ export class Function extends Construct {
           // Avoid permission issues by creating another target directory.
           CARGO_TARGET_DIR: "target-cdk-docker-bundling",
           // The bundling container needs to be able to connect to the container running postgres.
-          DATABASE_URL: "postgresql://filemanager:filemanager@localhost:4321/filemanager", // pragma: allowlist secret
+          DATABASE_URL: `postgresql://filemanager:filemanager@${address}/filemanager`, // pragma: allowlist secret
         }
       },
       memorySize: 128,


### PR DESCRIPTION
Related to #180 and #183.

Not sure exactly why the CodeBuild docker error occurs, but I think it's something to do with running `docker compose` in parallel. E.g. try running `docker compose up & docker compose up` and the same error occurs.

Either way, to hopefully fix this for good, the changes are:
* Use `docker compose run` in the CDK code, which always creates a unique container name with a random suffix.
    * Local dev can still use `docker compose up`.
* Use address and port `0.0.0.0:0` to create an arbitrary host:port mapping to the host.
* Rearrange `Makefile` and `.env.example` to reflect these changes.