### PR TITLE
fix(filemanager): make `HeadObject` optional

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -161,6 +161,8 @@ export const bclconvertInteropQcIcav2EventSource = 'orcabus.bclconvertinteropqc'
 export const bclconvertInteropQcIcav2EventDetailType = 'WorkflowRunStateChange';
 export const bclconvertInteropQcStateMachinePrefix = 'bclconvertInteropQcSfn';
 
+export const fileManagerIngestRoleName = 'orcabus-file-manager-ingest-role';
+
 /*
 Resources used by the bclConvert InteropQc Pipeline
 */

--- a/config/stacks/fileManager.ts
+++ b/config/stacks/fileManager.ts
@@ -10,6 +10,7 @@ import {
   cognitoStatusPageAppClientIdParameterName,
   cognitoUserPoolIdParameterName,
   oncoanalyserBucket,
+  icav2PipelineCacheBucket,
 } from '../constants';
 
 export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => {
@@ -24,6 +25,6 @@ export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => 
     cognitoStatusPageAppClientIdParameterName: cognitoStatusPageAppClientIdParameterName,
     cognitoUserPoolIdParameterName: cognitoUserPoolIdParameterName,
     inventorySourceBuckets: ['filemanager-inventory-test'],
-    eventSourceBuckets: [oncoanalyserBucket[stage]],
+    eventSourceBuckets: [oncoanalyserBucket[stage], icav2PipelineCacheBucket[stage]],
   };
 };

--- a/config/stacks/fileManager.ts
+++ b/config/stacks/fileManager.ts
@@ -11,6 +11,7 @@ import {
   cognitoUserPoolIdParameterName,
   oncoanalyserBucket,
   icav2PipelineCacheBucket,
+  fileManagerIngestRoleName,
 } from '../constants';
 
 export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => {
@@ -26,5 +27,6 @@ export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => 
     cognitoUserPoolIdParameterName: cognitoUserPoolIdParameterName,
     inventorySourceBuckets: ['filemanager-inventory-test'],
     eventSourceBuckets: [oncoanalyserBucket[stage], icav2PipelineCacheBucket[stage]],
+    fileManagerIngestRoleName: fileManagerIngestRoleName,
   };
 };

--- a/lib/workload/components/named-lambda-role/index.ts
+++ b/lib/workload/components/named-lambda-role/index.ts
@@ -1,0 +1,29 @@
+import { Construct } from 'constructs';
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+
+/**
+ * Props for the named lambda role construct.
+ */
+export type NamedLambdaRoleProps = {
+  /**
+   * The name of the role, automatically generated if not specified.
+   */
+  name?: string;
+  /**
+   * Description for the role.
+   */
+  description?: string;
+};
+
+/**
+ * A construct which represents a named role that a Lambda function can assume.
+ */
+export class NamedLambdaRole extends Role {
+  constructor(scope: Construct, id: string, props?: NamedLambdaRoleProps) {
+    super(scope, id, {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      description: props?.description ?? 'Lambda execution role',
+      roleName: props?.name,
+    });
+  }
+}

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
@@ -1,7 +1,6 @@
 import { Construct } from 'constructs';
 import { IQueue } from 'aws-cdk-lib/aws-sqs';
 import * as fn from './function';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { DatabaseProps } from './function';
 
@@ -18,7 +17,7 @@ export type EventSourceProps = {
    * 's3:List*' and 's3:Get*'.
    */
   readonly buckets: string[];
-}
+};
 
 /**
  * Props for the ingest function.

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/inventory.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/inventory.ts
@@ -14,19 +14,25 @@ export type InventoryFunctionConfig = {
    * 's3:List*' and 's3:Get*'.
    */
   readonly buckets: string[];
-}
+};
 
 /**
  * Props for the inventory function.
  */
-export type InventoryFunctionProps = fn.FunctionPropsNoPackage & DatabaseProps & InventoryFunctionConfig;
+export type InventoryFunctionProps = fn.FunctionPropsNoPackage &
+  DatabaseProps &
+  InventoryFunctionConfig;
 
 /**
  * A construct for the Lambda inventory function.
  */
 export class InventoryFunction extends fn.Function {
   constructor(scope: Construct, id: string, props: InventoryFunctionProps) {
-    super(scope, id, { package: 'filemanager-inventory-lambda', ...props, functionName: INVENTORY_FUNCTION_NAME });
+    super(scope, id, {
+      package: 'filemanager-inventory-lambda',
+      ...props,
+      functionName: INVENTORY_FUNCTION_NAME,
+    });
 
     this.addPoliciesForBuckets(props.buckets);
   }

--- a/lib/workload/stateless/stacks/filemanager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/stack.ts
@@ -12,6 +12,7 @@ import { IQueue, Queue } from 'aws-cdk-lib/aws-sqs';
 import { HttpMethod, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv2';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
 import { InventoryFunction } from './constructs/functions/inventory';
+import { NamedLambdaRole } from '../../../../components/named-lambda-role';
 
 export const FILEMANAGER_SERVICE_NAME = 'filemanager';
 
@@ -29,7 +30,8 @@ export type FilemanagerConfig = Omit<DatabaseProps, 'host' | 'securityGroup'> & 
   cognitoUserPoolIdParameterName: string;
   cognitoPortalAppClientIdParameterName: string;
   cognitoStatusPageAppClientIdParameterName: string;
-}
+  fileManagerIngestRoleName: string;
+};
 
 /**
  * Props for the filemanager stack.
@@ -44,7 +46,7 @@ export class Filemanager extends Stack {
   private readonly host: string;
   private readonly securityGroup: ISecurityGroup;
   private readonly queue: IQueue;
-  
+
   constructor(scope: Construct, id: string, props: FilemanagerProps) {
     super(scope, id, props);
 
@@ -93,8 +95,13 @@ export class Filemanager extends Stack {
     this.createInventoryFunction(props);
   }
 
-  /// Lambda function definitions and surrounding infra
-  // Ingest function
+  private createIngestRole(name: string) {
+    return new NamedLambdaRole(this, 'IngestFunctionRole', { name })
+  }
+
+  /**
+   * Lambda function definitions and surrounding infrastructure.
+   */
   private createIngestFunction(props: FilemanagerProps) {
     return new IngestFunction(this, 'IngestFunction', {
       vpc: this.vpc,
@@ -102,7 +109,8 @@ export class Filemanager extends Stack {
       securityGroup: this.securityGroup,
       eventSources: [this.queue],
       buckets: props.eventSourceBuckets,
-      ...props
+      role: this.createIngestRole(props.fileManagerIngestRoleName),
+      ...props,
     });
   }
 
@@ -119,13 +127,15 @@ export class Filemanager extends Stack {
     });
   }
 
-  // Query function and API Gateway fronting the function
+  /**
+   * Query function and API Gateway fronting the function.
+   */
   private createQueryFunction(props: FilemanagerProps) {
     let objectsQueryLambda = new QueryFunction(this, 'ObjectsQueryFunction', {
       vpc: this.vpc,
       host: this.host,
       securityGroup: this.securityGroup,
-      ...props
+      ...props,
     });
 
     const ApiGateway = new ApiGatewayConstruct(this, 'ApiGateway', {
@@ -137,7 +147,8 @@ export class Filemanager extends Stack {
 
     const apiIntegration = new HttpLambdaIntegration('ApiIntegration', objectsQueryLambda.function);
 
-    new HttpRoute(this, 'HttpRoute', { // FIXME: Should not be just proxy but objects/{:id}
+    new HttpRoute(this, 'HttpRoute', {
+      // FIXME: Should not be just proxy but objects/{:id}
       httpApi: httpApi,
       integration: apiIntegration,
       routeKey: HttpRouteKey.with('/{proxy+}', HttpMethod.ANY),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -23,8 +23,6 @@ pub enum Error {
     MissingEnvironmentVariable(String),
     #[error("Invalid environment variable: `{0}`")]
     InvalidEnvironmentVariable(String),
-    #[error("S3 error: `{0}`")]
-    S3Error(String),
     #[error("credential generator error: `{0}`")]
     CredentialGeneratorError(String),
     #[error("S3 inventory error: `{0}`")]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/collecter.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/collecter.rs
@@ -2,7 +2,7 @@
 //!
 
 use async_trait::async_trait;
-use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
+use aws_sdk_s3::operation::head_object::HeadObjectOutput;
 use aws_sdk_s3::primitives;
 use aws_sdk_s3::types::StorageClass::Standard;
 use chrono::{DateTime, Utc};
@@ -16,8 +16,8 @@ use crate::clients::aws::s3::Client;
 use crate::clients::aws::s3::Client as S3Client;
 #[double]
 use crate::clients::aws::sqs::Client as SQSClient;
+use crate::error::Error::InvalidEnvironmentVariable;
 use crate::error::Error::{DeserializeError, SQSError};
-use crate::error::Error::{InvalidEnvironmentVariable, S3Error};
 use crate::error::Result;
 use crate::events::aws::{
     EventType, FlatS3EventMessage, FlatS3EventMessages, StorageClass, TransposedS3EventMessages,
@@ -142,26 +142,8 @@ impl Collecter {
     }
 
     /// Gets S3 metadata from HeadObject such as creation/archival timestamps and statuses.
-    pub async fn head(
-        client: &Client,
-        key: &str,
-        bucket: &str,
-    ) -> Result<Option<HeadObjectOutput>> {
-        let head = client.head_object(key, bucket).await;
-
-        match head {
-            Ok(head) => Ok(Some(head)),
-            Err(err) => {
-                let err = err.into_service_error();
-                if let HeadObjectError::NotFound(_) = err {
-                    // Object not found, could be deleted.
-                    Ok(None)
-                } else {
-                    // I.e: Cannot connect to server
-                    Err(S3Error(err.to_string()))
-                }
-            }
-        }
+    pub async fn head(client: &Client, key: &str, bucket: &str) -> Option<HeadObjectOutput> {
+        client.head_object(key, bucket).await.ok()
     }
 
     /// Process events and add header and datetime fields.
@@ -182,7 +164,7 @@ impl Collecter {
                 // Race condition: it's possible that an object gets deleted so quickly that it
                 // occurs before calling head. This means that there may be cases where the storage
                 // class and other fields are not known.
-                if let Some(head) = Self::head(client, &event.key, &event.bucket).await? {
+                if let Some(head) = Self::head(client, &event.key, &event.bucket).await {
                     trace!(head = ?head, "received head object output");
 
                     let HeadObjectOutput {
@@ -254,6 +236,7 @@ pub(crate) mod tests {
     use std::result;
 
     use aws_sdk_s3::error::SdkError;
+    use aws_sdk_s3::operation::head_object::HeadObjectError;
     use aws_sdk_s3::primitives::{DateTimeFormat, SdkBody};
     use aws_sdk_s3::types;
     use aws_sdk_s3::types::error::NotFound;
@@ -331,9 +314,7 @@ pub(crate) mod tests {
 
         set_s3_client_expectations(&mut collecter.client, vec![|| Ok(expected_head_object())]);
 
-        let result = Collecter::head(&collecter.client, "key", "bucket")
-            .await
-            .unwrap();
+        let result = Collecter::head(&collecter.client, "key", "bucket").await;
         assert_eq!(result, Some(expected_head_object()));
     }
 
@@ -346,9 +327,7 @@ pub(crate) mod tests {
             vec![|| Err(expected_head_object_not_found())],
         );
 
-        let result = Collecter::head(&collecter.client, "key", "bucket")
-            .await
-            .unwrap();
+        let result = Collecter::head(&collecter.client, "key", "bucket").await;
         assert!(result.is_none());
     }
 

--- a/test/stateless/deployment.test.ts
+++ b/test/stateless/deployment.test.ts
@@ -174,6 +174,17 @@ function applyNagSuppression(stackId: string, stack: Stack) {
         [
           {
             id: 'AwsSolutions-IAM5',
+            reason: "'*' is required to access objects in the indexed bucket by filemanager.",
+            appliesTo: ['Resource::arn:aws:s3:::pipeline-prod-cache-503977275616-ap-southeast-2/*'],
+          },
+        ],
+        true
+      );
+      NagSuppressions.addResourceSuppressions(
+        stack,
+        [
+          {
+            id: 'AwsSolutions-IAM5',
             reason:
               "'*' is required to access the inventory manifest and data files by the inventory function.",
             appliesTo: ['Resource::arn:aws:s3:::filemanager-inventory-test/*'],


### PR DESCRIPTION
Closes #354 

### Changes
* Makes the `HeadObject` call for ingesting events optional.