### PR TITLE
Fix docker options for filemanager

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
@@ -102,6 +102,9 @@ export class Function extends Construct {
           // The bundling process needs to be able to connect to the container running postgres.
           DATABASE_URL: localDatabaseUrl,
         },
+        dockerOptions: {
+          network: 'host',
+        }
       },
       memorySize: 128,
       timeout: Duration.seconds(28),


### PR DESCRIPTION
When building the rust function, it wants to connect to the file manager, because I'm working on a intel machine, this needs to be built over a docker container, when doing so it doesn't by default allow ports on the container, and then fails as it can't find the existing docker container running the file manager. 

Resolves #241 