### PR TITLE
feat(filemanager): iam rds credentials

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -4,7 +4,10 @@ import { OrcaBusStatelessConfig } from '../lib/workload/orcabus-stateless-stack'
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { EventSourceProps } from '../lib/workload/stateful/event_source/component';
 import { DbAuthType } from '../lib/workload/stateless/postgres_manager/function/type';
-import { FilemanagerConfig } from '../lib/workload/stateless/filemanager/deploy/lib/filemanager';
+import {
+  FILEMANAGER_SERVICE_NAME,
+  FilemanagerConfig,
+} from '../lib/workload/stateless/filemanager/deploy/lib/filemanager';
 
 const regName = 'OrcaBusSchemaRegistry';
 const eventBusName = 'OrcaBusMain';
@@ -13,7 +16,6 @@ const dbClusterIdentifier = 'orcabus-db';
 const dbClusterResourceIdParameterName = '/orcabus/db-cluster-resource-id';
 
 const eventSourceQueueName = 'orcabus-event-source-queue';
-const eventSourceDLQName = 'orcabus-event-source-dlq';
 const devBucket = 'umccr-temp-dev';
 const stgBucket = 'umccr-temp-stg';
 const prodBucket = 'org.umccr.data.oncoanalyser';
@@ -22,8 +24,6 @@ const prodBucket = 'org.umccr.data.oncoanalyser';
 // able to find the secret using a partial ARN.
 const rdsMasterSecretName = 'orcabus/master-rds'; // pragma: allowlist secret
 const databasePort = 5432;
-
-const filemanagerName = 'filemanager';
 
 const orcaBusStatefulConfig = {
   schemaRegistryProps: {
@@ -89,7 +89,7 @@ const orcaBusStatelessConfig = {
         name: 'metadata_manager',
         authType: DbAuthType.USERNAME_PASSWORD,
       },
-      { name: filemanagerName, authType: DbAuthType.RDS_IAM },
+      { name: FILEMANAGER_SERVICE_NAME, authType: DbAuthType.RDS_IAM },
     ],
   },
 };
@@ -97,7 +97,6 @@ const orcaBusStatelessConfig = {
 const eventSourceConfig = (bucket: string): EventSourceProps => {
   return {
     queueName: eventSourceQueueName,
-    deadLetterQueueName: eventSourceDLQName,
     maxReceiveCount: 3,
     rules: [
       {
@@ -111,8 +110,6 @@ const filemanagerConfig = (bucket: string): FilemanagerConfig => {
   return {
     eventSourceQueueName: eventSourceQueueName,
     databaseClusterIdentifierParameter: orcaBusStatefulConfig.databaseProps.masterSecretName,
-    database: filemanagerName,
-    user: filemanagerName,
     port: databasePort,
     eventSourceBuckets: [bucket],
   };

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -14,6 +14,7 @@ const eventBusName = 'OrcaBusMain';
 const lambdaSecurityGroupName = 'OrcaBusLambdaSecurityGroup';
 const dbClusterIdentifier = 'orcabus-db';
 const dbClusterResourceIdParameterName = '/orcabus/db-cluster-resource-id';
+const dbClusterEndpointHostParameterName = '/orcabus/db-cluster-endpoint-host';
 
 const eventSourceQueueName = 'orcabus-event-source-queue';
 const devBucket = 'umccr-temp-dev';
@@ -48,6 +49,7 @@ const orcaBusStatefulConfig = {
       cloudwatchLogsExports: ['orcabus-postgresql'],
     },
     clusterResourceIdParameterName: dbClusterResourceIdParameterName,
+    clusterEndpointHostParameterName: dbClusterEndpointHostParameterName,
   },
   securityGroupProps: {
     securityGroupName: lambdaSecurityGroupName,
@@ -109,7 +111,8 @@ const eventSourceConfig = (bucket: string): EventSourceProps => {
 const filemanagerConfig = (bucket: string): FilemanagerConfig => {
   return {
     eventSourceQueueName: eventSourceQueueName,
-    databaseClusterIdentifierParameter: orcaBusStatefulConfig.databaseProps.masterSecretName,
+    databaseClusterEndpointHostParameter:
+      orcaBusStatefulConfig.databaseProps.clusterEndpointHostParameterName,
     port: databasePort,
     eventSourceBuckets: [bucket],
   };

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -20,6 +20,9 @@ const prodBucket = 'org.umccr.data.oncoanalyser';
 // Note, this should not end with a hyphen and 6 characters, otherwise secrets manager won't be
 // able to find the secret using a partial ARN.
 const rdsMasterSecretName = 'orcabus/master-rds'; // pragma: allowlist secret
+const databasePort = 5432;
+
+const filemanagerName = 'filemanager';
 
 const orcaBusStatefulConfig = {
   schemaRegistryProps: {
@@ -38,7 +41,7 @@ const orcaBusStatefulConfig = {
     version: AuroraPostgresEngineVersion.VER_15_4,
     parameterGroupName: 'default.aurora-postgresql15',
     username: 'postgres',
-    dbPort: 5432,
+    dbPort: databasePort,
     masterSecretName: rdsMasterSecretName,
     monitoring: {
       cloudwatchLogsExports: ['orcabus-postgresql'],
@@ -85,7 +88,7 @@ const orcaBusStatelessConfig = {
         name: 'metadata_manager',
         authType: DbAuthType.USERNAME_PASSWORD,
       },
-      { name: 'filemanager', authType: DbAuthType.RDS_IAM },
+      { name: filemanagerName, authType: DbAuthType.RDS_IAM },
     ],
   },
 };
@@ -105,7 +108,10 @@ const eventSourceConfig = (bucket: string): EventSourceProps => {
 const filemanagerConfig = (bucket: string): FilemanagerConfig => {
   return {
     eventSourceQueueName: eventSourceQueueName,
-    databaseSecretName: orcaBusStatefulConfig.databaseProps.masterSecretName,
+    databaseClusterIdentifierParameter: orcaBusStatefulConfig.databaseProps.masterSecretName,
+    database: filemanagerName,
+    user: filemanagerName,
+    port: databasePort,
     eventSourceBuckets: [bucket],
   };
 };

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -13,6 +13,7 @@ const dbClusterIdentifier = 'orcabus-db';
 const dbClusterResourceIdParameterName = '/orcabus/db-cluster-resource-id';
 
 const eventSourceQueueName = 'orcabus-event-source-queue';
+const eventSourceDLQName = 'orcabus-event-source-dlq';
 const devBucket = 'umccr-temp-dev';
 const stgBucket = 'umccr-temp-stg';
 const prodBucket = 'org.umccr.data.oncoanalyser';
@@ -96,6 +97,7 @@ const orcaBusStatelessConfig = {
 const eventSourceConfig = (bucket: string): EventSourceProps => {
   return {
     queueName: eventSourceQueueName,
+    deadLetterQueueName: eventSourceDLQName,
     maxReceiveCount: 3,
     rules: [
       {

--- a/lib/workload/orcabus-stateless-stack.ts
+++ b/lib/workload/orcabus-stateless-stack.ts
@@ -6,13 +6,13 @@ import { MultiSchemaConstructProps } from './stateless/schema/component';
 import { IVpc, ISecurityGroup, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Filemanager, FilemanagerConfig } from './stateless/filemanager/deploy/lib/filemanager';
 import { Queue } from 'aws-cdk-lib/aws-sqs';
-import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import {
   PostgresManagerStack,
   PostgresManagerConfig,
 } from './stateless/postgres_manager/deploy/postgres-manager-stack';
 import { SequenceRunManagerStack } from './stateless/sequence_run_manager/deploy/component';
 import { EventBus, IEventBus } from 'aws-cdk-lib/aws-events';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 export interface OrcaBusStatelessConfig {
   multiSchemaConstructProps: MultiSchemaConstructProps;
@@ -88,17 +88,20 @@ export class OrcaBusStatelessStack extends cdk.Stack {
         this
       )
     );
-    const databaseSecret = Secret.fromSecretNameV2(
+
+    const clusterIdentifier = StringParameter.valueFromLookup(
       this,
-      'FilemanagerDatabaseSecret',
-      config.databaseSecretName
+      config.databaseClusterIdentifierParameter
     );
 
     return new Filemanager(this, 'Filemanager', {
       buckets: config.eventSourceBuckets,
       buildEnvironment: {},
-      databaseSecret,
-      databaseSecurityGroup: this.lambdaSecurityGroup,
+      host: clusterIdentifier,
+      port: config.port,
+      database: config.database,
+      user: config.user,
+      securityGroup: this.lambdaSecurityGroup,
       eventSources: [queue],
       migrateDatabase: true,
       vpc: this.vpc,

--- a/lib/workload/stateful/database/component.ts
+++ b/lib/workload/stateful/database/component.ts
@@ -77,9 +77,13 @@ export type ConfigurableDatabaseProps = MonitoringProps & {
    */
   removalPolicy: RemovalPolicy;
   /**
-   * The ssm parameter name to store the cluster resource id
+   * The ssm parameter name to store the cluster resource id.
    */
   clusterResourceIdParameterName: string;
+  /**
+   * The ssm parameter name to store the cluster endpoint
+   */
+  clusterEndpointHostParameterName: string;
 };
 
 /**
@@ -160,6 +164,13 @@ export class Database extends Construct {
       stringValue: this.cluster.clusterResourceIdentifier,
       description: 'cluster resource id at the orcabus rds cluster',
       parameterName: props.clusterResourceIdParameterName,
+    });
+
+    // Save the endpoint so that it can be used by the stateless services.
+    new ssm.StringParameter(this, 'DbClusterEndpointHostSSM', {
+      stringValue: this.cluster.clusterEndpoint.hostname,
+      description: 'orcabus rds writer cluster endpoint host',
+      parameterName: props.clusterEndpointHostParameterName,
     });
   }
 }

--- a/lib/workload/stateful/event_source/component.ts
+++ b/lib/workload/stateful/event_source/component.ts
@@ -56,7 +56,7 @@ export class EventSource extends Construct {
     super(scope, id);
 
     this.deadLetterQueue = new Queue(this, 'DeadLetterQueue', {
-      queueName: 'orcabus-event-source-dlq',
+      queueName: `${props.queueName}-dlq`,
       enforceSSL: true,
     });
     this.queue = new Queue(this, 'Queue', {

--- a/lib/workload/stateful/event_source/component.ts
+++ b/lib/workload/stateful/event_source/component.ts
@@ -34,6 +34,10 @@ export type EventSourceProps = {
    */
   queueName: string;
   /**
+   * The name of the dead letter queue to construct.
+   */
+  deadLetterQueueName: string;
+  /**
    * The maximum number of times a message can be unsuccessfully received before
    * pushing it to the DLQ.
    */
@@ -55,7 +59,10 @@ export class EventSource extends Construct {
   constructor(scope: Construct, id: string, props: EventSourceProps) {
     super(scope, id);
 
-    this.deadLetterQueue = new Queue(this, 'DeadLetterQueue', { enforceSSL: true });
+    this.deadLetterQueue = new Queue(this, 'DeadLetterQueue', {
+      queueName: props.deadLetterQueueName,
+      enforceSSL: true,
+    });
     this.queue = new Queue(this, 'Queue', {
       queueName: props.queueName,
       enforceSSL: true,

--- a/lib/workload/stateful/event_source/component.ts
+++ b/lib/workload/stateful/event_source/component.ts
@@ -34,10 +34,6 @@ export type EventSourceProps = {
    */
   queueName: string;
   /**
-   * The name of the dead letter queue to construct.
-   */
-  deadLetterQueueName: string;
-  /**
    * The maximum number of times a message can be unsuccessfully received before
    * pushing it to the DLQ.
    */
@@ -60,7 +56,7 @@ export class EventSource extends Construct {
     super(scope, id);
 
     this.deadLetterQueue = new Queue(this, 'DeadLetterQueue', {
-      queueName: props.deadLetterQueueName,
+      queueName: 'orcabus-event-source-dlq',
       enforceSSL: true,
     });
     this.queue = new Queue(this, 'Queue', {

--- a/lib/workload/stateless/filemanager/.gitignore
+++ b/lib/workload/stateless/filemanager/.gitignore
@@ -2,4 +2,4 @@ target/
 *.swp
 /volume/
 .build
-target-cdk-docker-bundling/
+target-cdk-bundling*

--- a/lib/workload/stateless/filemanager/Cargo.lock
+++ b/lib/workload/stateless/filemanager/Cargo.lock
@@ -962,8 +962,10 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "aws-config",
+ "aws-credential-types",
  "aws-sdk-s3",
  "aws-sdk-sqs",
+ "aws-sigv4",
  "aws-smithy-runtime-api",
  "aws_lambda_events",
  "chrono",
@@ -981,6 +983,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/lib/workload/stateless/filemanager/deploy/constructs/functions/ingest.ts
+++ b/lib/workload/stateless/filemanager/deploy/constructs/functions/ingest.ts
@@ -26,7 +26,7 @@ export class IngestFunction extends fn.Function {
   constructor(scope: Construct, id: string, props: IngestFunctionProps) {
     super(scope, id, { package: 'filemanager-ingest-lambda', ...props });
 
-    this.addManagedPolicy('service-role/AWSLambdaSQSQueueExecutionRole');
+    this.addAwsManagedPolicy('service-role/AWSLambdaSQSQueueExecutionRole');
 
     props.eventSources.forEach((source) => {
       const eventSource = new SqsEventSource(source);

--- a/lib/workload/stateless/filemanager/deploy/lib/filemanager.ts
+++ b/lib/workload/stateless/filemanager/deploy/lib/filemanager.ts
@@ -11,7 +11,7 @@ import { CdkResourceInvoke } from '../../../../components/cdk_resource_invoke';
 /**
  * Stateful config for filemanager.
  */
-export type FilemanagerConfig = {
+export type FilemanagerConfig = Omit<DatabaseProps, 'host' | 'securityGroup'> & {
   /**
    * Queue name used by the EventSource construct.
    */
@@ -21,9 +21,9 @@ export type FilemanagerConfig = {
    */
   eventSourceBuckets: string[];
   /**
-   * Database secret name for the filemanager.
+   * The parameter name that contains the database cluster identifier.
    */
-  databaseSecretName: string;
+  databaseClusterIdentifierParameter: string;
 }
 
 /**
@@ -64,8 +64,11 @@ export class Filemanager extends Stack {
         },
         functionProps: {
           vpc: props.vpc,
-          databaseSecret: props.databaseSecret,
-          databaseSecurityGroup: props.databaseSecurityGroup,
+          host: props.host,
+          port: props.port,
+          user: props.user,
+          database: props.database,
+          securityGroup: props.securityGroup,
           buildEnvironment: props?.buildEnvironment,
           rustLog: props?.rustLog,
         },
@@ -76,8 +79,11 @@ export class Filemanager extends Stack {
 
     new IngestFunction(this, 'IngestLambda', {
       vpc: props.vpc,
-      databaseSecret: props.databaseSecret,
-      databaseSecurityGroup: props.databaseSecurityGroup,
+      host: props.host,
+      port: props.port,
+      user: props.user,
+      database: props.database,
+      securityGroup: props.securityGroup,
       eventSources: props.eventSources,
       buckets: props.buckets,
       buildEnvironment: props?.buildEnvironment,

--- a/lib/workload/stateless/filemanager/deploy/lib/filemanager.ts
+++ b/lib/workload/stateless/filemanager/deploy/lib/filemanager.ts
@@ -2,9 +2,9 @@ import { Construct } from 'constructs';
 import { IngestFunction, IngestFunctionProps } from '../constructs/functions/ingest';
 import { MigrateFunction } from '../constructs/functions/migrate';
 import * as fn from '../constructs/functions/function';
+import { DatabaseProps } from '../constructs/functions/function';
 import { IVpc } from 'aws-cdk-lib/aws-ec2';
 import { IQueue } from 'aws-cdk-lib/aws-sqs';
-import { DatabaseProps } from '../constructs/functions/function';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { CdkResourceInvoke } from '../../../../components/cdk_resource_invoke';
 

--- a/lib/workload/stateless/filemanager/deploy/lib/filemanager.ts
+++ b/lib/workload/stateless/filemanager/deploy/lib/filemanager.ts
@@ -8,6 +8,8 @@ import { IQueue } from 'aws-cdk-lib/aws-sqs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { CdkResourceInvoke } from '../../../../components/cdk_resource_invoke';
 
+export const FILEMANAGER_SERVICE_NAME = 'filemanager';
+
 /**
  * Stateful config for filemanager.
  */
@@ -66,8 +68,6 @@ export class Filemanager extends Stack {
           vpc: props.vpc,
           host: props.host,
           port: props.port,
-          user: props.user,
-          database: props.database,
           securityGroup: props.securityGroup,
           buildEnvironment: props?.buildEnvironment,
           rustLog: props?.rustLog,
@@ -81,8 +81,6 @@ export class Filemanager extends Stack {
       vpc: props.vpc,
       host: props.host,
       port: props.port,
-      user: props.user,
-      database: props.database,
       securityGroup: props.securityGroup,
       eventSources: props.eventSources,
       buckets: props.buckets,

--- a/lib/workload/stateless/filemanager/deploy/lib/filemanager.ts
+++ b/lib/workload/stateless/filemanager/deploy/lib/filemanager.ts
@@ -23,9 +23,9 @@ export type FilemanagerConfig = Omit<DatabaseProps, 'host' | 'securityGroup'> & 
    */
   eventSourceBuckets: string[];
   /**
-   * The parameter name that contains the database cluster identifier.
+   * The parameter name that contains the database cluster endpoint.
    */
-  databaseClusterIdentifierParameter: string;
+  databaseClusterEndpointHostParameter: string;
 }
 
 /**

--- a/lib/workload/stateless/filemanager/filemanager-http-lambda/src/main.rs
+++ b/lib/workload/stateless/filemanager/filemanager-http-lambda/src/main.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{fmt, EnvFilter};
 use filemanager::clients::aws::s3::Client as S3Client;
 use filemanager::clients::aws::sqs::Client as SQSClient;
 use filemanager::database::Client as DbClient;
-use filemanager::handlers::aws::{create_database_pool, receive_and_ingest};
+use filemanager::handlers::aws::{create_database_pool, receive_and_ingest, update_credentials};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -20,6 +20,8 @@ async fn main() -> Result<(), Error> {
 
     let options = &create_database_pool().await?;
     run(service_fn(|_: LambdaEvent<()>| async move {
+        update_credentials(options).await?;
+
         receive_and_ingest(
             S3Client::with_defaults().await,
             SQSClient::with_defaults().await,

--- a/lib/workload/stateless/filemanager/filemanager-http-lambda/src/main.rs
+++ b/lib/workload/stateless/filemanager/filemanager-http-lambda/src/main.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::{fmt, EnvFilter};
 
 use filemanager::clients::aws::s3::Client as S3Client;
 use filemanager::clients::aws::sqs::Client as SQSClient;
+use filemanager::database::aws::credentials::IamGeneratorBuilder;
 use filemanager::handlers::aws::receive_and_ingest;
 
 #[tokio::main]
@@ -23,6 +24,7 @@ async fn main() -> Result<(), Error> {
             SQSClient::with_defaults().await,
             None::<String>,
             None,
+            Some(IamGeneratorBuilder::default().build().await?),
         )
         .await?;
 

--- a/lib/workload/stateless/filemanager/filemanager-ingest-lambda/src/main.rs
+++ b/lib/workload/stateless/filemanager/filemanager-ingest-lambda/src/main.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{fmt, EnvFilter};
 
 use filemanager::clients::aws::s3::Client;
+use filemanager::database::aws::credentials::IamGeneratorBuilder;
 use filemanager::handlers::aws::ingest_event;
 
 #[tokio::main]
@@ -17,7 +18,13 @@ async fn main() -> Result<(), Error> {
         .init();
 
     run(service_fn(|event: LambdaEvent<SqsEvent>| async move {
-        ingest_event(event.payload, Client::with_defaults().await, None).await?;
+        ingest_event(
+            event.payload,
+            Client::with_defaults().await,
+            None,
+            Some(IamGeneratorBuilder::default().build().await?),
+        )
+        .await?;
 
         Ok::<(), Error>(())
     }))

--- a/lib/workload/stateless/filemanager/filemanager-ingest-lambda/src/main.rs
+++ b/lib/workload/stateless/filemanager/filemanager-ingest-lambda/src/main.rs
@@ -6,7 +6,7 @@ use tracing_subscriber::{fmt, EnvFilter};
 
 use filemanager::clients::aws::s3::Client;
 use filemanager::database::Client as DbClient;
-use filemanager::handlers::aws::{create_database_pool, ingest_event};
+use filemanager::handlers::aws::{create_database_pool, ingest_event, update_credentials};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -19,6 +19,8 @@ async fn main() -> Result<(), Error> {
 
     let options = &create_database_pool().await?;
     run(service_fn(|event: LambdaEvent<SqsEvent>| async move {
+        update_credentials(options).await?;
+
         ingest_event(
             event.payload,
             Client::with_defaults().await,

--- a/lib/workload/stateless/filemanager/filemanager-migrate-lambda/src/main.rs
+++ b/lib/workload/stateless/filemanager/filemanager-migrate-lambda/src/main.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use filemanager::database::aws::credentials::IamGeneratorBuilder;
 use lambda_runtime::{run, service_fn, Error, LambdaEvent};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -19,7 +20,10 @@ async fn main() -> Result<(), Error> {
 
     run(service_fn(
         |_: LambdaEvent<HashMap<String, String>>| async move {
-            Migration::with_defaults().await?.migrate().await
+            Migration::with_defaults(Some(IamGeneratorBuilder::default().build().await?))
+                .await?
+                .migrate()
+                .await
         },
     ))
     .await

--- a/lib/workload/stateless/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/filemanager/filemanager/Cargo.toml
@@ -28,14 +28,13 @@ uuid = { version = "1", features = ["v7"] }
 mockall = "0.12"
 mockall_double = "0.3"
 itertools = "0.12"
+url = "2"
 
 aws-sdk-sqs = "1"
 aws-config = "1"
 aws-sdk-s3 = "1"
 aws-credential-types = "1"
 aws-sigv4 = "1"
-url = "2"
-
 lambda_runtime = "0.11"
 aws_lambda_events = "0.15"
 

--- a/lib/workload/stateless/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/filemanager/filemanager/Cargo.toml
@@ -32,6 +32,10 @@ itertools = "0.12"
 aws-sdk-sqs = "1"
 aws-config = "1"
 aws-sdk-s3 = "1"
+aws-credential-types = "1"
+aws-sigv4 = "1"
+url = "2"
+
 lambda_runtime = "0.10"
 aws_lambda_events = "0.15"
 

--- a/lib/workload/stateless/filemanager/filemanager/src/clients/aws/config.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/clients/aws/config.rs
@@ -1,4 +1,4 @@
-use aws_config::{defaults, BehaviorVersion, Region, SdkConfig};
+use aws_config::{defaults, BehaviorVersion, SdkConfig};
 use aws_credential_types::provider::error::CredentialsError;
 use aws_credential_types::provider::ProvideCredentials;
 use aws_credential_types::Credentials;
@@ -33,10 +33,8 @@ impl Config {
     }
 
     /// Get the region used by the config.
-    // This lifetime is required because of the way automock generates the mock struct.
-    #[allow(clippy::needless_lifetimes)]
-    pub fn region<'a>(&'a self) -> Option<&'a Region> {
-        self.inner().region()
+    pub fn region(&self) -> Option<String> {
+        self.inner().region().map(ToString::to_string)
     }
 
     pub fn inner(&self) -> &SdkConfig {

--- a/lib/workload/stateless/filemanager/filemanager/src/clients/aws/config.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/clients/aws/config.rs
@@ -1,26 +1,50 @@
-use aws_config::{defaults, BehaviorVersion, ConfigLoader, SdkConfig};
+use aws_config::{defaults, BehaviorVersion, Region, SdkConfig};
+use aws_credential_types::provider::error::CredentialsError;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_credential_types::Credentials;
 use mockall::automock;
 
 /// A wrapper around a config loader.
 #[derive(Debug)]
 pub struct Config {
-    inner: ConfigLoader,
+    inner: SdkConfig,
 }
 
 #[automock]
 impl Config {
     /// Create a new config.
-    pub fn new(inner: ConfigLoader) -> Self {
+    pub fn new(inner: SdkConfig) -> Self {
         Self { inner }
     }
 
     /// Load the config.
-    pub async fn load(self) -> SdkConfig {
-        self.inner.load().await
+    pub fn load(self) -> SdkConfig {
+        self.inner
+    }
+
+    /// Get the provided credentials from the config.
+    pub async fn provide_credentials(&self) -> Option<Result<Credentials, CredentialsError>> {
+        Some(
+            self.inner
+                .credentials_provider()?
+                .provide_credentials()
+                .await,
+        )
+    }
+
+    /// Get the region used by the config.
+    // This lifetime is required because of the way automock generates the mock struct.
+    #[allow(clippy::needless_lifetimes)]
+    pub fn region<'a>(&'a self) -> Option<&'a Region> {
+        self.inner().region()
+    }
+
+    pub fn inner(&self) -> &SdkConfig {
+        &self.inner
     }
 
     /// Create a new config with default behaviour.
-    pub fn with_defaults() -> Self {
-        Self::new(defaults(BehaviorVersion::latest()))
+    pub async fn with_defaults() -> Self {
+        Self::new(defaults(BehaviorVersion::latest()).load().await)
     }
 }

--- a/lib/workload/stateless/filemanager/filemanager/src/clients/aws/s3.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/clients/aws/s3.rs
@@ -25,7 +25,7 @@ impl Client {
 
     /// Create an S3 client with default config.
     pub async fn with_defaults() -> Self {
-        Self::new(s3::Client::new(&Config::with_defaults().load().await))
+        Self::new(s3::Client::new(&Config::with_defaults().await.load()))
     }
 
     /// Execute the `ListBuckets` operation.

--- a/lib/workload/stateless/filemanager/filemanager/src/clients/aws/sqs.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/clients/aws/sqs.rs
@@ -25,7 +25,7 @@ impl Client {
 
     /// Create an SQS client with default config.
     pub async fn with_defaults() -> Self {
-        Self::new(sqs::Client::new(&Config::with_defaults().load().await))
+        Self::new(sqs::Client::new(&Config::with_defaults().await.load()))
     }
 
     /// Execute the `ReceiveMessage` operation.

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/credentials.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/credentials.rs
@@ -1,0 +1,100 @@
+//! A module for generating RDS IAM credentials.
+//!
+
+use std::iter::empty;
+use std::time::{Duration, SystemTime};
+
+use crate::clients::aws::config::Config;
+use crate::error::Error::CredentialGeneratorError;
+use crate::error::Result;
+use aws_credential_types::provider::ProvideCredentials;
+use aws_sigv4::http_request::SignatureLocation::QueryParams;
+use aws_sigv4::http_request::{sign, SignableBody, SignableRequest, SigningSettings};
+use aws_sigv4::sign::v4::SigningParams;
+
+#[derive(Debug)]
+pub struct IamCredentialGenerator {
+    config: Config,
+    address: String,
+    user: String,
+}
+
+impl IamCredentialGenerator {
+    /// Create a new credential generator.
+    pub fn new(config: Config, address: String, user: String) -> Self {
+        Self {
+            config,
+            address,
+            user,
+        }
+    }
+
+    /// Create a new credential generator with default config.
+    pub fn with_defaults(address: String, user: String) -> Self {
+        Self::new(Config::with_defaults(), address, user)
+    }
+
+    /// Get the config.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Get the address.
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    /// Get the user
+    pub fn user(&self) -> &str {
+        &self.user
+    }
+
+    /// Generate an RDS IAM token which can be used as the password to connect to the RDS database.
+    pub async fn generate_iam_token(self) -> Result<String> {
+        let config = self.config.load().await;
+
+        let identity = config
+            .credentials_provider()
+            .ok_or_else(|| CredentialGeneratorError("missing credentials provider".to_string()))?
+            .provide_credentials()
+            .await
+            .map_err(|err| CredentialGeneratorError(err.to_string()))?
+            .into();
+        let region = config
+            .region()
+            .ok_or_else(|| CredentialGeneratorError("missing region".to_string()))?
+            .to_string();
+
+        let mut signing_settings = SigningSettings::default();
+        signing_settings.expires_in = Some(Duration::from_secs(900));
+        signing_settings.signature_location = QueryParams;
+
+        let signing_params = SigningParams::builder()
+            .identity(&identity)
+            .region(&region)
+            .name("rds-db")
+            .time(SystemTime::now())
+            .settings(signing_settings)
+            .build()
+            .map_err(|err| CredentialGeneratorError(err.to_string()))?;
+
+        let url = format!(
+            "https://{}/?Action=connect&DBUser={}",
+            self.address, self.user
+        );
+
+        let signable_request = SignableRequest::new("GET", &url, empty(), SignableBody::Bytes(&[]))
+            .map_err(|err| CredentialGeneratorError(err.to_string()))?;
+
+        let (signing_instructions, _) = sign(signable_request, &signing_params.into())
+            .map_err(|err| CredentialGeneratorError(err.to_string()))?
+            .into_parts();
+
+        let mut url = url::Url::parse(&url).unwrap();
+        for (name, value) in signing_instructions.params() {
+            url.query_pairs_mut().append_pair(name, value);
+        }
+
+        Ok(url.to_string().split_off("https://".len()))
+    }
+}

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/credentials.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/credentials.rs
@@ -18,6 +18,10 @@ use crate::env::read_env;
 use crate::error::Error::CredentialGeneratorError;
 use crate::error::Result;
 
+/// Number of seconds that the IAM credentials expire in.
+/// Equals the max Lambda timeout.
+pub const CREDENTIAL_EXPIRES_IN_SECONDS: u64 = 900;
+
 /// The builder for the IamGenerator.
 #[derive(Debug, Default)]
 pub struct IamGeneratorBuilder {
@@ -118,7 +122,7 @@ impl IamGenerator {
             .ok_or_else(|| CredentialGeneratorError("missing region".to_string()))?;
 
         let mut signing_settings = SigningSettings::default();
-        signing_settings.expires_in = Some(Duration::from_secs(900));
+        signing_settings.expires_in = Some(Duration::from_secs(CREDENTIAL_EXPIRES_IN_SECONDS));
         signing_settings.signature_location = QueryParams;
 
         let signing_params = SigningParams::builder()

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/credentials.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/credentials.rs
@@ -7,7 +7,6 @@ use std::time::{Duration, SystemTime};
 use crate::clients::aws::config::Config;
 use crate::error::Error::CredentialGeneratorError;
 use crate::error::Result;
-use aws_credential_types::provider::ProvideCredentials;
 use aws_sigv4::http_request::SignatureLocation::QueryParams;
 use aws_sigv4::http_request::{sign, SignableBody, SignableRequest, SigningSettings};
 use aws_sigv4::sign::v4::SigningParams;
@@ -15,23 +14,19 @@ use aws_sigv4::sign::v4::SigningParams;
 #[derive(Debug)]
 pub struct IamCredentialGenerator {
     config: Config,
-    address: String,
+    host: String,
     user: String,
 }
 
 impl IamCredentialGenerator {
     /// Create a new credential generator.
-    pub fn new(config: Config, address: String, user: String) -> Self {
-        Self {
-            config,
-            address,
-            user,
-        }
+    pub fn new(config: Config, host: String, user: String) -> Self {
+        Self { config, host, user }
     }
 
     /// Create a new credential generator with default config.
-    pub fn with_defaults(address: String, user: String) -> Self {
-        Self::new(Config::with_defaults(), address, user)
+    pub async fn with_defaults(address: String, user: String) -> Self {
+        Self::new(Config::with_defaults().await, address, user)
     }
 
     /// Get the config.
@@ -39,28 +34,27 @@ impl IamCredentialGenerator {
         &self.config
     }
 
-    /// Get the address.
-    pub fn address(&self) -> &str {
-        &self.address
+    /// Get the host address.
+    pub fn host(&self) -> &str {
+        &self.host
     }
 
-    /// Get the user
+    /// Get the user.
     pub fn user(&self) -> &str {
         &self.user
     }
 
     /// Generate an RDS IAM token which can be used as the password to connect to the RDS database.
-    pub async fn generate_iam_token(self) -> Result<String> {
-        let config = self.config.load().await;
-
-        let identity = config
-            .credentials_provider()
-            .ok_or_else(|| CredentialGeneratorError("missing credentials provider".to_string()))?
+    pub async fn generate_iam_token(&self) -> Result<String> {
+        let identity = self
+            .config
             .provide_credentials()
             .await
+            .ok_or_else(|| CredentialGeneratorError("missing credentials provider".to_string()))?
             .map_err(|err| CredentialGeneratorError(err.to_string()))?
             .into();
-        let region = config
+        let region = self
+            .config
             .region()
             .ok_or_else(|| CredentialGeneratorError("missing region".to_string()))?
             .to_string();
@@ -78,10 +72,7 @@ impl IamCredentialGenerator {
             .build()
             .map_err(|err| CredentialGeneratorError(err.to_string()))?;
 
-        let url = format!(
-            "https://{}/?Action=connect&DBUser={}",
-            self.address, self.user
-        );
+        let url = format!("https://{}/?Action=connect&DBUser={}", self.host, self.user);
 
         let signable_request = SignableRequest::new("GET", &url, empty(), SignableBody::Bytes(&[]))
             .map_err(|err| CredentialGeneratorError(err.to_string()))?;
@@ -96,5 +87,21 @@ impl IamCredentialGenerator {
         }
 
         Ok(url.to_string().split_off("https://".len()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn generate_iam_token() {
+        let generator = IamCredentialGenerator::with_defaults(
+            "127.0.0.1".to_string(),
+            "filemanager".to_string(),
+        )
+        .await;
+        let creds = generator.generate_iam_token().await;
+        println!("{:#?}", creds);
     }
 }

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/ingester.rs
@@ -4,7 +4,7 @@ use sqlx::{query_file, query_file_as};
 use tracing::{debug, trace};
 use uuid::Uuid;
 
-use crate::database::{Client, Ingest};
+use crate::database::{Client, CredentialGenerator, Ingest};
 use crate::error::Result;
 use crate::events::aws::message::EventType;
 use crate::events::aws::{Events, TransposedS3EventMessages};
@@ -32,9 +32,9 @@ impl Ingester {
     }
 
     /// Create a new ingester with a default database client.
-    pub async fn with_defaults() -> Result<Self> {
+    pub async fn with_defaults(generator: Option<impl CredentialGenerator>) -> Result<Self> {
         Ok(Self {
-            client: Client::default().await?,
+            client: Client::with_defaults(generator).await?,
         })
     }
 

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/ingester.rs
@@ -252,11 +252,12 @@ impl Ingest for Ingester {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::ops::Add;
+
     use chrono::{DateTime, Utc};
     use itertools::Itertools;
     use sqlx::postgres::PgRow;
     use sqlx::{Executor, PgPool, Row};
-    use std::ops::Add;
     use tokio::time::Instant;
 
     use crate::database::aws::ingester::Ingester;

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/migration.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/migration.rs
@@ -3,7 +3,7 @@ use sqlx::migrate;
 use sqlx::migrate::Migrator;
 use tracing::trace;
 
-use crate::database::{Client, Migrate};
+use crate::database::{Client, CredentialGenerator, Migrate};
 use crate::error::Error::MigrateError;
 use crate::error::Result;
 
@@ -20,9 +20,9 @@ impl Migration {
     }
 
     /// Create a new migration with a default database client.
-    pub async fn with_defaults() -> Result<Self> {
+    pub async fn with_defaults(generator: Option<impl CredentialGenerator>) -> Result<Self> {
         Ok(Self {
-            client: Client::default().await?,
+            client: Client::with_defaults(generator).await?,
         })
     }
 

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/migration.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/migration.rs
@@ -9,20 +9,20 @@ use crate::error::Result;
 
 /// A struct to perform database migrations.
 #[derive(Debug)]
-pub struct Migration {
-    client: Client,
+pub struct Migration<'a> {
+    client: Client<'a>,
 }
 
-impl Migration {
+impl<'a> Migration<'a> {
     /// Create a new migration.
-    pub fn new(client: Client) -> Self {
+    pub fn new(client: Client<'a>) -> Self {
         Self { client }
     }
 
     /// Create a new migration with a default database client.
     pub async fn with_defaults(generator: Option<impl CredentialGenerator>) -> Result<Self> {
         Ok(Self {
-            client: Client::with_defaults(generator).await?,
+            client: Client::from_generator(generator).await?,
         })
     }
 
@@ -38,7 +38,7 @@ impl Migration {
 }
 
 #[async_trait]
-impl Migrate for Migration {
+impl<'a> Migrate for Migration<'a> {
     async fn migrate(&self) -> Result<()> {
         trace!("applying migrations");
         Self::migrator()

--- a/lib/workload/stateless/filemanager/filemanager/src/database/aws/mod.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/aws/mod.rs
@@ -5,6 +5,7 @@ use aws_sdk_s3::types::StorageClass;
 
 pub mod ingester;
 
+pub mod credentials;
 #[cfg(feature = "migrate")]
 pub mod migration;
 

--- a/lib/workload/stateless/filemanager/filemanager/src/database/mod.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/mod.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use sqlx::postgres::PgConnectOptions;
 use sqlx::PgPool;
 use std::borrow::Cow;
+use tracing::debug;
 
 use crate::env::read_env;
 use crate::error::Result;
@@ -73,6 +74,7 @@ impl<'a> Client<'a> {
         // Otherwise use generator if it is available.
         match generator {
             Some(generator) => {
+                debug!("generating credentials to connect to database");
                 Ok(PgConnectOptions::default().password(&generator.generate_password().await?))
             }
             None => Ok(PgConnectOptions::default()),

--- a/lib/workload/stateless/filemanager/filemanager/src/database/mod.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/database/mod.rs
@@ -4,6 +4,7 @@
 use async_trait::async_trait;
 use sqlx::postgres::PgConnectOptions;
 use sqlx::PgPool;
+use std::borrow::Cow;
 
 use crate::env::read_env;
 use crate::error::Result;
@@ -20,45 +21,62 @@ pub trait CredentialGenerator {
 
 /// A database client handles database interaction.
 #[derive(Debug)]
-pub struct Client {
-    pool: PgPool,
+pub struct Client<'a> {
+    // Use a Cow here to allow an owned pool or a shared reference to a pool.
+    pool: Cow<'a, PgPool>,
 }
 
-impl Client {
+impl<'a> Client<'a> {
     /// Create a database from an existing pool.
     pub fn new(pool: PgPool) -> Self {
-        Self { pool }
+        Self {
+            pool: Cow::Owned(pool),
+        }
     }
 
-    /// Create a database with default DATABASE_URL connection.
-    pub async fn from_database_url(url: String) -> Result<Self> {
-        Ok(Self {
-            pool: PgPool::connect(&url).await?,
-        })
+    /// Create a database from a reference to an existing pool.
+    pub fn from_ref(pool: &'a PgPool) -> Self {
+        Self {
+            pool: Cow::Borrowed(pool),
+        }
     }
 
-    /// Create a database using default credential loading logic.
-    /// First, tries to load a DATABASE_URL environment variable to connect.
-    /// Then, uses the generator if it is not None and PGPASSWORD is not set.
+    /// Create a database using default credential loading logic as defined in
+    /// `Self::connect_options`.
+    pub async fn from_generator(generator: Option<impl CredentialGenerator>) -> Result<Self> {
+        Ok(Self::new(Self::create_pool(generator).await?))
+    }
+
+    /// Create a database connection pool using credential loading logic defined in
+    /// `Self::connect_options`.
+    pub async fn create_pool(generator: Option<impl CredentialGenerator>) -> Result<PgPool> {
+        Ok(PgPool::connect_with(Self::connect_options(generator).await?).await?)
+    }
+
+    /// Create database connect options using a series of credential loading logic.
+    ///
+    /// First, this tries to load a DATABASE_URL environment variable to connect.
+    /// Then, it uses the generator if it is not None and PGPASSWORD is not set.
     /// Otherwise, uses default logic defined in PgConnectOptions::default.
-    pub async fn with_defaults(generator: Option<impl CredentialGenerator>) -> Result<Self> {
-        // If the DATABASE_URL is defined, use that
+    pub async fn connect_options(
+        generator: Option<impl CredentialGenerator>,
+    ) -> Result<PgConnectOptions> {
+        // If the DATABASE_URL is defined, use that.
         if let Ok(url) = read_env("DATABASE_URL") {
-            return Self::from_database_url(url).await;
+            return Ok(url.parse()?);
+        }
+        // If PGPASSWORD is set, use default options.
+        if read_env("PGPASSWORD").is_ok() {
+            return Ok(PgConnectOptions::default());
         }
 
-        let options = match generator {
-            // Only use generator is PGPASSWORD is not set.
-            Some(generator) if read_env("PGPASSWORD").is_err() => {
-                PgConnectOptions::default().password(&generator.generate_password().await?)
+        // Otherwise use generator if it is available.
+        match generator {
+            Some(generator) => {
+                Ok(PgConnectOptions::default().password(&generator.generate_password().await?))
             }
-            // Otherwise try the default credentials.
-            _ => PgConnectOptions::default(),
-        };
-
-        Ok(Self {
-            pool: PgPool::connect_with(options).await?,
-        })
+            None => Ok(PgConnectOptions::default()),
+        }
     }
 
     /// Get the database pool.

--- a/lib/workload/stateless/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/env.rs
@@ -1,7 +1,6 @@
 //! Handle environment variables.
 //!
 
-use std::ffi::OsStr;
 use std::{env, fmt};
 
 use dotenvy::dotenv;
@@ -40,8 +39,8 @@ pub fn load_env() -> AppEnv {
 }
 
 /// Read an environment variable into a string.
-pub fn read_env<K: AsRef<OsStr>>(key: K) -> Result<String> {
-    env::var(key).map_err(|err| MissingEnvironmentVariable(err.to_string()))
+pub fn read_env<K: AsRef<str>>(key: K) -> Result<String> {
+    env::var(key.as_ref()).map_err(|err| MissingEnvironmentVariable(err.to_string()))
 }
 
 impl fmt::Display for AppEnv {

--- a/lib/workload/stateless/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/env.rs
@@ -1,10 +1,10 @@
 //! Handle environment variables.
 //!
 
-use dotenvy::dotenv;
 use std::ffi::OsStr;
 use std::{env, fmt};
 
+use dotenvy::dotenv;
 use tracing::{error, info};
 
 use crate::error::Error::MissingEnvironmentVariable;

--- a/lib/workload/stateless/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/error.rs
@@ -41,6 +41,8 @@ pub enum Error {
     ConfigError(String),
     #[error("Ingester error: `{0}`")]
     IngesterError(String),
+    #[error("credential generator error: `{0}`")]
+    CredentialGeneratorError(String),
 }
 
 impl From<sqlx::Error> for Error {

--- a/lib/workload/stateless/filemanager/filemanager/src/events/aws/collecter.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/events/aws/collecter.rs
@@ -9,19 +9,18 @@ use tracing::trace;
 
 #[double]
 use crate::clients::aws::s3::Client;
-use crate::error::Error::S3Error;
-use crate::error::Result;
-use crate::events::aws::{
-    EventType, Events, FlatS3EventMessage, FlatS3EventMessages, StorageClass,
-};
-use crate::events::{Collect, EventSourceType};
-
 #[double]
 use crate::clients::aws::s3::Client as S3Client;
 #[double]
 use crate::clients::aws::sqs::Client as SQSClient;
 use crate::env::read_env;
+use crate::error::Error::S3Error;
 use crate::error::Error::{DeserializeError, SQSReceiveError};
+use crate::error::Result;
+use crate::events::aws::{
+    EventType, Events, FlatS3EventMessage, FlatS3EventMessages, StorageClass,
+};
+use crate::events::{Collect, EventSourceType};
 
 /// Build an AWS collector struct.
 #[derive(Default, Debug)]
@@ -240,10 +239,9 @@ pub(crate) mod tests {
 
     use crate::events::aws::tests::{expected_event_record_simple, expected_flat_events_simple};
     use crate::events::aws::StorageClass::IntelligentTiering;
+    use crate::events::Collect;
 
     use super::*;
-
-    use crate::events::Collect;
 
     #[tokio::test]
     async fn receive() {

--- a/lib/workload/stateless/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/events/aws/message.rs
@@ -1,8 +1,9 @@
-use crate::events::aws::{FlatS3EventMessage, FlatS3EventMessages};
-use crate::uuid::UuidGenerator;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::{PgHasArrayType, PgTypeInfo};
+
+use crate::events::aws::{FlatS3EventMessage, FlatS3EventMessages};
+use crate::uuid::UuidGenerator;
 
 #[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd, Clone, Hash, sqlx::Type)]
 #[sqlx(type_name = "event_type")]
@@ -155,13 +156,14 @@ impl From<Message> for FlatS3EventMessages {
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use crate::events::aws::tests::{
         assert_flat_s3_event, expected_event_bridge_record, expected_sqs_record,
         EXPECTED_SEQUENCER_DELETED_ONE, EXPECTED_VERSION_ID,
     };
     use crate::events::aws::EventType::Deleted;
     use crate::events::aws::FlatS3EventMessages;
-    use serde_json::json;
 
     #[test]
     fn deserialize_sqs_message() {

--- a/lib/workload/stateless/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/events/aws/mod.rs
@@ -4,10 +4,11 @@
 use aws_sdk_s3::types::StorageClass as AwsStorageClass;
 use chrono::{DateTime, Utc};
 use itertools::{izip, Itertools};
-use message::EventMessage;
 use serde::Deserialize;
 use sqlx::postgres::{PgHasArrayType, PgTypeInfo};
 use uuid::Uuid;
+
+use message::EventMessage;
 
 use crate::events::aws::message::EventType;
 use crate::events::aws::EventType::{Created, Deleted, Other};

--- a/lib/workload/stateless/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/handlers/aws.rs
@@ -86,6 +86,16 @@ pub async fn create_database_pool() -> Result<PgPool, Error> {
     Ok(Client::create_pool(Some(IamGeneratorBuilder::default().build().await?)).await?)
 }
 
+/// Update connection options with new credentials.
+/// Todo, replace this with sqlx `before_connect` once it is implemented.
+pub async fn update_credentials(pool: &PgPool) -> Result<(), Error> {
+    pool.set_connect_options(
+        Client::connect_options(Some(IamGeneratorBuilder::default().build().await?)).await?,
+    );
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use aws_lambda_events::sqs::SqsMessage;

--- a/lib/workload/stateless/filemanager/filemanager/src/uuid.rs
+++ b/lib/workload/stateless/filemanager/filemanager/src/uuid.rs
@@ -22,8 +22,9 @@ impl UuidGenerator {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use itertools::Itertools;
+
+    use super::*;
 
     #[test]
     fn generate_n() {

--- a/lib/workload/stateless/postgres_manager/deploy/postgres-manager-stack.ts
+++ b/lib/workload/stateless/postgres_manager/deploy/postgres-manager-stack.ts
@@ -88,7 +88,7 @@ export class PostgresManagerStack extends Stack {
     for (const microservice of microserviceDbConfig) {
       if (microservice.authType == DbAuthType.RDS_IAM) {
         const iamPolicy = new iam.ManagedPolicy(this, `${microservice.name}RdsIamPolicy`, {
-          managedPolicyName: `orcabus-rds-connect-${microservice.name}`,
+          managedPolicyName: PostgresManagerStack.formatRdsPolicyName(microservice.name),
         });
 
         const dbCluster = rds.DatabaseCluster.fromDatabaseClusterAttributes(
@@ -131,5 +131,13 @@ export class PostgresManagerStack extends Stack {
       functionName: 'orcabus-alter-pg-db-owner',
     });
     masterSecret.grantRead(alterDbPgOwnerLambda);
+  }
+
+  /**
+   * Format the name of the managed policy which is created for a microservice using RDS credentials.
+   * @param microserviceName the name of the microservice
+   */
+  static formatRdsPolicyName(microserviceName: string) {
+    return `orcabus-rds-connect-${microserviceName}`;
   }
 }

--- a/test/stateful/eventSourceConstruct.test.ts
+++ b/test/stateful/eventSourceConstruct.test.ts
@@ -40,7 +40,6 @@ beforeEach(() => {
 test('Test EventSource created props', () => {
   new EventSource(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
-    deadLetterQueueName: 'dlq',
     maxReceiveCount: 100,
     rules: [
       {
@@ -58,7 +57,6 @@ test('Test EventSource created props', () => {
 test('Test EventSource created props with event types', () => {
   new EventSource(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
-    deadLetterQueueName: 'dlq',
     maxReceiveCount: 100,
     rules: [
       {
@@ -80,7 +78,6 @@ test('Test EventSource created props with event types', () => {
 test('Test EventSource created props with prefix', () => {
   new EventSource(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
-    deadLetterQueueName: 'dlq',
     maxReceiveCount: 100,
     rules: [
       {
@@ -110,7 +107,6 @@ test('Test EventSource created props with prefix', () => {
 test('Test EventSource created props with rules matching any bucket', () => {
   new EventSource(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
-    deadLetterQueueName: 'dlq',
     maxReceiveCount: 100,
     rules: [{}],
   });

--- a/test/stateful/eventSourceConstruct.test.ts
+++ b/test/stateful/eventSourceConstruct.test.ts
@@ -40,6 +40,7 @@ beforeEach(() => {
 test('Test EventSource created props', () => {
   new EventSource(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
+    deadLetterQueueName: 'dlq',
     maxReceiveCount: 100,
     rules: [
       {
@@ -57,6 +58,7 @@ test('Test EventSource created props', () => {
 test('Test EventSource created props with event types', () => {
   new EventSource(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
+    deadLetterQueueName: 'dlq',
     maxReceiveCount: 100,
     rules: [
       {
@@ -78,6 +80,7 @@ test('Test EventSource created props with event types', () => {
 test('Test EventSource created props with prefix', () => {
   new EventSource(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
+    deadLetterQueueName: 'dlq',
     maxReceiveCount: 100,
     rules: [
       {
@@ -107,6 +110,7 @@ test('Test EventSource created props with prefix', () => {
 test('Test EventSource created props with rules matching any bucket', () => {
   new EventSource(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
+    deadLetterQueueName: 'dlq',
     maxReceiveCount: 100,
     rules: [{}],
   });


### PR DESCRIPTION
Closes #138 

### Changes
* Generate RDS IAM credentials in order to connect to the filemanager database.
    * This uses `DbAuthType.RDS_IAM` postgres manager setting.
    
### Misc
* Add a name to the event source dead letter queue.
* Filemanager lambda functions now use a shared database pool created in the init lambda execution phase.