### PR TITLE
Update Stateless Pipeline Test

### DIFF
--- a/lib/workload/stateless/postgres_manager/deploy/postgres-manager-stack.ts
+++ b/lib/workload/stateless/postgres_manager/deploy/postgres-manager-stack.ts
@@ -41,7 +41,6 @@ export class PostgresManagerStack extends Stack {
 
     const dependencyLayer = new lambda.LayerVersion(this, 'DependenciesLayer', {
       code: lambda.Code.fromDockerBuild(__dirname + '/../', {
-        cacheDisabled: true,
         file: 'deploy/construct/layer/node_module.Dockerfile',
         imagePath: 'home/node/app/output',
       }),

--- a/test/stateless/stateless-pipeline.test.ts
+++ b/test/stateless/stateless-pipeline.test.ts
@@ -1,8 +1,18 @@
-import { App, Aspects } from 'aws-cdk-lib';
+import { App, Aspects, Stack } from 'aws-cdk-lib';
 import { Annotations, Match } from 'aws-cdk-lib/assertions';
 import { SynthesisMessage } from 'aws-cdk-lib/cx-api';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 import { StatelessPipelineStack } from '../../lib/pipeline/orcabus-stateless-pipeline-stack';
+
+// we are mocking the deployment stack here, as we have a dedicated cdk-nag test for deployment stack
+// see the ./stateless-deployment.test.ts
+jest.mock('../../lib/workload/orcabus-stateless-stack', () => {
+  return {
+    OrcaBusStatelessStack: jest.fn().mockImplementation((value) => {
+      return new Stack(value, 'mockStack', {});
+    }),
+  };
+});
 
 function synthesisMessageToString(sm: SynthesisMessage): string {
   return `${sm.entry.data} [${sm.id}]`;
@@ -10,27 +20,22 @@ function synthesisMessageToString(sm: SynthesisMessage): string {
 
 // Stateless Stack
 describe('cdk-nag-stateless-pipeline', () => {
-  let stack: StatelessPipelineStack;
-  let app: App;
-
-  beforeEach(() => {
-    app = new App({});
-    stack = new StatelessPipelineStack(app, 'TestStack', {
-      env: {
-        account: '123456789',
-        region: 'ap-southeast-2',
-      },
-    });
-    Aspects.of(stack).add(new AwsSolutionsChecks());
-
-    NagSuppressions.addStackSuppressions(stack, [
-      { id: 'AwsSolutions-IAM4', reason: 'Allow CDK Pipeline' },
-      { id: 'AwsSolutions-IAM5', reason: 'Allow CDK Pipeline' },
-      { id: 'AwsSolutions-S1', reason: 'Allow CDK Pipeline' },
-      { id: 'AwsSolutions-KMS5', reason: 'Allow CDK Pipeline' },
-      { id: 'AwsSolutions-CB3', reason: 'Allow CDK Pipeline' },
-    ]);
+  const app: App = new App({});
+  const stack: StatelessPipelineStack = new StatelessPipelineStack(app, 'TestStack', {
+    env: {
+      account: '123456789',
+      region: 'ap-southeast-2',
+    },
   });
+
+  Aspects.of(stack).add(new AwsSolutionsChecks());
+  NagSuppressions.addStackSuppressions(stack, [
+    { id: 'AwsSolutions-IAM4', reason: 'Allow CDK Pipeline' },
+    { id: 'AwsSolutions-IAM5', reason: 'Allow CDK Pipeline' },
+    { id: 'AwsSolutions-S1', reason: 'Allow CDK Pipeline' },
+    { id: 'AwsSolutions-KMS5', reason: 'Allow CDK Pipeline' },
+    { id: 'AwsSolutions-CB3', reason: 'Allow CDK Pipeline' },
+  ]);
 
   test('cdk-nag AwsSolutions Pack errors', () => {
     const errors = Annotations.fromStack(stack)


### PR DESCRIPTION
It seems that cdk-ing the pipeline stack will also synth all the children stacks (microservice stack), but we also have a dedicated test for these children stacks. The `cdk-nag` test only works on the top layer stack and for that reason we have the deployment (children) stack to be tested separately.

The solution is to mock the children stack with a mock stack when testing the pipeline so it doesn't expose the real micro-stack. This should half the building time for testing.

Thanks @mmalenic for pointing the double build when testing!
 