### PR TITLE
Fixed WorkflowRunStateChange schema required field

### DIFF
--- a/docs/event-schemas/wfm/WorkflowRunStateChange.json
+++ b/docs/event-schemas/wfm/WorkflowRunStateChange.json
@@ -56,8 +56,7 @@
           "status",
           "workflowType",
           "workflowVersion",
-          "payload",
-          "serviceVersion"
+          "payload"
         ],
         "properties": {
           "portalRunId": {


### PR DESCRIPTION
* The `serviceVersion` field get refactored into Payload version
  Hence, it is obsolete property. It was oversight to remove it
  from previous PR #272.

Related #257
