### PR TITLE
chore: splitting config file

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -1,0 +1,98 @@
+import { region } from './constants';
+import { StatefulStackCollectionProps } from '../lib/workload/stateful/statefulStackCollectionClass';
+import { StatelessStackCollectionProps } from '../lib/workload/stateless/statelessStackCollectionClass';
+import { getSharedStackProps } from './stacks/shared';
+import { getIcaEventPipeStackProps } from './stacks/icaEventPipe';
+import { getTokenServiceStackProps } from './stacks/tokenService';
+import { getPostgresManagerStackProps } from './stacks/postgresManager';
+import { getMetadataManagerStackProps } from './stacks/metadataManager';
+import { getSequenceRunManagerStackProps } from './stacks/sequenceRunManager';
+import { getFileManagerStackProps } from './stacks/fileManager';
+
+interface EnvironmentConfig {
+  name: string;
+  region: string;
+  accountId: string;
+  stackProps: {
+    statefulConfig: StatefulStackCollectionProps;
+    statelessConfig: StatelessStackCollectionProps;
+  };
+}
+
+/**
+ * The function will return the appropriate configuration for the given account
+ *
+ * @param accountName the name of account stage
+ * @returns the configuration for the given accountName
+ */
+export const getEnvironmentConfig = (
+  accountName: 'beta' | 'gamma' | 'prod'
+): EnvironmentConfig | null => {
+  let config = null;
+  switch (accountName) {
+    case 'beta':
+      config = {
+        name: 'beta',
+        region,
+        accountId: '843407916570', // umccr_development
+        stackProps: {
+          statefulConfig: {
+            sharedStackProps: getSharedStackProps(accountName),
+            tokenServiceStackProps: getTokenServiceStackProps(),
+            icaEventPipeStackProps: getIcaEventPipeStackProps(),
+          },
+          statelessConfig: {
+            postgresManagerStackProps: getPostgresManagerStackProps(),
+            metadataManagerStackProps: getMetadataManagerStackProps(),
+            sequenceRunManagerStackProps: getSequenceRunManagerStackProps(),
+            fileManagerStackProps: getFileManagerStackProps(accountName),
+          },
+        },
+      };
+      break;
+
+    case 'gamma':
+      config = {
+        name: 'gamma',
+        region,
+        accountId: '455634345446', // umccr_staging
+        stackProps: {
+          statefulConfig: {
+            sharedStackProps: getSharedStackProps(accountName),
+            tokenServiceStackProps: getTokenServiceStackProps(),
+            icaEventPipeStackProps: getIcaEventPipeStackProps(),
+          },
+          statelessConfig: {
+            postgresManagerStackProps: getPostgresManagerStackProps(),
+            metadataManagerStackProps: getMetadataManagerStackProps(),
+            sequenceRunManagerStackProps: getSequenceRunManagerStackProps(),
+            fileManagerStackProps: getFileManagerStackProps(accountName),
+          },
+        },
+      };
+      break;
+
+    case 'prod':
+      config = {
+        name: 'prod',
+        region,
+        accountId: '472057503814', // umccr_production
+        stackProps: {
+          statefulConfig: {
+            sharedStackProps: getSharedStackProps(accountName),
+            tokenServiceStackProps: getTokenServiceStackProps(),
+            icaEventPipeStackProps: getIcaEventPipeStackProps(),
+          },
+          statelessConfig: {
+            postgresManagerStackProps: getPostgresManagerStackProps(),
+            metadataManagerStackProps: getMetadataManagerStackProps(),
+            sequenceRunManagerStackProps: getSequenceRunManagerStackProps(),
+            fileManagerStackProps: getFileManagerStackProps(accountName),
+          },
+        },
+      };
+      break;
+  }
+
+  return config;
+};

--- a/config/config.ts
+++ b/config/config.ts
@@ -28,10 +28,9 @@ interface EnvironmentConfig {
 export const getEnvironmentConfig = (
   accountName: 'beta' | 'gamma' | 'prod'
 ): EnvironmentConfig | null => {
-  let config = null;
   switch (accountName) {
     case 'beta':
-      config = {
+      return {
         name: 'beta',
         region,
         accountId: '843407916570', // umccr_development
@@ -52,7 +51,7 @@ export const getEnvironmentConfig = (
       break;
 
     case 'gamma':
-      config = {
+      return {
         name: 'gamma',
         region,
         accountId: '455634345446', // umccr_staging
@@ -73,7 +72,7 @@ export const getEnvironmentConfig = (
       break;
 
     case 'prod':
-      config = {
+      return {
         name: 'prod',
         region,
         accountId: '472057503814', // umccr_production
@@ -91,8 +90,5 @@ export const getEnvironmentConfig = (
           },
         },
       };
-      break;
   }
-
-  return config;
 };

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -1,25 +1,13 @@
-import { AuroraPostgresEngineVersion } from 'aws-cdk-lib/aws-rds';
 import { VpcLookupOptions } from 'aws-cdk-lib/aws-ec2';
-import { Duration, RemovalPolicy } from 'aws-cdk-lib';
-import { EventSourceProps } from '../lib/workload/stateful/stacks/shared/constructs/event-source';
-import { DbAuthType } from '../lib/workload/stateless/stacks/postgres-manager/function/type';
-import {
-  FILEMANAGER_SERVICE_NAME,
-  FilemanagerConfig,
-} from '../lib/workload/stateless/stacks/filemanager/deploy/lib/filemanager';
-import { IcaEventPipeStackProps } from '../lib/workload/stateful/stacks/ica-event-pipe/stack';
-import { StatefulStackCollectionProps } from '../lib/workload/stateful/statefulStackCollectionClass';
-import { StatelessStackCollectionProps } from '../lib/workload/stateless/statelessStackCollectionClass';
-import { SequenceRunManagerStackProps } from '../lib/workload/stateless/stacks/sequence-run-manager/deploy/component';
-import { MetadataManagerStackProps } from '../lib/workload/stateless/stacks/metadata-manager/deploy/stack';
-import { PostgresManagerStackProps } from '../lib/workload/stateless/stacks/postgres-manager/deploy/stack';
 
-const region = 'ap-southeast-2';
+export type AccountName = 'beta' | 'gamma' | 'prod';
+
+export const region = 'ap-southeast-2';
 
 // upstream infra: vpc
 const vpcName = 'main-vpc';
 const vpcStackName = 'networking';
-const vpcProps: VpcLookupOptions = {
+export const vpcProps: VpcLookupOptions = {
   vpcName: vpcName,
   tags: {
     Stack: vpcStackName,
@@ -27,105 +15,50 @@ const vpcProps: VpcLookupOptions = {
 };
 
 // upstream infra: cognito
-const cognitoUserPoolIdParameterName = '/data_portal/client/cog_user_pool_id';
-const cognitoPortalAppClientIdParameterName = '/data_portal/client/data2/cog_app_client_id_stage';
+export const cognitoUserPoolIdParameterName = '/data_portal/client/cog_user_pool_id';
+export const cognitoPortalAppClientIdParameterName =
+  '/data_portal/client/data2/cog_app_client_id_stage';
 
-const regName = 'OrcaBusSchemaRegistry';
-const eventBusName = 'OrcaBusMain';
-const computeSecurityGroupName = 'OrcaBusSharedComputeSecurityGroup';
-const dbClusterIdentifier = 'orcabus-db';
-const dbClusterResourceIdParameterName = '/orcabus/db-cluster-resource-id';
-const dbClusterEndpointHostParameterName = '/orcabus/db-cluster-endpoint-host';
+export const devBucket = 'umccr-temp-dev';
+export const stgBucket = 'umccr-temp-stg';
+export const prodBucket = 'org.umccr.data.oncoanalyser';
 
-const eventSourceQueueName = 'orcabus-event-source-queue';
-const devBucket = 'umccr-temp-dev';
-const stgBucket = 'umccr-temp-stg';
-const prodBucket = 'org.umccr.data.oncoanalyser';
-
-// Note, this should not end with a hyphen and 6 characters, otherwise secrets manager won't be
-// able to find the secret using a partial ARN.
-const rdsMasterSecretName = 'orcabus/master-rds'; // pragma: allowlist secret
-const databasePort = 5432;
-
-const icaEventPipeProps: IcaEventPipeStackProps = {
-  name: 'IcaEventPipeStack',
-  eventBusName: eventBusName,
-  slackTopicName: 'AwsChatBotTopic',
+/**
+ * Validate the secret name so that it doesn't end with 6 characters and a hyphen.
+ *
+ */
+export const validateSecretName = (secretName: string) => {
+  // Note, this should not end with a hyphen and 6 characters, otherwise secrets manager won't be
+  // able to find the secret using a partial ARN.
+  if (/-(.){6}$/.test(secretName)) {
+    throw new Error('the secret name should not end with a hyphen and 6 characters');
+  }
 };
 
-const serviceUserSecretName = 'orcabus/token-service-user'; // pragma: allowlist secret
-const jwtSecretName = 'orcabus/token-service-jwt'; // pragma: allowlist secret
+/**
+ * Configuration for resources created in SharedStack
+ */
+// Db Construct
+export const computeSecurityGroupName = 'OrcaBusSharedComputeSecurityGroup';
+export const dbClusterIdentifier = 'orcabus-db';
+export const dbClusterResourceIdParameterName = '/orcabus/db-cluster-resource-id';
+export const dbClusterEndpointHostParameterName = '/orcabus/db-cluster-endpoint-host';
+export const databasePort = 5432;
 
-const statefulConfig = {
-  schemaRegistryProps: {
-    registryName: regName,
-    description: 'Registry for OrcaBus Events',
-  },
-  eventBusProps: {
-    eventBusName: eventBusName,
-    archiveName: 'OrcaBusMainArchive',
-    archiveDescription: 'OrcaBus main event bus archive',
-    archiveRetention: 365,
-  },
-  databaseProps: {
-    clusterIdentifier: dbClusterIdentifier,
-    defaultDatabaseName: 'orcabus',
-    version: AuroraPostgresEngineVersion.VER_15_4,
-    parameterGroupName: 'default.aurora-postgresql15',
-    username: 'postgres',
-    dbPort: databasePort,
-    masterSecretName: rdsMasterSecretName,
-    monitoring: {
-      cloudwatchLogsExports: ['orcabus-postgresql'],
-    },
-    clusterResourceIdParameterName: dbClusterResourceIdParameterName,
-    clusterEndpointHostParameterName: dbClusterEndpointHostParameterName,
-    secretRotationSchedule: Duration.days(7),
-  },
-  computeProps: {
-    securityGroupName: computeSecurityGroupName,
-  },
-  icaEventPipeProps: icaEventPipeProps,
-  tokenServiceProps: {
-    serviceUserSecretName: serviceUserSecretName,
-    jwtSecretName: jwtSecretName,
-    vpcProps: vpcProps,
-    cognitoUserPoolIdParameterName: cognitoUserPoolIdParameterName,
-    cognitoPortalAppClientIdParameterName: cognitoPortalAppClientIdParameterName,
-  },
-};
+export const rdsMasterSecretName = 'orcabus/master-rds'; // pragma: allowlist secret
+validateSecretName(rdsMasterSecretName);
 
-const sequenceRunManagerStackProps: SequenceRunManagerStackProps = {
-  vpcProps,
-  lambdaSecurityGroupName: computeSecurityGroupName,
-  mainBusName: eventBusName,
-};
+// Other constants that exist in the SharedStack
+export const regName = 'OrcaBusSchemaRegistry';
+export const eventBusName = 'OrcaBusMain';
+export const eventSourceQueueName = 'orcabus-event-source-queue';
 
-const metadataManagerStackProps: MetadataManagerStackProps = {
-  vpcProps,
-  lambdaSecurityGroupName: computeSecurityGroupName,
-};
+/**
+ * Configuration for resources created in TokenServiceStack
+ */
 
-const postgresManagerStackProps: PostgresManagerStackProps = {
-  vpcProps,
-  lambdaSecurityGroupName: computeSecurityGroupName,
-  masterSecretName: rdsMasterSecretName,
-  dbClusterIdentifier: dbClusterIdentifier,
-  clusterResourceIdParameterName: dbClusterResourceIdParameterName,
-  dbPort: databasePort,
-  microserviceDbConfig: [
-    {
-      name: 'sequence_run_manager',
-      authType: DbAuthType.USERNAME_PASSWORD,
-    },
-    {
-      name: 'metadata_manager',
-      authType: DbAuthType.USERNAME_PASSWORD,
-    },
-    { name: FILEMANAGER_SERVICE_NAME, authType: DbAuthType.RDS_IAM },
-  ],
-  secretRotationSchedule: Duration.days(7),
-};
+export const serviceUserSecretName = 'orcabus/token-service-user'; // pragma: allowlist secret
+export const jwtSecretName = 'orcabus/token-service-jwt'; // pragma: allowlist secret
 
 // const statelessConfig = {
 //   multiSchemaConstructProps: {
@@ -149,166 +82,3 @@ const postgresManagerStackProps: PostgresManagerStackProps = {
 //   computeSecurityGroupName: computeSecurityGroupName,
 //   rdsMasterSecretName: rdsMasterSecretName,
 // };
-
-const eventSourceConfig = (bucket: string): EventSourceProps => {
-  return {
-    queueName: eventSourceQueueName,
-    maxReceiveCount: 3,
-    rules: [
-      {
-        bucket,
-      },
-    ],
-  };
-};
-
-const filemanagerConfig = (bucket: string): FilemanagerConfig => {
-  return {
-    securityGroupName: computeSecurityGroupName,
-    vpcProps,
-    eventSourceQueueName: eventSourceQueueName,
-    databaseClusterEndpointHostParameter:
-      statefulConfig.databaseProps.clusterEndpointHostParameterName,
-    port: databasePort,
-    eventSourceBuckets: [bucket],
-    migrateDatabase: true,
-  };
-};
-
-interface EnvironmentConfig {
-  name: string;
-  region: string;
-  accountId: string;
-  stackProps: {
-    statefulConfig: StatefulStackCollectionProps;
-    statelessConfig: StatelessStackCollectionProps;
-  };
-}
-
-/**
- * Validate the secret name so that it doesn't end with 6 characters and a hyphen.
- */
-export const validateSecretName = (secretName: string) => {
-  // If there are more config validation requirements like this it might be good to use
-  // a dedicated library like zod.
-  if (/-(.){6}$/.test(secretName)) {
-    throw new Error('the secret name should not end with a hyphen and 6 characters');
-  }
-};
-
-export const getEnvironmentConfig = (
-  accountName: 'beta' | 'gamma' | 'prod'
-): EnvironmentConfig | null => {
-  let config = null;
-  switch (accountName) {
-    case 'beta':
-      config = {
-        name: 'beta',
-        region,
-        accountId: '843407916570', // umccr_development
-        stackProps: {
-          statefulConfig: {
-            sharedStackProps: {
-              vpcProps,
-              schemaRegistryProps: statefulConfig.schemaRegistryProps,
-              eventBusProps: statefulConfig.eventBusProps,
-              databaseProps: {
-                ...statefulConfig.databaseProps,
-                numberOfInstance: 1,
-                minACU: 0.5,
-                maxACU: 16,
-                enhancedMonitoringInterval: Duration.seconds(60),
-                enablePerformanceInsights: true,
-                removalPolicy: RemovalPolicy.DESTROY,
-              },
-              computeProps: statefulConfig.computeProps,
-              eventSourceProps: eventSourceConfig(devBucket),
-            },
-            tokenServiceStackProps: statefulConfig.tokenServiceProps,
-            icaEventPipeStackProps: statefulConfig.icaEventPipeProps,
-          },
-          statelessConfig: {
-            postgresManagerStackProps: postgresManagerStackProps,
-            metadataManagerStackProps: metadataManagerStackProps,
-            sequenceRunManagerStackProps: sequenceRunManagerStackProps,
-            fileManagerStackProps: filemanagerConfig(devBucket),
-          },
-        },
-      };
-      break;
-
-    case 'gamma':
-      config = {
-        name: 'gamma',
-        region,
-        accountId: '455634345446', // umccr_staging
-        stackProps: {
-          statefulConfig: {
-            sharedStackProps: {
-              vpcProps,
-              schemaRegistryProps: statefulConfig.schemaRegistryProps,
-              eventBusProps: statefulConfig.eventBusProps,
-              databaseProps: {
-                ...statefulConfig.databaseProps,
-                numberOfInstance: 1,
-                minACU: 0.5,
-                maxACU: 16,
-                enhancedMonitoringInterval: Duration.seconds(60),
-                enablePerformanceInsights: true,
-                removalPolicy: RemovalPolicy.DESTROY,
-              },
-              computeProps: statefulConfig.computeProps,
-              eventSourceProps: eventSourceConfig(stgBucket),
-            },
-            tokenServiceStackProps: statefulConfig.tokenServiceProps,
-            icaEventPipeStackProps: statefulConfig.icaEventPipeProps,
-          },
-          statelessConfig: {
-            postgresManagerStackProps: postgresManagerStackProps,
-            metadataManagerStackProps: metadataManagerStackProps,
-            sequenceRunManagerStackProps: sequenceRunManagerStackProps,
-            fileManagerStackProps: filemanagerConfig(stgBucket),
-          },
-        },
-      };
-      break;
-
-    case 'prod':
-      config = {
-        name: 'prod',
-        region,
-        accountId: '472057503814', // umccr_production
-        stackProps: {
-          statefulConfig: {
-            sharedStackProps: {
-              vpcProps,
-              schemaRegistryProps: statefulConfig.schemaRegistryProps,
-              eventBusProps: statefulConfig.eventBusProps,
-              databaseProps: {
-                ...statefulConfig.databaseProps,
-                numberOfInstance: 1,
-                minACU: 0.5,
-                maxACU: 16,
-                removalPolicy: RemovalPolicy.RETAIN,
-              },
-              computeProps: statefulConfig.computeProps,
-              eventSourceProps: eventSourceConfig(prodBucket),
-            },
-            tokenServiceStackProps: statefulConfig.tokenServiceProps,
-            icaEventPipeStackProps: statefulConfig.icaEventPipeProps,
-          },
-          statelessConfig: {
-            postgresManagerStackProps: postgresManagerStackProps,
-            metadataManagerStackProps: metadataManagerStackProps,
-            sequenceRunManagerStackProps: sequenceRunManagerStackProps,
-            fileManagerStackProps: filemanagerConfig(prodBucket),
-          },
-        },
-      };
-      break;
-  }
-
-  // validateSecretName(config.stackProps.statefulConfig.databaseProps.masterSecretName);
-
-  return config;
-};

--- a/config/stacks/fileManager.ts
+++ b/config/stacks/fileManager.ts
@@ -1,0 +1,41 @@
+import { FilemanagerConfig } from '../../lib/workload/stateless/stacks/filemanager/deploy/lib/filemanager';
+import {
+  AccountName,
+  computeSecurityGroupName,
+  databasePort,
+  dbClusterEndpointHostParameterName,
+  devBucket,
+  eventSourceQueueName,
+  prodBucket,
+  stgBucket,
+  vpcProps,
+} from '../constants';
+
+export const getFileManagerStackProps = (n: AccountName): FilemanagerConfig => {
+  const baseConfig = {
+    securityGroupName: computeSecurityGroupName,
+    vpcProps,
+    eventSourceQueueName: eventSourceQueueName,
+    databaseClusterEndpointHostParameter: dbClusterEndpointHostParameterName,
+    port: databasePort,
+    migrateDatabase: true,
+  };
+
+  switch (n) {
+    case 'beta':
+      return {
+        ...baseConfig,
+        eventSourceBuckets: [devBucket],
+      };
+    case 'gamma':
+      return {
+        ...baseConfig,
+        eventSourceBuckets: [stgBucket],
+      };
+    case 'prod':
+      return {
+        ...baseConfig,
+        eventSourceBuckets: [prodBucket],
+      };
+  }
+};

--- a/config/stacks/icaEventPipe.ts
+++ b/config/stacks/icaEventPipe.ts
@@ -1,0 +1,10 @@
+import { IcaEventPipeStackProps } from '../../lib/workload/stateful/stacks/ica-event-pipe/stack';
+import { eventBusName } from '../constants';
+
+export const getIcaEventPipeStackProps = (): IcaEventPipeStackProps => {
+  return {
+    name: 'IcaEventPipeStack',
+    eventBusName: eventBusName,
+    slackTopicName: 'AwsChatBotTopic',
+  };
+};

--- a/config/stacks/metadataManager.ts
+++ b/config/stacks/metadataManager.ts
@@ -1,0 +1,9 @@
+import { computeSecurityGroupName, vpcProps } from '../constants';
+import { MetadataManagerStackProps } from '../../lib/workload/stateless/stacks/metadata-manager/deploy/stack';
+
+export const getMetadataManagerStackProps = (): MetadataManagerStackProps => {
+  return {
+    vpcProps,
+    lambdaSecurityGroupName: computeSecurityGroupName,
+  };
+};

--- a/config/stacks/postgresManager.ts
+++ b/config/stacks/postgresManager.ts
@@ -1,0 +1,35 @@
+import { Duration } from 'aws-cdk-lib';
+import { FILEMANAGER_SERVICE_NAME } from '../../lib/workload/stateless/stacks/filemanager/deploy/lib/filemanager';
+import { PostgresManagerStackProps } from '../../lib/workload/stateless/stacks/postgres-manager/deploy/stack';
+import { DbAuthType } from '../../lib/workload/stateless/stacks/postgres-manager/function/type';
+import {
+  computeSecurityGroupName,
+  databasePort,
+  dbClusterIdentifier,
+  dbClusterResourceIdParameterName,
+  rdsMasterSecretName,
+  vpcProps,
+} from '../constants';
+
+export const getPostgresManagerStackProps = (): PostgresManagerStackProps => {
+  return {
+    vpcProps,
+    lambdaSecurityGroupName: computeSecurityGroupName,
+    masterSecretName: rdsMasterSecretName,
+    dbClusterIdentifier: dbClusterIdentifier,
+    clusterResourceIdParameterName: dbClusterResourceIdParameterName,
+    dbPort: databasePort,
+    microserviceDbConfig: [
+      {
+        name: 'sequence_run_manager',
+        authType: DbAuthType.USERNAME_PASSWORD,
+      },
+      {
+        name: 'metadata_manager',
+        authType: DbAuthType.USERNAME_PASSWORD,
+      },
+      { name: FILEMANAGER_SERVICE_NAME, authType: DbAuthType.RDS_IAM },
+    ],
+    secretRotationSchedule: Duration.days(7),
+  };
+};

--- a/config/stacks/sequenceRunManager.ts
+++ b/config/stacks/sequenceRunManager.ts
@@ -1,0 +1,10 @@
+import { computeSecurityGroupName, eventBusName, vpcProps } from '../constants';
+import { SequenceRunManagerStackProps } from '../../lib/workload/stateless/stacks/sequence-run-manager/deploy/component';
+
+export const getSequenceRunManagerStackProps = (): SequenceRunManagerStackProps => {
+  return {
+    vpcProps,
+    lambdaSecurityGroupName: computeSecurityGroupName,
+    mainBusName: eventBusName,
+  };
+};

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -1,0 +1,138 @@
+import { AuroraPostgresEngineVersion } from 'aws-cdk-lib/aws-rds';
+import { ConfigurableDatabaseProps } from '../../lib/workload/stateful/stacks/shared/constructs/database';
+import { SharedStackProps } from '../../lib/workload/stateful/stacks/shared/stack';
+import {
+  AccountName,
+  computeSecurityGroupName,
+  databasePort,
+  dbClusterEndpointHostParameterName,
+  dbClusterIdentifier,
+  dbClusterResourceIdParameterName,
+  devBucket,
+  eventBusName,
+  eventSourceQueueName,
+  prodBucket,
+  rdsMasterSecretName,
+  regName,
+  stgBucket,
+  vpcProps,
+} from '../constants';
+import { Duration, RemovalPolicy } from 'aws-cdk-lib';
+import { SchemaRegistryProps } from '../../lib/workload/stateful/stacks/shared/constructs/schema-registry';
+import { EventBusProps } from '../../lib/workload/stateful/stacks/shared/constructs/event-bus';
+import { ComputeProps } from '../../lib/workload/stateful/stacks/shared/constructs/compute';
+import { EventSourceProps } from '../../lib/workload/stateful/stacks/shared/constructs/event-source';
+
+const getSchemaRegistryConstructProps = (): SchemaRegistryProps => {
+  return {
+    registryName: regName,
+    description: 'Registry for OrcaBus Events',
+  };
+};
+
+const getEventBusConstructProps = (): EventBusProps => {
+  return {
+    eventBusName: eventBusName,
+    archiveName: 'OrcaBusMainArchive',
+    archiveDescription: 'OrcaBus main event bus archive',
+    archiveRetention: 365,
+  };
+};
+
+const getComputeConstructProps = (): ComputeProps => {
+  return {
+    securityGroupName: computeSecurityGroupName,
+  };
+};
+
+const getEventSourceConstructProps = (n: AccountName): EventSourceProps => {
+  switch (n) {
+    case 'beta':
+      return {
+        queueName: eventSourceQueueName,
+        maxReceiveCount: 3,
+        rules: [
+          {
+            bucket: devBucket,
+          },
+        ],
+      };
+    case 'gamma':
+      return {
+        queueName: eventSourceQueueName,
+        maxReceiveCount: 3,
+        rules: [
+          {
+            bucket: stgBucket,
+          },
+        ],
+      };
+    case 'prod':
+      return {
+        queueName: eventSourceQueueName,
+        maxReceiveCount: 3,
+        rules: [
+          {
+            bucket: prodBucket,
+          },
+        ],
+      };
+  }
+};
+
+const getDatabaseConstructProps = (n: AccountName): ConfigurableDatabaseProps => {
+  const baseConfig = {
+    clusterIdentifier: dbClusterIdentifier,
+    defaultDatabaseName: 'orcabus',
+    version: AuroraPostgresEngineVersion.VER_15_4,
+    parameterGroupName: 'default.aurora-postgresql15',
+    username: 'postgres',
+    dbPort: databasePort,
+    masterSecretName: rdsMasterSecretName,
+    clusterResourceIdParameterName: dbClusterResourceIdParameterName,
+    clusterEndpointHostParameterName: dbClusterEndpointHostParameterName,
+    secretRotationSchedule: Duration.days(7),
+  };
+
+  switch (n) {
+    case 'beta':
+      return {
+        ...baseConfig,
+        numberOfInstance: 1,
+        minACU: 0.5,
+        maxACU: 16,
+        enhancedMonitoringInterval: Duration.seconds(60),
+        enablePerformanceInsights: true,
+        removalPolicy: RemovalPolicy.DESTROY,
+      };
+    case 'gamma':
+      return {
+        ...baseConfig,
+        numberOfInstance: 1,
+        minACU: 0.5,
+        maxACU: 16,
+        enhancedMonitoringInterval: Duration.seconds(60),
+        enablePerformanceInsights: true,
+        removalPolicy: RemovalPolicy.DESTROY,
+      };
+    case 'prod':
+      return {
+        ...baseConfig,
+        numberOfInstance: 1,
+        minACU: 0.5,
+        maxACU: 16,
+        removalPolicy: RemovalPolicy.RETAIN,
+      };
+  }
+};
+
+export const getSharedStackProps = (n: AccountName): SharedStackProps => {
+  return {
+    vpcProps,
+    schemaRegistryProps: getSchemaRegistryConstructProps(),
+    eventBusProps: getEventBusConstructProps(),
+    databaseProps: getDatabaseConstructProps(n),
+    computeProps: getComputeConstructProps(),
+    eventSourceProps: getEventSourceConstructProps(n),
+  };
+};

--- a/config/stacks/tokenService.ts
+++ b/config/stacks/tokenService.ts
@@ -1,0 +1,18 @@
+import { TokenServiceStackProps } from '../../lib/workload/stateful/stacks/token-service/deploy/stack';
+import {
+  cognitoPortalAppClientIdParameterName,
+  cognitoUserPoolIdParameterName,
+  jwtSecretName,
+  serviceUserSecretName,
+  vpcProps,
+} from '../constants';
+
+export const getTokenServiceStackProps = (): TokenServiceStackProps => {
+  return {
+    serviceUserSecretName: serviceUserSecretName,
+    jwtSecretName: jwtSecretName,
+    vpcProps: vpcProps,
+    cognitoUserPoolIdParameterName: cognitoUserPoolIdParameterName,
+    cognitoPortalAppClientIdParameterName: cognitoPortalAppClientIdParameterName,
+  };
+};

--- a/lib/pipeline/statefulPipelineStack.ts
+++ b/lib/pipeline/statefulPipelineStack.ts
@@ -7,7 +7,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as chatbot from 'aws-cdk-lib/aws-chatbot';
 import * as codestarnotifications from 'aws-cdk-lib/aws-codestarnotifications';
-import { getEnvironmentConfig } from '../../config/constants';
+import { getEnvironmentConfig } from '../../config/config';
 import {
   StatefulStackCollectionProps,
   StatefulStackCollection,

--- a/lib/pipeline/statelessPipelineStack.ts
+++ b/lib/pipeline/statelessPipelineStack.ts
@@ -13,7 +13,7 @@ import {
   StatelessStackCollectionProps,
 } from '../workload/stateless/statelessStackCollectionClass';
 
-import { getEnvironmentConfig } from '../../config/constants';
+import { getEnvironmentConfig } from '../../config/config';
 
 export class StatelessPipelineStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: cdk.StackProps) {

--- a/lib/workload/stateful/stacks/shared/constructs/database/index.ts
+++ b/lib/workload/stateful/stacks/shared/constructs/database/index.ts
@@ -14,19 +14,19 @@ type MonitoringProps = {
   /**
    * Add cloud watch exports.
    */
-  readonly cloudwatchLogsExports?: string[];
+  cloudwatchLogsExports?: string[];
   /**
    * Enable performance insights.
    */
-  readonly enablePerformanceInsights?: boolean;
+  enablePerformanceInsights?: boolean;
   /**
    * performance insights retention period.
    */
-  readonly performanceInsightsRetention?: rds.PerformanceInsightRetention;
+  performanceInsightsRetention?: rds.PerformanceInsightRetention;
   /**
    * Enable enhanced monitoring by specifying the interval.
    */
-  readonly enhancedMonitoringInterval?: Duration;
+  enhancedMonitoringInterval?: Duration;
 };
 
 /**

--- a/test/stateful/pipeline/deployment.test.ts
+++ b/test/stateful/pipeline/deployment.test.ts
@@ -3,7 +3,7 @@ import { Annotations, Match } from 'aws-cdk-lib/assertions';
 import { SynthesisMessage } from 'aws-cdk-lib/cx-api';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
 
-import { getEnvironmentConfig } from '../../../config/constants';
+import { getEnvironmentConfig } from '../../../config/config';
 import { StatefulStackCollection } from '../../../lib/workload/stateful/statefulStackCollectionClass';
 
 function synthesisMessageToString(sm: SynthesisMessage): string {

--- a/test/stateful/shared/computeConstruct.test.ts
+++ b/test/stateful/shared/computeConstruct.test.ts
@@ -1,7 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import { Template } from 'aws-cdk-lib/assertions';
-import { getEnvironmentConfig } from '../../../config/constants';
+import { getEnvironmentConfig } from '../../../config/config';
 import { ComputeConstruct } from '../../../lib/workload/stateful/stacks/shared/constructs/compute';
 
 let stack: cdk.Stack;

--- a/test/stateful/shared/databaseConstruct.test.ts
+++ b/test/stateful/shared/databaseConstruct.test.ts
@@ -2,7 +2,7 @@ import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
 import { DatabaseConstruct } from '../../../lib/workload/stateful/stacks/shared/constructs/database';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import { getEnvironmentConfig } from '../../../config/constants';
+import { getEnvironmentConfig } from '../../../config/config';
 
 let stack: cdk.Stack;
 let vpc: ec2.Vpc;

--- a/test/stateful/shared/eventbusConstruct.test.ts
+++ b/test/stateful/shared/eventbusConstruct.test.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { getEnvironmentConfig } from '../../../config/constants';
+import { getEnvironmentConfig } from '../../../config/config';
 import { EventBusConstruct } from '../../../lib/workload/stateful/stacks/shared/constructs/event-bus';
 
 let stack: cdk.Stack;

--- a/test/stateful/shared/schemaRegistryConstruct.test.ts
+++ b/test/stateful/shared/schemaRegistryConstruct.test.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { getEnvironmentConfig } from '../../../config/constants';
+import { getEnvironmentConfig } from '../../../config/config';
 import { SchemaRegistryConstruct } from '../../../lib/workload/stateful/stacks/shared/constructs/schema-registry';
 
 let stack: cdk.Stack;

--- a/test/stateful/token-service/tokenServiceConstruct.test.ts
+++ b/test/stateful/token-service/tokenServiceConstruct.test.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Template } from 'aws-cdk-lib/assertions';
-import { getEnvironmentConfig } from '../../../config/constants';
+import { getEnvironmentConfig } from '../../../config/config';
 import { TokenServiceStack } from '../../../lib/workload/stateful/stacks/token-service/deploy/stack';
 
 const constructConfig = getEnvironmentConfig('beta');

--- a/test/stateless/deployment.test.ts
+++ b/test/stateless/deployment.test.ts
@@ -2,7 +2,7 @@ import { App, Aspects, Stack } from 'aws-cdk-lib';
 import { Annotations, Match } from 'aws-cdk-lib/assertions';
 import { SynthesisMessage } from 'aws-cdk-lib/cx-api';
 import { AwsSolutionsChecks, NagSuppressions } from 'cdk-nag';
-import { getEnvironmentConfig } from '../../config/constants';
+import { getEnvironmentConfig } from '../../config/config';
 import { StatelessStackCollection } from '../../lib/workload/stateless/statelessStackCollectionClass';
 
 function synthesisMessageToString(sm: SynthesisMessage): string {


### PR DESCRIPTION
Just the initial phase of refactoring config file as now seems to be a bit tedious. Splitting the config per individual stack, so could make use of the Type check for each stack props.

Partial #167  