### PR TITLE
Use 'currentVersion' for lambda object to resolve the cdk nag issue

### DIFF
--- a/lib/workload/stateless/stacks/cttso-v2-pipeline-manager/deploy/constructs/cttsov2-icav2-manager/index.ts
+++ b/lib/workload/stateless/stacks/cttso-v2-pipeline-manager/deploy/constructs/cttsov2-icav2-manager/index.ts
@@ -194,7 +194,7 @@ export class Cttsov2Icav2PipelineManagerConstruct extends Construct {
       generate_trimmed_samplesheet_lambda_obj,
       upload_samplesheet_to_cache_dir_lambda_obj,
     ].forEach((lambda_obj) => {
-      lambda_obj.grantInvoke(<iam.IRole>stateMachine.role);
+      lambda_obj.currentVersion.grantInvoke(<iam.IRole>stateMachine.role);
     });
 
     // Allow state machine to read/write to dynamodb table


### PR DESCRIPTION
Related issue: https://github.com/aws/aws-cdk/issues/20177

`grantInvoke` will use `*` for all lambda versions which breaks cdk-nag.  

By using `currentVersion` attribute of the lambda obj we only grantInvoke for only the latest version of the lambda object, resolving the cdc-nag errors