### PR TITLE
Update libumccr version to 0.4.0rc3

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/deps/requirements.txt
+++ b/lib/workload/stateless/stacks/workflow-manager/deps/requirements.txt
@@ -11,7 +11,7 @@ djangorestframework-camel-case==1.4.2
 psycopg[binary]==3.1.18
 Werkzeug==3.0.3
 # libica==2.2.1
-libumccr==0.4.0rc1
+libumccr==0.4.0rc3
 cachetools==5.3.3
 serverless-wsgi==3.0.3
 # six and regex required by automatically generated EventBridge code binding


### PR DESCRIPTION
Fixes to large lambda layer by removing unnecessary transient libs from libumccr.