### PR TITLE
event archive bucket policy modification according different env

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -1,4 +1,4 @@
-import { region } from './constants';
+import { region, accountIdAlias } from './constants';
 import { StatefulStackCollectionProps } from '../lib/workload/stateful/statefulStackCollectionClass';
 import { StatelessStackCollectionProps } from '../lib/workload/stateless/statelessStackCollectionClass';
 import { getSharedStackProps } from './stacks/shared';
@@ -35,7 +35,7 @@ export const getEnvironmentConfig = (
       return {
         name: 'beta',
         region,
-        accountId: '843407916570', // umccr_development
+        accountId: accountIdAlias[accountName], // umccr_development
         stackProps: {
           statefulConfig: {
             sharedStackProps: getSharedStackProps(accountName),
@@ -57,7 +57,7 @@ export const getEnvironmentConfig = (
       return {
         name: 'gamma',
         region,
-        accountId: '455634345446', // umccr_staging
+        accountId: accountIdAlias[accountName], // umccr_staging
         stackProps: {
           statefulConfig: {
             sharedStackProps: getSharedStackProps(accountName),
@@ -79,7 +79,7 @@ export const getEnvironmentConfig = (
       return {
         name: 'prod',
         region,
-        accountId: '472057503814', // umccr_production
+        accountId: accountIdAlias[accountName], // umccr_production
         stackProps: {
           statefulConfig: {
             sharedStackProps: getSharedStackProps(accountName),

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -4,6 +4,20 @@ export type AccountName = 'beta' | 'gamma' | 'prod';
 
 export const region = 'ap-southeast-2';
 
+/**
+ * accountIdAlias: mapping from AccountName to AWS Account ID.
+ * accountIdAliasType to ensure that the accountId is always explicitly defined for each account.
+ */
+type accountIdAliasType = {
+  [K in AccountName]: string;
+};
+
+export const accountIdAlias: accountIdAliasType = {
+  beta: '843407916570', // umccr_development
+  gamma: '455634345446', // umccr_staging
+  prod: '472057503814', // umccr_production
+};
+
 // external ICA constants
 export const icaAwsAccountNumber = '079623148045';
 
@@ -63,7 +77,7 @@ export const eventBusName = 'OrcaBusMain';
 export const eventSourceQueueName = 'orcabus-event-source-queue';
 
 // Event Archiver constants for EventBus Contruct in SharedStack
-export const archiveBucketNamePrefix = 'orcabus-event-archive-';
+export const archiveBucketNameSuffix = '-orcabus-event-archive';
 export const archiveSecurityGroupName = 'OrcaBusSharedEventBusEventArchiveSecurityGroup';
 
 /**

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -63,8 +63,8 @@ export const eventBusName = 'OrcaBusMain';
 export const eventSourceQueueName = 'orcabus-event-source-queue';
 
 // Event Archiver constants for EventBus Contruct in SharedStack
-export const archiveBucketName = 'event-archive-bucket';
-export const archiveSecurityGroupName = 'OrcaBusEventArchiveSecurityGroup';
+export const archiveBucketNameSuffix = 'event-archive-bucket';
+export const archiveSecurityGroupName = 'OrcaBusShareEventBusEventArchiveSecurityGroup';
 
 /**
  * Configuration for resources created in TokenServiceStack

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -63,7 +63,7 @@ export const eventBusName = 'OrcaBusMain';
 export const eventSourceQueueName = 'orcabus-event-source-queue';
 
 // Event Archiver constants for EventBus Contruct in SharedStack
-export const archiveBucketNameSuffix = 'orcabus-event-archive-bucket';
+export const archiveBucketNamePrefix = 'orcabus-event-archive-';
 export const archiveSecurityGroupName = 'OrcaBusSharedEventBusEventArchiveSecurityGroup';
 
 /**

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -77,7 +77,7 @@ export const eventBusName = 'OrcaBusMain';
 export const eventSourceQueueName = 'orcabus-event-source-queue';
 
 // Event Archiver constants for EventBus Contruct in SharedStack
-export const archiveBucketNameSuffix = '-orcabus-event-archive';
+export const archiveBucketNamePrefix = 'orcabus-event-archive-';
 export const archiveSecurityGroupName = 'OrcaBusSharedEventBusEventArchiveSecurityGroup';
 
 /**

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -64,7 +64,7 @@ export const eventSourceQueueName = 'orcabus-event-source-queue';
 
 // Event Archiver constants for EventBus Contruct in SharedStack
 export const archiveBucketNameSuffix = 'event-archive-bucket';
-export const archiveSecurityGroupName = 'OrcaBusShareEventBusEventArchiveSecurityGroup';
+export const archiveSecurityGroupName = 'OrcaBusSharedEventBusEventArchiveSecurityGroup';
 
 /**
  * Configuration for resources created in TokenServiceStack

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -63,7 +63,7 @@ export const eventBusName = 'OrcaBusMain';
 export const eventSourceQueueName = 'orcabus-event-source-queue';
 
 // Event Archiver constants for EventBus Contruct in SharedStack
-export const archiveBucketNameSuffix = 'event-archive-bucket';
+export const archiveBucketNameSuffix = 'orcabus-event-archive-bucket';
 export const archiveSecurityGroupName = 'OrcaBusSharedEventBusEventArchiveSecurityGroup';
 
 /**

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -76,10 +76,6 @@ export const regName = 'OrcaBusSchemaRegistry';
 export const eventBusName = 'OrcaBusMain';
 export const eventSourceQueueName = 'orcabus-event-source-queue';
 
-// Event Archiver constants for EventBus Contruct in SharedStack
-export const archiveBucketNamePrefix = 'orcabus-event-archive-';
-export const archiveSecurityGroupName = 'OrcaBusSharedEventBusEventArchiveSecurityGroup';
-
 /**
  * Configuration for resources created in TokenServiceStack
  */

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -17,8 +17,6 @@ import {
   regName,
   stgBucket,
   vpcProps,
-  archiveBucketNamePrefix,
-  archiveSecurityGroupName,
 } from '../constants';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { SchemaRegistryProps } from '../../lib/workload/stateful/stacks/shared/constructs/schema-registry';
@@ -42,8 +40,8 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
 
     // common config for custom event archiver
     vpcProps: vpcProps,
-    lambdaSecurityGroupName: archiveSecurityGroupName,
-    archiveBucketName: archiveBucketNamePrefix + accountIdAlias[n],
+    archiveBucketName: 'orcabus-event-archive-' + accountIdAlias[n],
+    lambdaSecurityGroupName: 'OrcaBusSharedEventBusEventArchiveSecurityGroup',
   };
 
   switch (n) {

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -17,7 +17,7 @@ import {
   regName,
   stgBucket,
   vpcProps,
-  archiveBucketNameSuffix,
+  archiveBucketNamePrefix,
   archiveSecurityGroupName,
 } from '../constants';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
@@ -43,6 +43,7 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
     // common config for custom event archiver
     vpcProps: vpcProps,
     lambdaSecurityGroupName: archiveSecurityGroupName,
+    archiveBucketName: archiveBucketNamePrefix + accountIdAlias[n],
   };
 
   switch (n) {
@@ -50,21 +51,18 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: accountIdAlias[n] + archiveBucketNameSuffix,
         bucketRemovalPolicy: RemovalPolicy.DESTROY,
       };
     case 'gamma':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: accountIdAlias[n] + archiveBucketNameSuffix,
         bucketRemovalPolicy: RemovalPolicy.DESTROY,
       };
     case 'prod':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: accountIdAlias[n] + archiveBucketNameSuffix,
         bucketRemovalPolicy: RemovalPolicy.RETAIN,
       };
   }

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -3,6 +3,7 @@ import { ConfigurableDatabaseProps } from '../../lib/workload/stateful/stacks/sh
 import { SharedStackProps } from '../../lib/workload/stateful/stacks/shared/stack';
 import {
   AccountName,
+  accountIdAlias,
   computeSecurityGroupName,
   databasePort,
   dbClusterEndpointHostParameterName,
@@ -16,7 +17,7 @@ import {
   regName,
   stgBucket,
   vpcProps,
-  archiveBucketNamePrefix,
+  archiveBucketNameSuffix,
   archiveSecurityGroupName,
 } from '../constants';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
@@ -49,21 +50,21 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: archiveBucketNamePrefix + 'dev',
+        archiveBucketName: accountIdAlias[n] + archiveBucketNameSuffix,
         bucketRemovalPolicy: RemovalPolicy.DESTROY,
       };
     case 'gamma':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: archiveBucketNamePrefix + 'stg',
+        archiveBucketName: accountIdAlias[n] + archiveBucketNameSuffix,
         bucketRemovalPolicy: RemovalPolicy.DESTROY,
       };
     case 'prod':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: archiveBucketNamePrefix + 'prod',
+        archiveBucketName: accountIdAlias[n] + archiveBucketNameSuffix,
         bucketRemovalPolicy: RemovalPolicy.RETAIN,
       };
   }

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -40,7 +40,7 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
 
     // common config for custom event archiver
     vpcProps: vpcProps,
-    archiveBucketName: 'orcabus-event-archive-' + accountIdAlias[n],
+    archiveBucketName: 'orcabus-universal-events-archive-' + accountIdAlias[n],
     lambdaSecurityGroupName: 'OrcaBusSharedEventBusEventArchiveSecurityGroup',
   };
 

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -16,7 +16,7 @@ import {
   regName,
   stgBucket,
   vpcProps,
-  archiveBucketNameSuffix,
+  archiveBucketNamePrefix,
   archiveSecurityGroupName,
 } from '../constants';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
@@ -49,21 +49,21 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: 'umccr-dev-' + archiveBucketNameSuffix,
+        archiveBucketName: archiveBucketNamePrefix + 'dev',
         bucketRemovalPolicy: RemovalPolicy.DESTROY,
       };
     case 'gamma':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: 'umccr-stg-' + archiveBucketNameSuffix,
+        archiveBucketName: archiveBucketNamePrefix + 'stg',
         bucketRemovalPolicy: RemovalPolicy.DESTROY,
       };
     case 'prod':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        archiveBucketName: 'umccr-prod-' + archiveBucketNameSuffix,
+        archiveBucketName: archiveBucketNamePrefix + 'prod',
         bucketRemovalPolicy: RemovalPolicy.RETAIN,
       };
   }

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -16,7 +16,7 @@ import {
   regName,
   stgBucket,
   vpcProps,
-  archiveBucketName,
+  archiveBucketNameSuffix,
   archiveSecurityGroupName,
 } from '../constants';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
@@ -33,19 +33,40 @@ const getSchemaRegistryConstructProps = (): SchemaRegistryProps => {
 };
 
 const getEventBusConstructProps = (n: AccountName): EventBusProps => {
-  return {
+  const baseConfig = {
     eventBusName: eventBusName,
     archiveName: 'OrcaBusMainArchive',
     archiveDescription: 'OrcaBus main event bus archive',
     archiveRetention: 365,
 
-    // add custom event archiver
-    addCustomEventArchiver: true,
+    // common config for custom event archiver
     vpcProps: vpcProps,
     lambdaSecurityGroupName: archiveSecurityGroupName,
-    archiveBucketName: archiveBucketName,
-    enableBucketRetainPolicy: n === 'prod',
   };
+
+  switch (n) {
+    case 'beta':
+      return {
+        ...baseConfig,
+        addCustomEventArchiver: true,
+        archiveBucketName: 'umccr-dev-' + archiveBucketNameSuffix,
+        enableBucketRetainPolicy: false,
+      };
+    case 'gamma':
+      return {
+        ...baseConfig,
+        addCustomEventArchiver: true,
+        archiveBucketName: 'umccr-stg-' + archiveBucketNameSuffix,
+        enableBucketRetainPolicy: false,
+      };
+    case 'prod':
+      return {
+        ...baseConfig,
+        addCustomEventArchiver: true,
+        archiveBucketName: 'umccr-prod-' + archiveBucketNameSuffix,
+        enableBucketRetainPolicy: true,
+      };
+  }
 };
 
 const getComputeConstructProps = (): ComputeProps => {

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -32,7 +32,7 @@ const getSchemaRegistryConstructProps = (): SchemaRegistryProps => {
   };
 };
 
-const getEventBusConstructProps = (): EventBusProps => {
+const getEventBusConstructProps = (n: AccountName): EventBusProps => {
   return {
     eventBusName: eventBusName,
     archiveName: 'OrcaBusMainArchive',
@@ -44,6 +44,7 @@ const getEventBusConstructProps = (): EventBusProps => {
     vpcProps: vpcProps,
     lambdaSecurityGroupName: archiveSecurityGroupName,
     archiveBucketName: archiveBucketName,
+    enableBucketRetainPolicy: n === 'prod',
   };
 };
 
@@ -138,7 +139,7 @@ export const getSharedStackProps = (n: AccountName): SharedStackProps => {
   return {
     vpcProps,
     schemaRegistryProps: getSchemaRegistryConstructProps(),
-    eventBusProps: getEventBusConstructProps(),
+    eventBusProps: getEventBusConstructProps(n),
     databaseProps: getDatabaseConstructProps(n),
     computeProps: getComputeConstructProps(),
     eventSourceProps: getEventSourceConstructProps(n),

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -50,21 +50,21 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
         ...baseConfig,
         addCustomEventArchiver: true,
         archiveBucketName: 'umccr-dev-' + archiveBucketNameSuffix,
-        enableBucketRetainPolicy: false,
+        bucketRemovalPolicy: RemovalPolicy.DESTROY,
       };
     case 'gamma':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
         archiveBucketName: 'umccr-stg-' + archiveBucketNameSuffix,
-        enableBucketRetainPolicy: false,
+        bucketRemovalPolicy: RemovalPolicy.DESTROY,
       };
     case 'prod':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
         archiveBucketName: 'umccr-prod-' + archiveBucketNameSuffix,
-        enableBucketRetainPolicy: true,
+        bucketRemovalPolicy: RemovalPolicy.RETAIN,
       };
   }
 };

--- a/lib/workload/stateful/stacks/shared/constructs/event-bus/index.ts
+++ b/lib/workload/stateful/stacks/shared/constructs/event-bus/index.ts
@@ -16,7 +16,7 @@ export interface EventBusProps {
   vpcProps?: VpcLookupOptions;
   lambdaSecurityGroupName?: string;
   archiveBucketName?: string;
-  enableBucketRetainPolicy?: boolean;
+  bucketRemovalPolicy?: RemovalPolicy;
 }
 
 export class EventBusConstruct extends Construct {
@@ -50,9 +50,14 @@ export class EventBusConstruct extends Construct {
   }
 
   private createUniversalEventArchiver(props: EventBusProps) {
-    if (!props.vpcProps || !props.archiveBucketName || !props.lambdaSecurityGroupName) {
+    if (
+      !props.vpcProps ||
+      !props.archiveBucketName ||
+      !props.lambdaSecurityGroupName ||
+      !props.bucketRemovalPolicy
+    ) {
       throw new Error(
-        'VPC, Security Group and Archive Bucket are required for custom event archiver function.'
+        'VPC, Security Group, Archive Bucket Name and Removal Policy are required for custom event archiver function.'
       );
     }
 
@@ -61,7 +66,7 @@ export class EventBusConstruct extends Construct {
     // dedicated bucket for archiving all events
     const archiveBucket = new Bucket(this, 'UniversalEventArchiveBucket', {
       bucketName: props.archiveBucketName,
-      removalPolicy: props.enableBucketRetainPolicy ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
+      removalPolicy: props.bucketRemovalPolicy,
       enforceSSL: true, //denies any request made via plain HTTP
     });
     // dedicated security group for the lambda function

--- a/lib/workload/stateful/stacks/shared/constructs/event-bus/index.ts
+++ b/lib/workload/stateful/stacks/shared/constructs/event-bus/index.ts
@@ -16,6 +16,7 @@ export interface EventBusProps {
   vpcProps?: VpcLookupOptions;
   lambdaSecurityGroupName?: string;
   archiveBucketName?: string;
+  enableBucketRetainPolicy?: boolean;
 }
 
 export class EventBusConstruct extends Construct {
@@ -60,7 +61,7 @@ export class EventBusConstruct extends Construct {
     // dedicated bucket for archiving all events
     const archiveBucket = new Bucket(this, 'UniversalEventArchiveBucket', {
       bucketName: props.archiveBucketName,
-      removalPolicy: RemovalPolicy.RETAIN,
+      removalPolicy: props.enableBucketRetainPolicy ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
       enforceSSL: true, //denies any request made via plain HTTP
     });
     // dedicated security group for the lambda function


### PR DESCRIPTION
Fix/Refactor of event archiver: 

1. RemovalPolicy:
`RemovalPolicy.DESTROY `mode in our dev/test envs, 
only enable `RemovalPolicy.RETAIN` in prod env. 
For dev/test redeployment, we may still delete all contents in the bucket and get the bucket physically deleted.

2. unique bucket name 
beta: orcabus-event-archive-_`devAccountId`_, 
gamma: orcabus-event-archive-_`stgAccountId`_, 
prod: orcabus-event-archive-_`prodAccountId`_, 

From discuss: https://umccr.slack.com/archives/C03ABJTSN7J/p1713927722151309