### PR TITLE
Fix workflow manager issues when handling WRSC events

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/workflow-manager/deploy/stack.ts
@@ -159,7 +159,7 @@ export class WorkflowManagerStack extends Stack {
 
     eventRule.addTarget(new aws_events_targets.LambdaFunction(procFn));
     eventRule.addEventPattern({
-      source: ["{ 'anything-but': 'orcabus.workflowmanager' }"],
+      source: ['{ "anything-but": "orcabus.workflowmanager" }'],
       detailType: ['WorkflowRunStateChange'],
     });
   }

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/models/workflow_run.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/models/workflow_run.py
@@ -46,7 +46,7 @@ class WorkflowRun(OrcaBusBaseModel):
             "id": self.id,
             "portal_run_id": self.portal_run_id,
             "status": self.status,
-            "timestamp": self.timestamp,
+            "timestamp": str(self.timestamp),
             "execution_id": self.execution_id,
             "workflow_run_name": self.workflow_run_name,
             "comment": self.comment,

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/lambdas/handle_service_wrsc_event.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/lambdas/handle_service_wrsc_event.py
@@ -12,7 +12,7 @@ from workflow_manager_proc.services import get_workflow_run, create_workflow_run
 def handler(event, context):
     """event will be a <any service>.WorkflowRunStateChange event"""
     print(f"Processing {event}, {context}")
-    
+
     input_event: srv.AWSEvent = srv.Marshaller.unmarshall(event, srv.AWSEvent)
     input_wrsc: srv.WorkflowRunStateChange = input_event.detail
 
@@ -21,25 +21,39 @@ def handler(event, context):
         "status": input_wrsc.status,
         "timestamp": input_wrsc.timestamp
 	}
+    print(f"Finding WorkflowRun records for query:{query}")
     wrsc_matches = get_workflow_run.handler(query, None)  # FIXME: may only need to be a "exist" query
-    
+
     # check workflow run list
     if len(wrsc_matches) == 0:
+        print(f"No matching WorkflowRun found. Creating...")
         # create new entry
         db_wfr: WorkflowRun = create_workflow_run.handler(srv.Marshaller.marshall(input_wrsc), None)
         
 		# create outgoing event
-        out_event = wfm.WorkflowRunStateChange(
-            portalRunId = db_wfr.portal_run_id,
-            timestamp = db_wfr.timestamp,
-            status = db_wfr.status,
-            workflowName = db_wfr.workflow.workflow_name,
-            workflowVersion = db_wfr.workflow.workflow_version,
-            payload = db_wfr.payload  # the DB payload (as opposed to the input payload) will have a reference ID
-		)
+        out_event = map_db_record_to_wrsc(db_wfr)
 
         # emit state change
+        print("Emitting WRSC.")
         emit_workflow_run_state_change.handler(wfm.Marshaller.marshall(out_event), None)
     else:
         # ignore - status already exists
-        print(f"WorkflowRun already exists for query:{query}")
+        print(f"WorkflowRun already exists. Nothing to do.")
+
+    print(f"{__name__} done.")
+
+
+def map_db_record_to_wrsc(db_record: WorkflowRun) -> wfm.WorkflowRunStateChange:
+    wrsc = wfm.WorkflowRunStateChange(
+        portalRunId = db_record.portal_run_id,
+        timestamp = db_record.timestamp,
+        status = db_record.status,
+        workflowName = db_record.workflow.workflow_name,
+        workflowVersion = db_record.workflow.workflow_version,
+        payload = wfm.Payload(
+            refId = db_record.payload.payload_ref_id,
+            version = db_record.payload.version,
+            data = db_record.payload.data
+        )
+    )
+    return wrsc

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/lambdas/transition_bcm_fastq_copy.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/lambdas/transition_bcm_fastq_copy.py
@@ -13,7 +13,7 @@ def handler(event, context):
     """event will be a workflowmanager.WorkflowRunStateChange event"""
     print(f"Processing {event}, {context}")
     
-    input_event: wfm.AWSEvent = wfm.Marshaller.unmarshall(event)
+    input_event: wfm.AWSEvent = wfm.Marshaller.unmarshall(event, wfm.AWSEvent)
     input_wrsc: wfm.WorkflowRunStateChange = input_event.detail
     
     ## Trigger signal is the announcement from the workflowmanager that the bclconvert workflow run has succeeded

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/create_workflow_run.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/create_workflow_run.py
@@ -4,28 +4,30 @@
 
 # # --- keep ^^^ at top of the module
 import uuid
-from django.utils.timezone import make_aware
-from datetime import datetime
+from django.db import transaction
 from workflow_manager_proc.domain.executionservice.workflowrunstatechange import WorkflowRunStateChange, Marshaller
 from workflow_manager.models.workflow_run import WorkflowRun, Workflow, Payload
 
 
+@transaction.atomic
 def handler(event, context):
     """
     event will be JSON conform to executionservice.WorkflowRunStateChange
     """
     print(f"Processing {event}, {context}")
-    
+
     wrsc: WorkflowRunStateChange = Marshaller.unmarshall(event, WorkflowRunStateChange)
 
 	# We expect: a corresponding Workflow has to exist for each workflow run
-    # FIXME: remove the try/except once workflows are pre-registered. Or allow creation?
+    # TODO: decide whether we allow dynamic workflow creation or expect them to exist and fail if not
     try:
+        print(f"Looking for workflow ({wrsc.workflowName}:{wrsc.workflowVersion}).")
         workflow: Workflow = Workflow.objects.get(
             workflow_name = wrsc.workflowName,
             workflow_version = wrsc.workflowVersion
         )
     except Exception:
+        print("No workflow found! Creating new entry.")
         workflow = Workflow(
             workflow_name = wrsc.workflowName,
             workflow_version = wrsc.workflowVersion,
@@ -33,15 +35,17 @@ def handler(event, context):
             execution_engine_pipeline_id = "Unknown",
             approval_state = "RESEARCH"
         )
+        print("Persisting Workflow record.")
         workflow.save()
 
     # first create a new payload entry and assign a unique reference ID for it
-    input_payload: Payload = wrsc.payload    
+    input_payload: Payload = wrsc.payload
     pld = Payload(
         payload_ref_id = str(uuid.uuid4()),
         version = input_payload.version,
         data = input_payload.data
     )
+    print("Persisting Payload record.")
     pld.save()
 
     # then create the actual workflow run state change entry
@@ -55,6 +59,8 @@ def handler(event, context):
         comment = None,
         timestamp = wrsc.timestamp
 	)
+    print("Persisting WorkflowRun record.")
     wfr.save()
 
+    print(f"{__name__} done.")
     return wfr  # FIXME: serialise in future (json.dumps)

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/emit_workflow_run_state_change.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/emit_workflow_run_state_change.py
@@ -1,5 +1,7 @@
 import os
 import boto3
+import json
+import workflow_manager_proc.domain.workflowmanager.workflowrunstatechange as wfm
 from workflow_manager_proc.domain.workflowmanager.workflowrunstatechange import WorkflowRunStateChange
 
 client = boto3.client('events')
@@ -11,16 +13,19 @@ def handler(event, context):
     event has to be JSON conform to workflowmanager.WorkflowRunStateChange
     """
     print(f"Processing {event}, {context}")
-    
+
     response = client.put_events(
 		Entries=[
 			{
 				'Source': source,
 				'DetailType': WorkflowRunStateChange.__name__,
-				'Detail': event,
+				'Detail': json.dumps(wfm.Marshaller.marshall(event)),
 				'EventBusName': event_bus_name,
 			},
 		],
 	)
 
+    print(f"Sent a WRSC event to event bus {event_bus_name}:")
+    print(event)
+    print(f"{__name__} done.")
     return response

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/get_workflow_run.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/get_workflow_run.py
@@ -31,7 +31,7 @@ def handler(event, context):
             status = status
         )
     if timestamp:
-        dt = datetime.datetime.fromisoformat(timestamp)
+        dt = datetime.datetime.fromisoformat(str(timestamp))
         start_t = dt - default_time_window
         end_t = dt + default_time_window
         qs.filter(

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/get_workflow_run.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/get_workflow_run.py
@@ -17,7 +17,7 @@ def handler(event, context):
         time_window: "" # currenty not used, defaults 1h
     }
     """
-    print(f"Processing {event}, {context}")
+    print(f"Processing get_workflow_run with: {event}, {context}")
     portal_run_id = event['portal_run_id']
     status = event.get('status', None)
     timestamp = event.get('timestamp', None)
@@ -27,19 +27,23 @@ def handler(event, context):
         portal_run_id = portal_run_id
     )
     if status:
-        qs.filter(
+        qs = qs.filter(
             status = status
         )
     if timestamp:
         dt = datetime.datetime.fromisoformat(str(timestamp))
+        print(f"Filter for time window around: {str(timestamp)}")
         start_t = dt - default_time_window
         end_t = dt + default_time_window
-        qs.filter(
-            timestamp__range=[start_t, end_t]
+        print(f"Time window from {start_t} to {end_t}.")
+        qs = qs.filter(
+            timestamp__range=(start_t, end_t)
         )
 
     workflow_runs = []
     for w in qs.all():
         workflow_runs.append(w)
+        print(w.to_dict())
+    print(f"Found {len(workflow_runs)} WorkflowRun records.")
 
     return workflow_runs  # FIXME: need to deserialise in future


### PR DESCRIPTION
Fix the following:
- correct call to handler methods
- unmarshaller usage.
- workflow type/name legacy code
- datetime handling
- handle non-existing `Workflow` record when persisting `WorkflowRun` record