### PR TITLE
feat: Refine Testing Configuration

### DIFF
--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -68,18 +68,18 @@ jobs:
       - run: make test-suite
 
   # This require a self hosted runner where the compute is in ARM architecture
-  #
-  # test-stateful-stack:
-  #   runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
 
-  #     - name: Install dependencies
-  #       run: |
-  #         yarn install --immutable
+  test-stateful-stack:
+    runs-on: codebuild-wil-test-cb-orcabus-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - run: make test-stateful
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
+
+      - run: make test-stateful
 
   # test-stateless-stack:
   #   runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -52,22 +52,24 @@ jobs:
         run: |
           make check
 
-  # test-stateless-suite:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  test-stateless-suite:
+    # codebuild project name is initiated at ./lib/bin/statelessPipelineStack (PR-290)
+    runs-on: codebuild-orcabus-codebuild-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Rust installation
-  #       uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Rust installation
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-  #     - name: Install dependencies
-  #       run: |
-  #         yarn install --immutable
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
 
-  #     - run: make test-suite
+      - run: make test-suite
 
   test-stateful-stack:
+    # codebuild project name is initiated at ./lib/bin/statelessPipelineStack (PR-290)
     runs-on: codebuild-orcabus-codebuild-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
@@ -80,6 +82,7 @@ jobs:
       - run: make test-stateful
 
   test-stateless-stack:
+    # codebuild project name is initiated at ./lib/bin/statelessPipelineStack (PR-290)
     runs-on: codebuild-orcabus-codebuild-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -57,8 +57,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Install dependencies
         run: |
@@ -71,8 +69,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Rust installation
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -88,8 +84,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Rust installation
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -81,17 +81,17 @@ jobs:
 
       - run: make test-stateful
 
-  # test-stateless-stack:
-  #   runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
+  test-stateless-stack:
+    runs-on: codebuild-wil-test-cb-orcabus-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-  #     - name: Rust installation
-  #       uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Rust installation
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
-  #     - name: Install dependencies
-  #       run: |
-  #         yarn install --immutable
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
 
-  #     - run: make test-stateless
+      - run: make test-stateless

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -16,56 +16,44 @@ permissions: read-all
 #  https://github.com/actions-rust-lang/setup-rust-toolchain
 
 jobs:
-  # pre-commit-lint-security:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Print toolchain versions
-  #       run: |
-  #         node -v
-  #         python3 -V
-  #         pip3 -V
-  #         make --version
-
-  #     # TODO see whether we can leverage https://github.com/pre-commit/action
-  #     - name: Install system-wide tools dependencies
-  #       run: |
-  #         pip3 install pre-commit detect-secrets black ggshield
-
-  #     - name: Checkout code
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-
-  #     - name: TruffleHog OSS
-  #       uses: trufflesecurity/trufflehog@v3.34.0
-  #       with:
-  #         path: ./
-  #         base: ${{ github.event.repository.default_branch }}
-  #         head: HEAD
-  #         extra_args: --debug --only-verified
-
-  #     - name: Install dependencies
-  #       run: |
-  #         make install
-
-  #     - name: Lint and code formatting
-  #       run: |
-  #         make check
-
-  test-stateful-stack:
-    runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
+  pre-commit-lint-security:
+    runs-on: ubuntu-latest
     steps:
+      - name: Print toolchain versions
+        run: |
+          node -v
+          python3 -V
+          pip3 -V
+          make --version
+
+      # TODO see whether we can leverage https://github.com/pre-commit/action
+      - name: Install system-wide tools dependencies
+        run: |
+          pip3 install pre-commit detect-secrets black ggshield
+
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@v3.34.0
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified
 
       - name: Install dependencies
         run: |
-          yarn install --immutable
+          make install
 
-      - run: make test-stateful
+      - name: Lint and code formatting
+        run: |
+          make check
 
-  test-stateless-stack:
-    runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
+  test-stateless-suite:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -77,10 +65,24 @@ jobs:
         run: |
           yarn install --immutable
 
-      - run: make test-stateless
+      - run: make test-suite
 
-  # test-stateless-suite:
-  #   runs-on: ubuntu-latest
+  # This require a self hosted runner where the compute is in ARM architecture
+  #
+  # test-stateful-stack:
+  #   runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+
+  #     - name: Install dependencies
+  #       run: |
+  #         yarn install --immutable
+
+  #     - run: make test-stateful
+
+  # test-stateless-stack:
+  #   runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
   #   steps:
   #     - name: Checkout code
   #       uses: actions/checkout@v4
@@ -92,4 +94,4 @@ jobs:
   #       run: |
   #         yarn install --immutable
 
-  #     - run: make test-suite
+  #     - run: make test-stateless

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -52,25 +52,23 @@ jobs:
         run: |
           make check
 
-  test-stateless-suite:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # test-stateless-suite:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Rust installation
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+  #     - name: Rust installation
+  #       uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Install dependencies
-        run: |
-          yarn install --immutable
+  #     - name: Install dependencies
+  #       run: |
+  #         yarn install --immutable
 
-      - run: make test-suite
-
-  # This require a self hosted runner where the compute is in ARM architecture
+  #     - run: make test-suite
 
   test-stateful-stack:
-    runs-on: codebuild-wil-test-cb-orcabus-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-orcabus-codebuild-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -82,7 +80,7 @@ jobs:
       - run: make test-stateful
 
   test-stateless-stack:
-    runs-on: codebuild-wil-test-cb-orcabus-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on: codebuild-orcabus-codebuild-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -16,44 +16,44 @@ permissions: read-all
 #  https://github.com/actions-rust-lang/setup-rust-toolchain
 
 jobs:
-  pre-commit-lint-security:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Print toolchain versions
-        run: |
-          node -v
-          python3 -V
-          pip3 -V
-          make --version
+  # pre-commit-lint-security:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Print toolchain versions
+  #       run: |
+  #         node -v
+  #         python3 -V
+  #         pip3 -V
+  #         make --version
 
-      # TODO see whether we can leverage https://github.com/pre-commit/action
-      - name: Install system-wide tools dependencies
-        run: |
-          pip3 install pre-commit detect-secrets black ggshield
+  #     # TODO see whether we can leverage https://github.com/pre-commit/action
+  #     - name: Install system-wide tools dependencies
+  #       run: |
+  #         pip3 install pre-commit detect-secrets black ggshield
 
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: TruffleHog OSS
-        uses: trufflesecurity/trufflehog@v3.34.0
-        with:
-          path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-          extra_args: --debug --only-verified
+  #     - name: TruffleHog OSS
+  #       uses: trufflesecurity/trufflehog@v3.34.0
+  #       with:
+  #         path: ./
+  #         base: ${{ github.event.repository.default_branch }}
+  #         head: HEAD
+  #         extra_args: --debug --only-verified
 
-      - name: Install dependencies
-        run: |
-          make install
+  #     - name: Install dependencies
+  #       run: |
+  #         make install
 
-      - name: Lint and code formatting
-        run: |
-          make check
+  #     - name: Lint and code formatting
+  #       run: |
+  #         make check
 
   test-stateful-stack:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
       - run: make test-stateful
 
   test-stateless-stack:
-    runs-on: ubuntu-latest
+    runs-on: codebuild-orcabus-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -79,17 +79,17 @@ jobs:
 
       - run: make test-stateless
 
-  test-stateless-suite:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+  # test-stateless-suite:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v4
 
-      - name: Rust installation
-        uses: actions-rust-lang/setup-rust-toolchain@v1
+  #     - name: Rust installation
+  #       uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Install dependencies
-        run: |
-          yarn install --immutable
+  #     - name: Install dependencies
+  #       run: |
+  #         yarn install --immutable
 
-      - run: make test-suite
+  #     - run: make test-suite

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -54,6 +54,8 @@ jobs:
 
   test-stateless-suite:
     # codebuild project name is initiated at ./lib/bin/statelessPipelineStack (PR-290)
+    # The format: `runs-on: codebuild-<project-name>-${{ github.run_id }}-${{ github.run_attempt }}`
+    # https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html
     runs-on: codebuild-orcabus-codebuild-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
@@ -70,6 +72,8 @@ jobs:
 
   test-stateful-stack:
     # codebuild project name is initiated at ./lib/bin/statelessPipelineStack (PR-290)
+    # The format: `runs-on: codebuild-<project-name>-${{ github.run_id }}-${{ github.run_attempt }}`
+    # https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html
     runs-on: codebuild-orcabus-codebuild-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
@@ -83,6 +87,8 @@ jobs:
 
   test-stateless-stack:
     # codebuild project name is initiated at ./lib/bin/statelessPipelineStack (PR-290)
+    # The format: `runs-on: codebuild-<project-name>-${{ github.run_id }}-${{ github.run_attempt }}`
+    # https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html
     runs-on: codebuild-orcabus-codebuild-gh-runner-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code

--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -5,21 +5,19 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 # Actions Used (please keep this documented here as added)
 #  https://github.com/marketplace/actions/checkout
 #  https://github.com/marketplace/actions/setup-python
 #  https://github.com/marketplace/actions/trufflehog-oss
 #  https://github.com/marketplace/actions/checkout
 #  https://github.com/marketplace/actions/cache
+#  https://github.com/actions-rust-lang/setup-rust-toolchain
 
 jobs:
-  build:
-    # Default access (restricted) - https://docs.github.com/en/actions/security-guides/automatic-token-authentication
-    permissions:
-      contents: read
-
+  pre-commit-lint-security:
     runs-on: ubuntu-latest
-
     steps:
       - name: Print toolchain versions
         run: |
@@ -34,7 +32,7 @@ jobs:
           pip3 install pre-commit detect-secrets black ggshield
 
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -53,3 +51,51 @@ jobs:
       - name: Lint and code formatting
         run: |
           make check
+
+  test-stateful-stack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
+
+      - run: make test-stateful
+
+  test-stateless-stack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Rust installation
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
+
+      - run: make test-stateless
+
+  test-stateless-suite:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Rust installation
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
+
+      - run: make test-suite

--- a/README.md
+++ b/README.md
@@ -185,7 +185,18 @@ pre-commit run --all-files
 
 ### GitHub Action
 
-We have GitHub Action workflow to reinforce Lint, Code Formatting and Pre-commit Hook check as [Pull Request Build](.github/workflows/prbuild.yml) pipeline before main CI/CD automation run at CodePipeline. This is to protect any accidental secrets leak and/or pre-flight check for CI/CD automation. 
+#### Lint-Formatting-Security
+
+We have GitHub Action workflow to reinforce Lint, Code Formatting and Pre-commit Hook check as [Pull Request
+Build](.github/workflows/prbuild.yml) pipeline before the main CI/CD automation run at CodePipeline. This is to protect any
+accidental secrets leak and/or pre-flight check for CI/CD automation.
+
+#### Testing
+
+We have enabled application unit tests and stack security compliance in our GitHub Actions workflow using
+AWS CodeBuild as the runner. This provides developers with faster feedback before merging changes into the main branch.
+The deployment pipeline will run all tests again before deployment. If you believe your commit doesn't
+require GitHub Actions testing, you can include the `[skip ci]` in your commit message to skip this step.
 
 ### IDE
 

--- a/lib/pipeline/statelessPipelineStack.ts
+++ b/lib/pipeline/statelessPipelineStack.ts
@@ -37,7 +37,7 @@ export class StatelessPipelineStack extends cdk.Stack {
       },
       environment: {
         type: 'ARM_CONTAINER',
-        computeType: 'BUILD_GENERAL1_SMALL',
+        computeType: 'BUILD_GENERAL1_LARGE',
         image: 'aws/codebuild/amazonlinux2-aarch64-standard:3.0',
         privilegedMode: true,
       },

--- a/lib/pipeline/statelessPipelineStack.ts
+++ b/lib/pipeline/statelessPipelineStack.ts
@@ -28,7 +28,7 @@ export class StatelessPipelineStack extends cdk.Stack {
     });
     new codebuild.CfnProject(this, 'GHRunnerCodeBuildProject', {
       // the name here act as a unique id for GH action to know which CodeBuild to use
-      // So if you change this, you need to update the GH action yaml file (.github/workflows/prbuild.yml)
+      // So if you change this, you need to update the GH action .yml file (.github/workflows/prbuild.yml)
       name: 'orcabus-codebuild-gh-runner',
       description: 'GitHub Action Runner in CodeBuild for `orcabus` repository',
       serviceRole: ghRunnerRole.roleArn,

--- a/lib/pipeline/statelessPipelineStack.ts
+++ b/lib/pipeline/statelessPipelineStack.ts
@@ -20,6 +20,41 @@ export class StatelessPipelineStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: cdk.StackProps) {
     super(scope, id, props);
 
+    // Define CodeBuild project for GH action runner to use
+    // the GH repo defined below already configured to allow CB webhook
+    // This is actually not part of the pipeline, so I guess we could move this someday.
+    const ghRunnerRole = new iam.Role(this, 'GHRunnerRole', {
+      assumedBy: new iam.ServicePrincipal('codebuild.amazonaws.com'),
+    });
+    new codebuild.CfnProject(this, 'GHRunnerCodeBuildProject', {
+      // the name here act as a unique id for GH action to know which CodeBuild to use
+      // So if you change this, you need to update the GH action yaml file (.github/workflows/prbuild.yml)
+      name: 'orcabus-codebuild-gh-runner',
+      description: 'GitHub Action Runner in CodeBuild for `orcabus` repository',
+      serviceRole: ghRunnerRole.roleArn,
+      artifacts: {
+        type: 'NO_ARTIFACTS',
+      },
+      environment: {
+        type: 'ARM_CONTAINER',
+        computeType: 'BUILD_GENERAL1_SMALL',
+        image: 'aws/codebuild/amazonlinux2-aarch64-standard:3.0',
+        privilegedMode: true,
+      },
+      source: {
+        type: 'GITHUB',
+        gitCloneDepth: 1,
+        location: 'https://github.com/umccr/orcabus.git',
+        reportBuildStatus: false,
+      },
+      logsConfig: { cloudWatchLogs: { status: 'DISABLED' } },
+      triggers: {
+        webhook: true,
+        buildType: 'BUILD',
+        filterGroups: [[{ type: 'EVENT', pattern: 'WORKFLOW_JOB_QUEUED' }]],
+      },
+    });
+
     // A connection where the pipeline get its source code
     const codeStarArn = ssm.StringParameter.valueForStringParameter(this, 'codestar_github_arn');
     const sourceFile = pipelines.CodePipelineSource.connection('umccr/orcabus', 'main', {

--- a/test/stateless/pipeline.test.ts
+++ b/test/stateless/pipeline.test.ts
@@ -37,6 +37,13 @@ describe('cdk-nag-stateless-pipeline', () => {
     { id: 'AwsSolutions-CB3', reason: 'Allow CDK Pipeline' },
   ]);
 
+  NagSuppressions.addResourceSuppressionsByPath(stack, `/TestStack/GHRunnerCodeBuildProject`, [
+    {
+      id: 'AwsSolutions-CB4',
+      reason: 'This codebuild does not use artifacts, so S3 KMS key is irrelevant.',
+    },
+  ]);
+
   test('cdk-nag AwsSolutions Pack errors', () => {
     const errors = Annotations.fromStack(stack)
       .findError('*', Match.stringLikeRegexp('AwsSolutions-.*'))


### PR DESCRIPTION
Put back GH Action which runs on AWS CodeBuild as GH Runners except for lint and Security check. All application test runs at different CodeBuild runner to cut on time.