### PR TITLE
Rotatable Db Secret Manager

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -50,6 +50,7 @@ const orcaBusStatefulConfig = {
     },
     clusterResourceIdParameterName: dbClusterResourceIdParameterName,
     clusterEndpointHostParameterName: dbClusterEndpointHostParameterName,
+    secretRotationSchedule: Duration.days(7),
   },
   securityGroupProps: {
     securityGroupName: lambdaSecurityGroupName,
@@ -82,6 +83,7 @@ const orcaBusStatelessConfig = {
     masterSecretName: rdsMasterSecretName,
     dbClusterIdentifier: dbClusterIdentifier,
     clusterResourceIdParameterName: dbClusterResourceIdParameterName,
+    dbPort: databasePort,
     microserviceDbConfig: [
       {
         name: 'sequence_run_manager',
@@ -93,6 +95,7 @@ const orcaBusStatelessConfig = {
       },
       { name: FILEMANAGER_SERVICE_NAME, authType: DbAuthType.RDS_IAM },
     ],
+    secretRotationSchedule: Duration.days(7),
   },
   metadataManagerConfig: {},
 };

--- a/lib/workload/stateful/database/component.ts
+++ b/lib/workload/stateful/database/component.ts
@@ -169,7 +169,7 @@ export class Database extends Construct {
       excludeCharacters: '" %+~`#$&()|[]{}:;' + `<>?!'/@"\\")*`,
       secret: dbSecret,
       target: this.cluster,
-      automaticallyAfter: Duration.days(1),
+      automaticallyAfter: props.secretRotationSchedule,
       securityGroup: props.allowedInboundSG,
       vpc: props.vpc,
       vpcSubnets: {

--- a/lib/workload/stateless/metadata_manager/app/settings/aws.py
+++ b/lib/workload/stateless/metadata_manager/app/settings/aws.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 DEBUG = False
 
-secret_id = os.environ.get("RDS_CRED_SECRET_NAME","orcabus/metadata_manager/rds-login-credential")
+secret_id = os.environ.get("RDS_CRED_SECRET_NAME")
 
 try:
     secret_str = libsm.get_secret(secret_id)  # this will be lru cached throughout exec lifetime

--- a/lib/workload/stateless/metadata_manager/app/settings/aws.py
+++ b/lib/workload/stateless/metadata_manager/app/settings/aws.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 DEBUG = False
 
-secret_id = os.environ.get("RDS_CRED_SECRET_NAME", "orcabus/metadata_manager/rdsLoginCredential")
+secret_id = os.environ.get("RDS_CRED_SECRET_NAME","orcabus/metadata_manager/rds-login-credential")
 
 try:
     secret_str = libsm.get_secret(secret_id)  # this will be lru cached throughout exec lifetime

--- a/lib/workload/stateless/metadata_manager/deploy/stack.ts
+++ b/lib/workload/stateless/metadata_manager/deploy/stack.ts
@@ -11,6 +11,7 @@ import { LambdaSyncGsheetConstruct } from './construct/lambda-sync-gsheet';
 import { LambdaMigrationConstruct } from './construct/lambda-migration';
 import { LambdaAPIConstruct } from './construct/lambda-api';
 import { ApiGatewayConstruct } from './construct/api-gw';
+import { PostgresManagerStack } from '../../postgres_manager/deploy/postgres-manager-stack';
 
 /**
  * this config should be configured at the top (root) cdk app
@@ -37,8 +38,8 @@ export type MetadataManagerProps = MetadataManagerConfig & {
 };
 
 export class MetadataManagerStack extends Stack {
-  // Follow by naming convention. See https://github.com/umccr/orcabus/pull/149
-  private readonly MM_RDS_CRED_SECRET_NAME = 'orcabus/metadata_manager/rdsLoginCredential'; // pragma: allowlist secret
+  private readonly MM_RDS_CRED_SECRET_NAME =
+    PostgresManagerStack.formatDbSecretManagerName('metadata_manager');
 
   constructor(scope: Construct, id: string, props: StackProps & MetadataManagerProps) {
     super(scope, id);

--- a/lib/workload/stateless/postgres_manager/README.md
+++ b/lib/workload/stateless/postgres_manager/README.md
@@ -52,7 +52,16 @@ There are 4 lambdas in this stack:
 
     Create a role with login credentials used for the microservice to use.
     The name of the role would be the microservice name itself, and the credential will be saved into the secret
-    manager. The secret manager name is saved to `orcabus/${microserviceName}/rdsLoginCredential`.
+    manager. The secret manager name is saved to `orcabus/${microserviceName}/rds-login-credential`.
+    You could make use of the static function called `formatDbSecretManagerName` in the `PostgresManagerStack` to get
+    the secret name, and you could pass this secret name to your app as an environment
+    variable when needed.
+
+    e.g.
+
+    ```typescript
+    const secretName = PostgresManagerStack.formatDbSecretManagerName('metadata_manager')
+    ```
 
     Note: this will only work if the DbAuthType is configured to `USERNAME_PASSWORD`.
 
@@ -69,7 +78,17 @@ There are 4 lambdas in this stack:
     Create a new role and assign `rds_iam` role to this role to be able to connect over IAM database authentication.
 
     A new managed policy will be created and the policy name
-    will be `orcabus-rds-connect-${microservice_name}`. This could be attached to your compute role for access to the RDS and the token needed. Follow the documentation from AWS to connect to the RDS [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html).
+    will be `orcabus-rds-connect-${microservice_name}`. This could be attached to your compute role for access to the
+    RDS and the token needed. Follow the documentation from AWS to connect to the RDS
+    [here](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.Connecting.html).
+    You could make use of the static function called `formatRdsPolicyName` in the `PostgresManagerStack` to get
+    the policy name that contains the correct permission.
+
+    e.g.
+
+    ```typescript
+    const rdsPolicyName = PostgresManagerStack.formatRdsPolicyName('metadata_manager')
+    ```
 
     Note: this will only work if the microservice DbAuthType is configured to `RDS_IAM`.
 

--- a/lib/workload/stateless/postgres_manager/deploy/postgres-manager-stack.ts
+++ b/lib/workload/stateless/postgres_manager/deploy/postgres-manager-stack.ts
@@ -1,4 +1,4 @@
-import { Duration, Stack, StackProps } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy, SecretValue, Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as nodejs from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -7,6 +7,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as rds from 'aws-cdk-lib/aws-rds';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as sm from 'aws-cdk-lib/aws-secretsmanager';
 import { MicroserviceConfig, DbAuthType } from '../function/type';
 import package_json from '../package.json';
 
@@ -15,6 +16,11 @@ export type PostgresManagerConfig = {
   dbClusterIdentifier: string;
   microserviceDbConfig: MicroserviceConfig;
   clusterResourceIdParameterName: string;
+  dbPort: number;
+  /**
+   * The schedule (in Duration) that will rotate the microservice app secret
+   */
+  secretRotationSchedule: Duration;
 };
 
 export type PostgresManagerProps = PostgresManagerConfig & {
@@ -23,6 +29,9 @@ export type PostgresManagerProps = PostgresManagerConfig & {
 };
 
 export class PostgresManagerStack extends Stack {
+  // From default: https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_rds.DatabaseSecret.html#excludecharacters
+  readonly passExcludedCharacter = '" %+~`#$&()|[]{}:;' + `<>?!'/@"\\")*`;
+
   constructor(scope: Construct, id: string, props: StackProps & PostgresManagerProps) {
     super(scope, id);
 
@@ -38,6 +47,12 @@ export class PostgresManagerStack extends Stack {
       this,
       props.clusterResourceIdParameterName
     );
+
+    const dbCluster = rds.DatabaseCluster.fromDatabaseClusterAttributes(this, 'OrcabusDbCluster', {
+      clusterIdentifier: dbClusterIdentifier,
+      clusterResourceIdentifier: dbClusterResourceId,
+      port: props.dbPort,
+    });
 
     const dependencyLayer = new lambda.LayerVersion(this, 'DependenciesLayer', {
       code: lambda.Code.fromDockerBuild(__dirname + '/../', {
@@ -89,39 +104,74 @@ export class PostgresManagerStack extends Stack {
         const iamPolicy = new iam.ManagedPolicy(this, `${microservice.name}RdsIamPolicy`, {
           managedPolicyName: PostgresManagerStack.formatRdsPolicyName(microservice.name),
         });
-
-        const dbCluster = rds.DatabaseCluster.fromDatabaseClusterAttributes(
-          this,
-          'OrcabusDbCluster',
-          {
-            clusterIdentifier: dbClusterIdentifier,
-            clusterResourceIdentifier: dbClusterResourceId,
-          }
-        );
-
         dbCluster.grantConnect(iamPolicy, microservice.name);
       }
     }
 
     // 3. lambda responsible on role creation with username-password auth
+
+    // the template of the secret where it has common props
+    const secretTemplateJson = {
+      engine: masterSecret.secretValueFromJson('engine').unsafeUnwrap(),
+      host: masterSecret.secretValueFromJson('host').unsafeUnwrap(),
+      port: masterSecret.secretValueFromJson('port').unsafeUnwrap(),
+    };
+
+    const secretManagerArray = [];
+    for (const microservice of microserviceDbConfig) {
+      if (microservice.authType == DbAuthType.USERNAME_PASSWORD) {
+        // create secret manager for specific µ-app
+        const microSM = new sm.Secret(this, `${microservice.name}UserPassCred`, {
+          description: `orcabus microservice secret for '${microservice.name}'`,
+          generateSecretString: {
+            excludeCharacters: this.passExcludedCharacter,
+            generateStringKey: 'password',
+            secretStringTemplate: JSON.stringify({
+              ...secretTemplateJson,
+              dbname: microservice.name,
+              username: microservice.name,
+            }),
+          },
+          removalPolicy: RemovalPolicy.DESTROY,
+          secretName: PostgresManagerStack.formatDbSecretManagerName(microservice.name),
+        });
+
+        // rotating these SM
+        new sm.SecretRotation(this, `${microservice.name}DbSecretRotation`, {
+          application: sm.SecretRotationApplication.POSTGRES_ROTATION_SINGLE_USER,
+          excludeCharacters: this.passExcludedCharacter,
+          secret: microSM,
+          target: dbCluster,
+          automaticallyAfter: props.secretRotationSchedule,
+          securityGroup: props.lambdaSecurityGroup,
+          vpc: props.vpc,
+          vpcSubnets: {
+            subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+          },
+        });
+
+        // pushing to an array so it can be referred later
+        secretManagerArray.push(microSM);
+      }
+    }
+
     const createRolePgLambda = new nodejs.NodejsFunction(this, 'CreateUserPassPostgresLambda', {
       ...rdsLambdaProps,
-      initialPolicy: [
-        new iam.PolicyStatement({
-          actions: ['secretsmanager:CreateSecret', 'secretsmanager:TagResource'],
-          effect: iam.Effect.ALLOW,
-          resources: [`arn:aws:secretsmanager:ap-southeast-2:*:secret:*`],
-        }),
-        new iam.PolicyStatement({
-          actions: ['secretsmanager:GetRandomPassword'],
-          effect: iam.Effect.ALLOW,
-          resources: ['*'],
-        }),
-      ],
       entry: __dirname + '/../function/create-pg-login-role.ts',
       functionName: 'orcabus-create-pg-login-role',
     });
+    createRolePgLambda.addEnvironment(
+      'MICRO_SECRET_MANAGER_TEMPLATE_NAME',
+      PostgresManagerStack.formatDbSecretManagerName('{replace_microservice_name}')
+    );
+
+    // grant lambda master secret
     masterSecret.grantRead(createRolePgLambda);
+
+    // grant to read all microservice secret name
+    for (const secret of secretManagerArray) {
+      secret.grantRead(createRolePgLambda);
+    }
 
     // 4. lambda responsible on alter db owner
     const alterDbPgOwnerLambda = new nodejs.NodejsFunction(this, 'AlterDbOwnerPostgresLambda', {
@@ -138,5 +188,13 @@ export class PostgresManagerStack extends Stack {
    */
   static formatRdsPolicyName(microserviceName: string) {
     return `orcabus-rds-connect-${microserviceName}`;
+  }
+
+  /**
+   * Format the name of the secret manager used for microservice connection string
+   * @param microserviceName the name of the microservice
+   */
+  static formatDbSecretManagerName(microserviceName: string) {
+    return `orcabus/${microserviceName}/rds-login-credential`;
   }
 }

--- a/lib/workload/stateless/postgres_manager/function/create-pg-login-role.ts
+++ b/lib/workload/stateless/postgres_manager/function/create-pg-login-role.ts
@@ -1,12 +1,11 @@
 import { DbAuthType } from './type';
-import { getMicroserviceName, getMicroserviceConfig, getRdsMasterSecret } from './utils';
 import {
-  SecretsManagerClient,
-  CreateSecretCommandInput,
-  CreateSecretCommand,
-  GetRandomPasswordCommandInput,
-  GetRandomPasswordCommand,
-} from '@aws-sdk/client-secrets-manager';
+  getMicroserviceName,
+  getMicroserviceConfig,
+  getRdsMasterSecret,
+  getSecretValue,
+} from './utils';
+import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { Client } from 'pg';
 
 type EventType = {
@@ -19,11 +18,13 @@ export const handler = async (event: EventType) => {
   const microserviceName = getMicroserviceName(microserviceConfig, event);
   const pgMasterConfig = await getRdsMasterSecret();
 
+  // validate if db is configured for username-password auth
   const findConfig = microserviceConfig.find((e) => e.name == microserviceName);
   if (findConfig?.authType != DbAuthType.USERNAME_PASSWORD) {
     throw new Error('this microservice is not configured for username-password authentication');
   }
 
+  // get db config for
   const pgClient = new Client(pgMasterConfig);
   await pgClient.connect();
   console.info('connected to RDS with master credential');
@@ -31,68 +32,23 @@ export const handler = async (event: EventType) => {
   // create a new role
   console.info('creating a user-password login role');
 
-  // get random password using aws secret manager sdk
-  const randomPassConfig: GetRandomPasswordCommandInput = {
-    PasswordLength: 32,
-    ExcludePunctuation: true,
-    RequireEachIncludedType: true,
-  };
-  const randomPassCommandInput = new GetRandomPasswordCommand(randomPassConfig);
-  const randomPassResponse = await smClient.send(randomPassCommandInput);
-  const password = randomPassResponse.RandomPassword;
-  if (!password) throw new Error('No password output from password generator');
+  // get microservice app password from the secret-manager
+  const microserviceSecretName = process.env.MICRO_SECRET_MANAGER_TEMPLATE_NAME?.replace(
+    '{replace_microservice_name}',
+    microserviceName
+  );
+  if (!microserviceSecretName)
+    throw new Error('No microservice secret name configure in the env variable');
+
+  const SMValue = JSON.parse(await getSecretValue(microserviceSecretName));
+  const SMPassword = SMValue?.password;
+  if (!SMPassword) throw new Error('No password output from password generator');
 
   // run the create role
-  const createRolePasswordSQL = `CREATE ROLE ${microserviceName} with LOGIN ENCRYPTED PASSWORD '${password}'`;
+  const createRolePasswordSQL = `CREATE ROLE ${microserviceName} with LOGIN ENCRYPTED PASSWORD '${SMPassword}'`;
   console.info(
     `RESULT: ${JSON.stringify(await pgClient.query(createRolePasswordSQL), undefined, 2)}`
   );
 
   await pgClient.end();
-
-  // store the new db config at secret manager
-  const secretName = `orcabus/${microserviceName}/rdsLoginCredential`; // pragma: allowlist secret
-  const secretValue = createSecretValue({
-    password: password,
-    host: pgMasterConfig.host,
-    port: pgMasterConfig.port,
-    username: microserviceName,
-    dbname: microserviceName,
-  });
-
-  const smInput: CreateSecretCommandInput = {
-    Name: secretName,
-    Description: `orcabus microservice secret for '${microserviceName}'`,
-    SecretString: JSON.stringify(secretValue),
-    Tags: [
-      { Key: 'stack', Value: 'manual' },
-      { Key: 'useCase', Value: 'store credential for the orcabus microservice' },
-      { Key: 'creator', Value: 'postgres_microservice at the orcabus stateless stack' },
-    ],
-  };
-  const smCommand = new CreateSecretCommand(smInput);
-
-  console.info(`storing the role credential at the secret manager (${secretName})`);
-  const response = await smClient.send(smCommand);
-  console.info(`ssm-response: ${JSON.stringify(response, undefined, 2)}`);
-};
-
-/**
- * create secret manager value for postgres format
- */
-const createSecretValue = (props: {
-  host: string;
-  username: string;
-  password: string;
-  dbname: string;
-  port: string;
-}) => {
-  return {
-    engine: 'postgres',
-    host: props.host,
-    username: props.username,
-    password: props.password,
-    dbname: props.dbname,
-    port: props.port,
-  };
 };

--- a/lib/workload/stateless/sequence_run_manager/deploy/component.ts
+++ b/lib/workload/stateless/sequence_run_manager/deploy/component.ts
@@ -10,6 +10,7 @@ import { HttpMethod, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv
 import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { SRMApiGatewayConstruct } from './apigw/component';
 import { Architecture } from 'aws-cdk-lib/aws-lambda';
+import { PostgresManagerStack } from '../../postgres_manager/deploy/postgres-manager-stack';
 
 export interface SequenceRunManagerProps {
   securityGroups: ISecurityGroup[];
@@ -18,8 +19,7 @@ export interface SequenceRunManagerProps {
 }
 
 export class SequenceRunManagerStack extends Stack {
-  // Follow by naming convention. See https://github.com/umccr/orcabus/pull/149
-  private readonly secretId: string = 'orcabus/sequence_run_manager/rdsLoginCredential';
+  private readonly secretId: string = PostgresManagerStack.formatDbSecretManagerName('sequence_run_manager');
   private readonly apiName: string = 'SequenceRunManager';  // apiNamespace `/srm/v1` is handled by Django Router
   private readonly id: string;
   private readonly props: SequenceRunManagerProps;

--- a/lib/workload/stateless/sequence_run_manager/sequence_run_manager/settings/aws.py
+++ b/lib/workload/stateless/sequence_run_manager/sequence_run_manager/settings/aws.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 DEBUG = False
 
-secret_id = os.environ.get("SECRET_ID", "orcabus/sequence_run_manager/rds-login-credential")
+secret_id = os.environ.get("SECRET_ID")
 
 try:
     secret_str = libsm.get_secret(secret_id)  # this will be lru cached throughout exec lifetime

--- a/lib/workload/stateless/sequence_run_manager/sequence_run_manager/settings/aws.py
+++ b/lib/workload/stateless/sequence_run_manager/sequence_run_manager/settings/aws.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 DEBUG = False
 
-secret_id = os.environ.get("SECRET_ID", "orcabus/sequence_run_manager/rdsLoginCredential")
+secret_id = os.environ.get("SECRET_ID", "orcabus/sequence_run_manager/rds-login-credential")
 
 try:
     secret_str = libsm.get_secret(secret_id)  # this will be lru cached throughout exec lifetime

--- a/test/stateful/stateful-deployment.test.ts
+++ b/test/stateful/stateful-deployment.test.ts
@@ -27,12 +27,6 @@ describe('cdk-nag-stateful-stack', () => {
     Aspects.of(stack).add(new AwsSolutionsChecks());
 
     // Suppress CDK-NAG for secret rotation
-    NagSuppressions.addResourceSuppressionsByPath(
-      stack,
-      `/${stack.stackName}/OrcaBusDatabaseConstruct/OrcaBusDatabaseConstructDbSecret/Resource`,
-      [{ id: 'AwsSolutions-SMG4', reason: 'Dont require secret rotation' }]
-    );
-
     NagSuppressions.addStackSuppressions(stack, [
       { id: 'AwsSolutions-APIG1', reason: 'See https://github.com/aws/aws-cdk/issues/11100' },
     ]);


### PR DESCRIPTION
- Make Master and µ-app secret manager to start rotating
- Secret Manager for µ-app is now in CDK instead of created from lambda

ToDo after merge:
- delete µ-app secret manager that is created outside cdk

closes #127 