### PR TITLE
User reference will always start with 'umccr__automated__workflowName`

### DIFF
--- a/lib/workload/components/dynamodb-icav2-handle-event-change-sfn/index.ts
+++ b/lib/workload/components/dynamodb-icav2-handle-event-change-sfn/index.ts
@@ -97,6 +97,13 @@ export class Icav2AnalysisEventHandlerConstruct extends Construct {
           'ica-event': {
             // ICA_EXEC_028 is an analysis state change in ICAv2
             eventCode: ['ICA_EXEC_028'],
+            payload: {
+              userReference: [
+                {
+                  prefix: `umccr__automated__${props.workflowName}`,
+                },
+              ],
+            },
           },
         },
       },


### PR DESCRIPTION
We cannot rely on the pipeline ID (since a user might want a different pipeline id to be run), 
We cannot rely on the pipeline Code (since ctDNA Pipeline codes are inconsistent between versions)

Instead the workflow run name (or userRefence) generated will always be `umccr_automated__${workflow_name}`.

Resolves #344 

Can confirm this works by using an eventSandbox

![image](https://github.com/umccr/orcabus/assets/8197659/98384513-cbc8-4803-b3fa-96fd353c7ba9)

