### PR TITLE
fix(filemanager): sequencer ordering

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/Cargo.lock
+++ b/lib/workload/stateless/stacks/filemanager/Cargo.lock
@@ -2145,6 +2145,7 @@ dependencies = [
  "mockall_double",
  "orc-rust",
  "parquet",
+ "rand",
  "sea-orm",
  "serde",
  "serde_json",

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0003_add_sequencer_index.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0003_add_sequencer_index.sql
@@ -1,0 +1,4 @@
+-- Create an index for ordering `s3_object`s in ascending order.
+-- TODO this should be created `concurrently` when running migrations without transactions is released:
+-- https://github.com/launchbadge/sqlx/issues/767
+create index sequencer_index on s3_object (sequencer);

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -69,6 +69,7 @@ aws_lambda_events = "0.15"
 
 [dev-dependencies]
 lazy_static = "1"
+rand = "0.8"
 
 aws-smithy-runtime-api = "1"
 aws-smithy-mocks-experimental = "0.2"

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -222,7 +222,7 @@ mod tests {
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::database::entities::object::Model as Object;
     use crate::database::entities::s3_object::Model as S3Object;
-    use crate::queries::tests::initialize_database;
+    use crate::queries::tests::{initialize_database, initialize_database_reorder};
     use crate::routes::list::{ListCount, ListResponse};
     use crate::routes::{api_router, AppState};
 
@@ -331,7 +331,7 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_api(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
+        let entries = initialize_database_reorder(state.client(), 10).await;
 
         let app = api_router(state);
         let response = app
@@ -365,7 +365,7 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_api_paginate(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
+        let entries = initialize_database_reorder(state.client(), 10).await;
 
         let app = api_router(state);
         let response = app
@@ -399,7 +399,7 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_api_zero_page_size(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
+        let entries = initialize_database_reorder(state.client(), 10).await;
 
         let app = api_router(state);
         let response = app


### PR DESCRIPTION
Closes #395 

### Changes
* Order by sequencer in list API queries.
* Add an index on the sequencer to support better sorting of ingested events.
    * I think this effectively does what this piece of code is doing, except it's a native construct to the database: https://github.com/umccr/orcabus/blob/2e4772c22edf982aef7d64fc4b10c685a716433c/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql#L64-L90 This is one of the reasons why I simplified the database ingestion, because I think a similar trade off with ingest/query performance can be achieved by just using an index (although I would need to test this to be sure).