### PR TITLE
Fix ica event translator build issue

### DIFF
--- a/config/stacks/icav2EventTranslator.ts
+++ b/config/stacks/icav2EventTranslator.ts
@@ -18,6 +18,6 @@ export const getIcav2EventTranslatorStackProps = (): Icav2EventTranslatorStackPr
     eventBusName,
     icav2EventTranslatorDynamodbTableName: dynamodbTableName,
     vpcProps: vpcProps,
-    lambdaSecurityGroupName: 'IcaEventTranslatorLambdaSecurityGroup',
+    lambdaSecurityGroupName: 'OrcaBusIcaEventTranslatorSecurityGroup',
   };
 };

--- a/lib/workload/stateless/stacks/icav2-event-translator/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/icav2-event-translator/deploy/stack.ts
@@ -34,12 +34,12 @@ export class Icav2EventTranslatorStack extends Stack {
       'Icav2EventTranslatorDynamoDBTable',
       props.icav2EventTranslatorDynamodbTableName
     );
-    this.lambdaSG = SecurityGroup.fromLookupByName(
-      this,
-      'LambdaSecurityGroup',
-      props.lambdaSecurityGroupName,
-      this.vpc
-    );
+    this.lambdaSG = new SecurityGroup(this, 'IcaEventTranslatorLambdaSG', {
+      vpc: this.vpc,
+      securityGroupName: props.lambdaSecurityGroupName,
+      allowAllOutbound: true,
+      description: 'Security group that allows teh Ica Event Translator function to egress out.',
+    });
 
     this.createICAv2EventTranslator(props);
   }


### PR DESCRIPTION
fix this [build](https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/OrcaBusStatelessPipeline-Pipeline9850B417-195F6QW8HU9NP/view?region=ap-southeast-2) issue:

1. add namespace in the ica event translator lambdaSecurityGroupName
2. create a new SG group with the lambdaSecurityGroupName

PS: Build Error come from `No security groups found matching`.