### PR TITLE
Fixed ICAv2 event handle StepFunction Payload schema

### DIFF
--- a/lib/workload/components/dynamodb-icav2-handle-event-change-sfn/step_functions_templates/icav2_get_workflow_status_and_raise_internal_event.asl.json
+++ b/lib/workload/components/dynamodb-icav2-handle-event-change-sfn/step_functions_templates/icav2_get_workflow_status_and_raise_internal_event.asl.json
@@ -159,7 +159,6 @@
         "workflowVersion": "${__workflow_version__}",
         "workflowRunName.$": "$.Item.workflow_run_name.S",
         "payload": {
-          "refId": null,
           "version": "${__service_version__}",
           "data": {
             "projectId.$": "$.Item.project_id.S",

--- a/lib/workload/components/dynamodb-icav2-ready-event-handler-sfn/step_functions_templates/icav2_launch_workflow_and_raise_internal_event.asl.json
+++ b/lib/workload/components/dynamodb-icav2-ready-event-handler-sfn/step_functions_templates/icav2_launch_workflow_and_raise_internal_event.asl.json
@@ -461,11 +461,12 @@
         "workflowVersion": "${__workflow_version__}",
         "workflowRunName.$": "$.Item.workflow_run_name.S",
         "payload": {
-          "refId": null,
           "version": "${__service_version__}",
-          "projectId.$": "$.Item.project_id.S",
-          "analysisId.$": "$.Item.analysis_id.S",
-          "analysisOutput": ""
+          "data": {
+            "projectId.$": "$.Item.project_id.S",
+            "analysisId.$": "$.Item.analysis_id.S",
+            "analysisOutput": ""
+          }
         }
       },
       "ResultPath": "$.database_event_data"


### PR DESCRIPTION
* Payload `refId` is no longer required for Execution Services
* Payload data should wrap under `data` property