### PR TITLE
Convert api-url to api-domain

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -102,7 +102,7 @@ Resources required for BaseSpace TES stack
  */
 
 export const basespaceAccessTokenSecretName = '/manual/BaseSpaceAccessTokenSecret'; // pragma: allowlist secret
-export const ssCheckApiUrlSsmParameterName = '/sscheck/lambda-api-domain';
+export const ssCheckApiDomainSsmParameterName = '/sscheck/lambda-api-domain';
 
 /*
 ICAv2 Resources - required by various stacks

--- a/config/stacks/bsRunsUploadManager.ts
+++ b/config/stacks/bsRunsUploadManager.ts
@@ -5,7 +5,7 @@ import {
   basespaceAccessTokenSecretName,
   eventBusName,
   gdsBsRunsUploadLogPath,
-  ssCheckApiUrlSsmParameterName,
+  ssCheckApiDomainSsmParameterName,
 } from '../constants';
 import { BsRunsUploadManagerConfig } from '../../lib/workload/stateless/stacks/bs-runs-upload-manager/deploy/stack';
 
@@ -14,7 +14,7 @@ export const getBsRunsUploadManagerStackProps = (stage: AppStage): BsRunsUploadM
     icaTokenSecretId: icaAccessTokenSecretName,
     portalTokenSecretId: jwtSecretName,
     basespaceTokenSecretId: basespaceAccessTokenSecretName,
-    ssCheckApiUrlSsmParameterName: ssCheckApiUrlSsmParameterName,
+    ssCheckApiDomainSsmParameterName: ssCheckApiDomainSsmParameterName,
     eventbusName: eventBusName,
     gdsSystemFilesPath: gdsBsRunsUploadLogPath[stage],
   };

--- a/lib/workload/stateless/stacks/bs-runs-upload-manager/deploy/constructs/bs-runs-upload-manager/index.ts
+++ b/lib/workload/stateless/stacks/bs-runs-upload-manager/deploy/constructs/bs-runs-upload-manager/index.ts
@@ -18,7 +18,7 @@ interface BsRunsUploadManagerConstructProps {
   icaTokenSecretObj: secretsManager.ISecret;
   portalTokenSecretObj: secretsManager.ISecret;
   basespaceSecretObj: secretsManager.ISecret;
-  ssCheckApiUrlSsmParameterObj: ssm.IStringParameter;
+  ssCheckApiDomainSsmParameterObj: ssm.IStringParameter;
   eventBusObj: events.IEventBus;
   /* Lambda layer paths */
   uploadV2SamplesheetToGdsBsshLambdaPath: string; // __dirname + '/../../../lambdas/upload_v2_samplesheet_to_gds_bssh'
@@ -51,7 +51,7 @@ export class BsRunsUploadManagerConstruct extends Construct {
         environment: {
           ICA_BASE_URL: 'https://aps2.platform.illumina.com',
           ICA_ACCESS_TOKEN_SECRET_ID: props.icaTokenSecretObj.secretName,
-          SS_CHECK_API_URL_PARAMETER_NAME: props.ssCheckApiUrlSsmParameterObj.parameterName,
+          SS_CHECK_API_DOMAIN_PARAMETER_NAME: props.ssCheckApiDomainSsmParameterObj.parameterName,
           PORTAL_TOKEN_SECRET_ID: props.portalTokenSecretObj.secretName,
         },
       }
@@ -92,7 +92,7 @@ export class BsRunsUploadManagerConstruct extends Construct {
     props.portalTokenSecretObj.grantRead(<IRole>upload_v2_samplesheet_to_gds_bssh_lambda.role);
 
     // Give the lambda permission to read the ssm parameter value of the data portal api url
-    props.ssCheckApiUrlSsmParameterObj.grantRead(
+    props.ssCheckApiDomainSsmParameterObj.grantRead(
       <IRole>upload_v2_samplesheet_to_gds_bssh_lambda.role
     );
 

--- a/lib/workload/stateless/stacks/bs-runs-upload-manager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/bs-runs-upload-manager/deploy/stack.ts
@@ -12,7 +12,7 @@ export interface BsRunsUploadManagerConfig {
   icaTokenSecretId: string; // IcaSecretsPortal
   portalTokenSecretId: string; // orcabus/token-service-jwt
   basespaceTokenSecretId: string; // /manual/BaseSpaceAccessTokenSecret
-  ssCheckApiUrlSsmParameterName: string; // /sscheck/lambda-api-domain
+  ssCheckApiDomainSsmParameterName: string; // /sscheck/lambda-api-domain
   gdsSystemFilesPath: string; // gds://development/primary_data/temp/bs_runs_upload_tes/
   eventbusName: string; // /umccr/orcabus/stateful/eventbridge
 }
@@ -50,8 +50,8 @@ export class BsRunsUploadManagerStack extends cdk.Stack {
 
     const ss_check_api_ssm_parameter_obj = ssm.StringParameter.fromStringParameterName(
       this,
-      'SsCheckApiUrlSsmParameter',
-      props.ssCheckApiUrlSsmParameterName
+      'SsCheckApiDomainSsmParameter',
+      props.ssCheckApiDomainSsmParameterName
     );
 
     const event_bus_obj = events.EventBus.fromEventBusName(this, 'event_bus', props.eventbusName);
@@ -62,7 +62,7 @@ export class BsRunsUploadManagerStack extends cdk.Stack {
       icaTokenSecretObj: ica_access_token_secret_obj,
       portalTokenSecretObj: portal_secret_obj,
       basespaceSecretObj: basespace_secret_obj,
-      ssCheckApiUrlSsmParameterObj: ss_check_api_ssm_parameter_obj,
+      ssCheckApiDomainSsmParameterObj: ss_check_api_ssm_parameter_obj,
       eventBusObj: event_bus_obj,
       /* Lambda paths */
       uploadV2SamplesheetToGdsBsshLambdaPath: path.join(

--- a/lib/workload/stateless/stacks/bs-runs-upload-manager/lambdas/upload_v2_samplesheet_to_gds_bssh/handler.py
+++ b/lib/workload/stateless/stacks/bs-runs-upload-manager/lambdas/upload_v2_samplesheet_to_gds_bssh/handler.py
@@ -16,7 +16,7 @@ With the following environment variables
 ICA_BASE_URL
 ICA_ACCESS_TOKEN_SECRET_ID
 PORTAL_TOKEN_SECRET_ID
-SS_CHECK_API_URL_PARAMETER_NAME
+SS_CHECK_API_DOMAIN_PARAMETER_NAME
 
 And performs the following operations:
 

--- a/lib/workload/stateless/stacks/bs-runs-upload-manager/layers/src/bs_runs_upload_manager_tools/utils/portal_helpers.py
+++ b/lib/workload/stateless/stacks/bs-runs-upload-manager/layers/src/bs_runs_upload_manager_tools/utils/portal_helpers.py
@@ -20,7 +20,7 @@ def set_portal_token():
 
 
 def set_api_url():
-    os.environ["SS_CHECK_API_URL"] = get_api_url_from_ssm_parameter()
+    os.environ["SS_CHECK_API_DOMAIN"] = get_api_url_from_ssm_parameter()
 
 
 def get_portal_token_from_aws_secrets_manager():
@@ -34,7 +34,7 @@ def get_portal_token_from_aws_secrets_manager():
 
 
 def get_api_url_from_ssm_parameter():
-    ssm_parameter_name = os.environ.get("SS_CHECK_API_URL_PARAMETER_NAME", None)
+    ssm_parameter_name = os.environ.get("SS_CHECK_API_DOMAIN_PARAMETER_NAME", None)
 
     if ssm_parameter_name is None:
         logger.error("API_URL_PARAMETER_NAME env var is not set")

--- a/lib/workload/stateless/stacks/bs-runs-upload-manager/layers/src/bs_runs_upload_manager_tools/utils/samplesheet_helpers.py
+++ b/lib/workload/stateless/stacks/bs-runs-upload-manager/layers/src/bs_runs_upload_manager_tools/utils/samplesheet_helpers.py
@@ -5,6 +5,8 @@ Generate samplesheet
 """
 from pathlib import Path
 import os
+from urllib.parse import urlunparse
+
 import requests
 from tempfile import NamedTemporaryFile
 import json
@@ -26,7 +28,7 @@ def generate_v2_samplesheet(v1_samplesheet_file: Path) -> Path:
     }
 
     response = requests.post(
-        url=os.getenv("SS_CHECK_API_URL", None),
+        url=urlunparse(["https", os.getenv("SS_CHECK_API_DOMAIN", None), "", None, None, None]),
         headers=headers,
         files=files
     )


### PR DESCRIPTION
Resolves error where requests expects env var to be url instead of a domain