### PR TITLE
Fix event duplication And Remove Server access logs when archiving to bucket 

### DIFF
--- a/lib/workload/stateful/stacks/shared/constructs/event-bus/custom-event-archiver/archive_service/universal_event_archiver.py
+++ b/lib/workload/stateful/stacks/shared/constructs/event-bus/custom-event-archiver/archive_service/universal_event_archiver.py
@@ -39,7 +39,7 @@ def handler(event, context):
     # Write the JSON to an S3 bucket
     try:
         s3.put_object(Bucket=BUCKET_NAME, Key=key, Body=event_json, Tagging='&'.join([f'{k}={v}' for k, v in default_tags.items()]))
-        logger.info("Event stored: %s", key)
+        logger.info("Event stored: %s", str(key))
     except Exception as e:
         logger.error("Error storing event: %s", str(e))
         raise e

--- a/lib/workload/stateful/stacks/shared/constructs/event-bus/custom-event-archiver/archive_service/universal_event_archiver.py
+++ b/lib/workload/stateful/stacks/shared/constructs/event-bus/custom-event-archiver/archive_service/universal_event_archiver.py
@@ -39,7 +39,7 @@ def handler(event, context):
     # Write the JSON to an S3 bucket
     try:
         s3.put_object(Bucket=BUCKET_NAME, Key=key, Body=event_json, Tagging='&'.join([f'{k}={v}' for k, v in default_tags.items()]))
-        logger.info("Event stored:", key)
+        logger.info("Event stored: %s", key)
     except Exception as e:
         logger.error("Error storing event: %s", str(e))
         raise e

--- a/lib/workload/stateful/stacks/shared/constructs/event-bus/index.ts
+++ b/lib/workload/stateful/stacks/shared/constructs/event-bus/index.ts
@@ -61,7 +61,6 @@ export class EventBusConstruct extends Construct {
     const archiveBucket = new Bucket(this, 'UniversalEventArchiveBucket', {
       bucketName: props.archiveBucketName,
       removalPolicy: RemovalPolicy.RETAIN,
-      serverAccessLogsPrefix: 'server-access-logs/',
       enforceSSL: true, //denies any request made via plain HTTP
     });
     // dedicated security group for the lambda function

--- a/test/stateful/pipeline/deployment.test.ts
+++ b/test/stateful/pipeline/deployment.test.ts
@@ -92,10 +92,16 @@ function applyNagSuppression(stackId: string, stack: Stack) {
       NagSuppressions.addResourceSuppressionsByPath(
         stack,
         [
+          '/SharedStack/EventBusConstruct/UniversalEventArchiveBucket/Resource',
           '/SharedStack/EventBusConstruct/UniversalEventArchiver/UniversalEventArchiver/ServiceRole/Resource',
           '/SharedStack/EventBusConstruct/UniversalEventArchiver/UniversalEventArchiver/ServiceRole/DefaultPolicy/Resource',
         ],
         [
+          {
+            id: 'AwsSolutions-S1',
+            reason:
+              'This is no necessity to retain the server access logs for Event Archiver Bucket.',
+          },
           {
             id: 'AwsSolutions-IAM4',
             reason:


### PR DESCRIPTION
1. Fix #244 
fix logger info format error in lambda

Duplicate Event Reason:
From the cloud watch log about this func, we have error in `logger.info` , and the error is```Error storing event: not all arguments converted during string formatting```, this may come the `%s` is a placeholder that expects a string to replace in the info.
![image](https://github.com/umccr/orcabus/assets/160200168/8760386f-7445-4aac-a355-f3c920ba56b5)

And this error will trigger retry function in our setting. Retry 3 times will generate 3 copy of the events.




2. Fix #245 
As I check around for our could trail events, we may not need the to retain the server access logs for event archiver bucket, as the main purpose for this bucket is to "**archive**" already, and serve for event statistic and analysis.

PS: add cdk-nag Suppressions for unit testing error for the s3 bucket: 
`["AwsSolutions-S1: The S3 Bucket has server access logs disabled. [/SharedStack/EventBusConstruct/UniversalEventArchiveBucket/Resource]"]`