### PR TITLE
custom event bus archiver props and stateful unit testing fixing

### DIFF
--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -20,7 +20,10 @@ import {
 } from '../constants';
 import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { SchemaRegistryProps } from '../../lib/workload/stateful/stacks/shared/constructs/schema-registry';
-import { EventBusProps } from '../../lib/workload/stateful/stacks/shared/constructs/event-bus';
+import {
+  EventBusProps,
+  EventBusArchiverProps,
+} from '../../lib/workload/stateful/stacks/shared/constructs/event-bus';
 import { ComputeProps } from '../../lib/workload/stateful/stacks/shared/constructs/compute';
 import { EventSourceProps } from '../../lib/workload/stateful/stacks/shared/constructs/event-source';
 
@@ -37,11 +40,13 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
     archiveName: 'OrcaBusMainArchive',
     archiveDescription: 'OrcaBus main event bus archive',
     archiveRetention: 365,
+  };
 
-    // common config for custom event archiver
+  const baseUniversalEventArchiverProps: EventBusArchiverProps = {
     vpcProps: vpcProps,
     archiveBucketName: 'orcabus-universal-events-archive-' + accountIdAlias[n],
-    lambdaSecurityGroupName: 'OrcaBusSharedEventBusEventArchiveSecurityGroup',
+    lambdaSecurityGroupName: 'OrcaBusSharedEventBusUniversalEventArchiveSecurityGroup',
+    bucketRemovalPolicy: RemovalPolicy.DESTROY,
   };
 
   switch (n) {
@@ -49,19 +54,22 @@ const getEventBusConstructProps = (n: AccountName): EventBusProps => {
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        bucketRemovalPolicy: RemovalPolicy.DESTROY,
+        universalEventArchiverProps: baseUniversalEventArchiverProps,
       };
     case 'gamma':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        bucketRemovalPolicy: RemovalPolicy.DESTROY,
+        universalEventArchiverProps: baseUniversalEventArchiverProps,
       };
     case 'prod':
       return {
         ...baseConfig,
         addCustomEventArchiver: true,
-        bucketRemovalPolicy: RemovalPolicy.RETAIN,
+        universalEventArchiverProps: {
+          ...baseUniversalEventArchiverProps,
+          bucketRemovalPolicy: RemovalPolicy.RETAIN,
+        },
       };
   }
 };

--- a/test/stateful/shared/eventbusConstruct.test.ts
+++ b/test/stateful/shared/eventbusConstruct.test.ts
@@ -1,5 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
-import { Template } from 'aws-cdk-lib/assertions';
+import { Template, Match } from 'aws-cdk-lib/assertions';
 import { getEnvironmentConfig } from '../../../config/config';
 import { EventBusConstruct } from '../../../lib/workload/stateful/stacks/shared/constructs/event-bus';
 import { vpcProps } from '../../../config/constants';
@@ -31,11 +31,12 @@ test('Test EventBusConstruct Creation With Custome Events Archiver', () => {
   template.hasResourceProperties('AWS::Events::EventBus', {
     Name: 'OrcaBusMain',
   });
-  template.hasResourceProperties('AWS::S3::Bucket', {
-    BucketName: 'event-archive-bucket',
-  });
+  template.hasResourceProperties(
+    'AWS::S3::Bucket',
+    Match.objectLike({ BucketName: Match.stringLikeRegexp('orcabus-universal-events-') })
+  );
   template.hasResourceProperties('AWS::EC2::SecurityGroup', {
-    GroupName: 'OrcaBusEventArchiveSecurityGroup',
+    GroupName: 'OrcaBusSharedEventBusUniversalEventArchiveSecurityGroup',
   });
   template.hasResourceProperties('AWS::Lambda::Function', {
     Handler: 'universal_event_archiver.handler',


### PR DESCRIPTION
for custom  event bus archiver:

1. refactor current event bus archiver props with new `EventBusArchiverProps` for **clarity and granular manipulation**, and also enable eventbus props for future extension with more special archivers.

2. fixing stateful unit testing error with new name conventions in` eventbusConstruct.test.ts`