### PR TITLE
fix: filemanager e_tag quoting

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
@@ -135,8 +135,8 @@ pub(crate) mod tests {
 
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::database::{Client, Ingest};
-    use crate::events::aws::message::EventType;
     use crate::events::aws::message::EventType::{Created, Deleted};
+    use crate::events::aws::message::{default_version_id, EventType};
     use crate::events::aws::tests::{
         expected_events_simple, expected_events_simple_delete_marker, expected_flat_events_simple,
         EXPECTED_E_TAG, EXPECTED_SEQUENCER_CREATED_ONE, EXPECTED_SEQUENCER_CREATED_ZERO,
@@ -546,7 +546,7 @@ pub(crate) mod tests {
         assert_ingest_events(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -577,7 +577,7 @@ pub(crate) mod tests {
         assert_ingest_events(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -617,7 +617,7 @@ pub(crate) mod tests {
         assert_ingest_events(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -645,7 +645,7 @@ pub(crate) mod tests {
         assert_ingest_events(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -826,7 +826,7 @@ pub(crate) mod tests {
         assert_missing_deleted(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -851,7 +851,7 @@ pub(crate) mod tests {
         assert_missing_deleted(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -877,7 +877,7 @@ pub(crate) mod tests {
         assert_missing_created(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -902,7 +902,7 @@ pub(crate) mod tests {
         assert_missing_created(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -1115,15 +1115,10 @@ pub(crate) mod tests {
                 .with_sequencer(Some("1".to_string())),
         ];
 
-        let message = expected_message(
-            None,
-            FlatS3EventMessage::default_version_id(),
-            false,
-            Created,
-        )
-        .with_sha256(None)
-        .with_e_tag(None)
-        .with_last_modified_date(None);
+        let message = expected_message(None, default_version_id(), false, Created)
+            .with_sha256(None)
+            .with_e_tag(None)
+            .with_last_modified_date(None);
         // 720 permutations
         run_permutation_test(&pool, event_permutations, 6, |s3_object_results| {
             assert_row(
@@ -1359,7 +1354,7 @@ pub(crate) mod tests {
         events
             .version_ids
             .iter_mut()
-            .for_each(|version_id| *version_id = FlatS3EventMessage::default_version_id());
+            .for_each(|version_id| *version_id = default_version_id());
 
         events
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
@@ -139,7 +139,7 @@ pub(crate) mod tests {
     use crate::events::aws::message::{default_version_id, EventType};
     use crate::events::aws::tests::{
         expected_events_simple, expected_events_simple_delete_marker, expected_flat_events_simple,
-        EXPECTED_E_TAG, EXPECTED_SEQUENCER_CREATED_ONE, EXPECTED_SEQUENCER_CREATED_ZERO,
+        EXPECTED_QUOTED_E_TAG, EXPECTED_SEQUENCER_CREATED_ONE, EXPECTED_SEQUENCER_CREATED_ZERO,
         EXPECTED_SEQUENCER_DELETED_ONE, EXPECTED_SEQUENCER_DELETED_TWO, EXPECTED_SHA256,
         EXPECTED_VERSION_ID,
     };
@@ -1464,7 +1464,7 @@ pub(crate) mod tests {
             .with_size(size)
             .with_version_id(version_id)
             .with_last_modified_date(Some(DateTime::<Utc>::default()))
-            .with_e_tag(Some(EXPECTED_E_TAG.to_string()))
+            .with_e_tag(Some(EXPECTED_QUOTED_E_TAG.to_string()))
             .with_sha256(Some(EXPECTED_SHA256.to_string()))
             .with_is_delete_marker(is_delete_marker)
             .with_event_type(event_type)

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
@@ -276,9 +276,10 @@ pub(crate) mod tests {
     use crate::events::aws::message::EventType::{Created, Deleted};
     use crate::events::aws::tests::{
         expected_event_record_simple, expected_flat_events, expected_flat_events_simple,
+        EXPECTED_QUOTED_E_TAG,
     };
     use crate::events::aws::tests::{
-        EXPECTED_E_TAG, EXPECTED_SEQUENCER_CREATED_ONE, EXPECTED_SEQUENCER_CREATED_ZERO,
+        EXPECTED_SEQUENCER_CREATED_ONE, EXPECTED_SEQUENCER_CREATED_ZERO,
         EXPECTED_SEQUENCER_DELETED_ONE, EXPECTED_SEQUENCER_DELETED_TWO, EXPECTED_SHA256,
         EXPECTED_VERSION_ID,
     };
@@ -1720,7 +1721,7 @@ pub(crate) mod tests {
             .with_size(size)
             .with_version_id(version_id)
             .with_last_modified_date(Some(DateTime::<Utc>::default()))
-            .with_e_tag(Some(EXPECTED_E_TAG.to_string()))
+            .with_e_tag(Some(EXPECTED_QUOTED_E_TAG.to_string()))
             .with_sha256(Some(EXPECTED_SHA256.to_string()))
             .with_is_delete_marker(is_delete_marker)
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
@@ -272,6 +272,7 @@ pub(crate) mod tests {
     use crate::database::aws::ingester::tests::fetch_results;
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::database::{Client, Ingest};
+    use crate::events::aws::message::default_version_id;
     use crate::events::aws::message::EventType::{Created, Deleted};
     use crate::events::aws::tests::{
         expected_event_record_simple, expected_flat_events, expected_flat_events_simple,
@@ -684,10 +685,7 @@ pub(crate) mod tests {
         assert_eq!(object_results.len(), 1);
         assert_eq!(s3_object_results.len(), 1);
         assert_eq!(0, s3_object_results[0].get::<i64, _>("number_reordered"));
-        assert_ingest_events(
-            &s3_object_results[0],
-            &FlatS3EventMessage::default_version_id(),
-        );
+        assert_ingest_events(&s3_object_results[0], &default_version_id());
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -710,10 +708,7 @@ pub(crate) mod tests {
             2,
             s3_object_results[0].get::<i64, _>("number_duplicate_events")
         );
-        assert_ingest_events(
-            &s3_object_results[0],
-            &FlatS3EventMessage::default_version_id(),
-        );
+        assert_ingest_events(&s3_object_results[0], &default_version_id());
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -747,10 +742,7 @@ pub(crate) mod tests {
             2,
             s3_object_results[0].get::<i64, _>("number_duplicate_events")
         );
-        assert_ingest_events(
-            &s3_object_results[0],
-            &FlatS3EventMessage::default_version_id(),
-        );
+        assert_ingest_events(&s3_object_results[0], &default_version_id());
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -782,7 +774,7 @@ pub(crate) mod tests {
             Some(0),
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
-            FlatS3EventMessage::default_version_id(),
+            default_version_id(),
             Some(Default::default()),
             Some(Default::default()),
         );
@@ -987,7 +979,7 @@ pub(crate) mod tests {
         assert_missing_deleted(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -1017,7 +1009,7 @@ pub(crate) mod tests {
         assert_missing_deleted(
             &s3_object_results[1],
             &s3_object_results[0],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -1046,7 +1038,7 @@ pub(crate) mod tests {
         assert_missing_created(
             &s3_object_results[0],
             &s3_object_results[1],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -1076,7 +1068,7 @@ pub(crate) mod tests {
         assert_missing_created(
             &s3_object_results[1],
             &s3_object_results[0],
-            &FlatS3EventMessage::default_version_id(),
+            &default_version_id(),
         );
     }
 
@@ -1331,7 +1323,7 @@ pub(crate) mod tests {
                 &s3_object_results,
                 "key",
                 "bucket",
-                &FlatS3EventMessage::default_version_id(),
+                &default_version_id(),
                 Some("1"),
                 Some("2"),
             )
@@ -1340,7 +1332,7 @@ pub(crate) mod tests {
                 &s3_object_results,
                 "key",
                 "bucket",
-                &FlatS3EventMessage::default_version_id(),
+                &default_version_id(),
                 None,
                 Some("3"),
             )
@@ -1349,7 +1341,7 @@ pub(crate) mod tests {
                 &s3_object_results,
                 "key",
                 "bucket",
-                &FlatS3EventMessage::default_version_id(),
+                &default_version_id(),
                 Some("4"),
                 None,
             )
@@ -1358,7 +1350,7 @@ pub(crate) mod tests {
                 &s3_object_results,
                 "key",
                 "bucket",
-                &FlatS3EventMessage::default_version_id(),
+                &default_version_id(),
                 Some("5"),
                 None,
             )
@@ -1367,7 +1359,7 @@ pub(crate) mod tests {
                 &s3_object_results,
                 "key1",
                 "bucket",
-                &FlatS3EventMessage::default_version_id(),
+                &default_version_id(),
                 Some("1"),
                 None,
             )
@@ -1624,12 +1616,12 @@ pub(crate) mod tests {
             .object_deleted
             .version_ids
             .iter_mut()
-            .for_each(|version_id| *version_id = FlatS3EventMessage::default_version_id());
+            .for_each(|version_id| *version_id = default_version_id());
         events
             .object_created
             .version_ids
             .iter_mut()
-            .for_each(|version_id| *version_id = FlatS3EventMessage::default_version_id());
+            .for_each(|version_id| *version_id = default_version_id());
 
         events
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
@@ -29,7 +29,7 @@ use serde_with::{serde_as, DisplayFromStr};
 use crate::clients::aws::s3::Client;
 use crate::error::Error::S3InventoryError;
 use crate::error::{Error, Result};
-use crate::events::aws::message::EventType::Created;
+use crate::events::aws::message::{default_version_id, EventType::Created};
 use crate::events::aws::{FlatS3EventMessage, FlatS3EventMessages, StorageClass};
 use crate::uuid::UuidGenerator;
 
@@ -529,7 +529,7 @@ impl From<Record> for FlatS3EventMessage {
             // Set this to the empty string so that any deleted events after this can bind to this
             // created event, as they are always greater than this event.
             sequencer: Some(Inventory::inventory_sequencer()),
-            version_id: version_id.unwrap_or_else(FlatS3EventMessage::default_version_id),
+            version_id: version_id.unwrap_or_else(default_version_id),
             storage_class,
             last_modified_date,
             sha256: None,
@@ -663,7 +663,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn parse_csv_manifest_from_checksum() {
-        let (mut client, checksum) = test_csv_manifest(None);
+        let (mut client, checksum) = test_csv_manifest(None, csv_data_empty_string());
 
         let bytes = csv_manifest_to_json(checksum);
         let checksum = format!("{}\n", hex::encode(md5::compute(bytes.as_slice()).0))
@@ -705,60 +705,56 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn parse_csv_manifest() {
-        let (client, checksum) = test_csv_manifest(None);
-
-        let inventory = Inventory::new(client);
-        let result = inventory
-            .parse_manifest(expected_csv_manifest(
-                Some(checksum),
-                Some(CSV_MANIFEST_SCHEMA.to_string()),
-            ))
-            .await
-            .unwrap();
-
-        assert_csv_records(result.as_slice());
+        assert_csv_with(
+            None,
+            csv_data_empty_string(),
+            Some(CSV_MANIFEST_SCHEMA.to_string()),
+            true,
+        )
+        .await;
+        assert_csv_with(
+            None,
+            csv_data_missing(),
+            Some(CSV_MANIFEST_SCHEMA.to_string()),
+            true,
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn parse_csv_manifest_no_checksum() {
-        let (client, _) = test_csv_manifest(None);
-
-        let inventory = Inventory::new(client);
-        let result = inventory
-            .parse_manifest(expected_csv_manifest(
-                None,
-                Some(CSV_MANIFEST_SCHEMA.to_string()),
-            ))
-            .await
-            .unwrap();
-
-        assert_csv_records(result.as_slice());
+        assert_csv_with(
+            None,
+            csv_data_empty_string(),
+            Some(CSV_MANIFEST_SCHEMA.to_string()),
+            false,
+        )
+        .await;
+        assert_csv_with(
+            None,
+            csv_data_missing(),
+            Some(CSV_MANIFEST_SCHEMA.to_string()),
+            false,
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn parse_csv_manifest_with_headers() {
-        let (client, checksum) = test_csv_manifest(Some(CSV_MANIFEST_SCHEMA));
-
-        let inventory = Inventory::new(client);
-        let result = inventory
-            .parse_manifest(expected_csv_manifest(Some(checksum), None))
-            .await
-            .unwrap();
-
-        assert_csv_records(result.as_slice());
+        assert_csv_with(
+            Some(CSV_MANIFEST_SCHEMA),
+            csv_data_empty_string(),
+            None,
+            true,
+        )
+        .await;
+        assert_csv_with(Some(CSV_MANIFEST_SCHEMA), csv_data_missing(), None, true).await;
     }
 
     #[tokio::test]
     async fn parse_csv_manifest_default_schema() {
-        let (client, checksum) = test_csv_manifest(None);
-
-        let inventory = Inventory::new(client);
-        let result = inventory
-            .parse_manifest(expected_csv_manifest(Some(checksum), None))
-            .await
-            .unwrap();
-
-        assert_csv_records(result.as_slice());
+        assert_csv_with(None, csv_data_empty_string(), None, true).await;
+        assert_csv_with(None, csv_data_missing(), None, true).await;
     }
 
     #[tokio::test]
@@ -833,8 +829,27 @@ pub(crate) mod tests {
         );
     }
 
+    async fn assert_csv_with(
+        headers: Option<&str>,
+        data: String,
+        schema: Option<String>,
+        use_checksum: bool,
+    ) {
+        let (client, checksum) = test_csv_manifest(headers, data);
+
+        let checksum = if use_checksum { Some(checksum) } else { None };
+
+        let inventory = Inventory::new(client);
+        let result = inventory
+            .parse_manifest(expected_csv_manifest(checksum, schema))
+            .await
+            .unwrap();
+
+        assert_csv_records(result.as_slice());
+    }
+
     pub(crate) fn csv_manifest_from_key_expectations() -> Client {
-        let (mut client, checksum) = test_csv_manifest(None);
+        let (mut client, checksum) = test_csv_manifest(None, csv_data_empty_string());
 
         let bytes = csv_manifest_to_json(checksum);
         set_client_manifest_expectations(&mut client, bytes);
@@ -862,8 +877,8 @@ pub(crate) mod tests {
             });
     }
 
-    fn test_csv_manifest(headers: Option<&str>) -> (Client, String) {
-        let mut data = concat!(
+    fn csv_data_empty_string() -> String {
+        concat!(
             r#""bucket","inventory_test/","","true","false","0","2024-04-22T01:11:06.000Z","d41d8cd98f00b204e9800998ecf8427e","STANDARD","false","","SSE-S3","","","","","DISABLED","","e30K","""#, // pragma: allowlist secret
             "\n",
             r#""bucket","inventory_test/key1","","true","false","0","2024-04-22T01:13:28.000Z","d41d8cd98f00b204e9800998ecf8427e","STANDARD","false","","SSE-S3","","","","","DISABLED","","e30K","""#, // pragma: allowlist secret
@@ -871,8 +886,22 @@ pub(crate) mod tests {
             r#""bucket","inventory_test/key2","","true","false","5","2024-04-22T01:14:53.000Z","d8e8fca2dc0f896fd7cb4cb0031ba249","STANDARD","false","","SSE-S3","","","","","DISABLED","","e30K","""#, // pragma: allowlist secret
             "\n\n"
         )
-        .to_string();
+        .to_string()
+    }
 
+    fn csv_data_missing() -> String {
+        concat!(
+            r#""bucket","inventory_test/",,"true","false","0","2024-04-22T01:11:06.000Z","d41d8cd98f00b204e9800998ecf8427e","STANDARD","false",,"SSE-S3",,,,,"DISABLED",,"e30K","#, // pragma: allowlist secret
+            "\n",
+            r#""bucket","inventory_test/key1",,"true","false","0","2024-04-22T01:13:28.000Z","d41d8cd98f00b204e9800998ecf8427e","STANDARD","false",,"SSE-S3",,,,,"DISABLED",,"e30K","#, // pragma: allowlist secret
+            "\n",
+            r#""bucket","inventory_test/key2",,"true","false","5","2024-04-22T01:14:53.000Z","d8e8fca2dc0f896fd7cb4cb0031ba249","STANDARD","false",,"SSE-S3",,,,,"DISABLED",,"e30K","#, // pragma: allowlist secret
+            "\n\n"
+        )
+        .to_string()
+    }
+
+    fn test_csv_manifest(headers: Option<&str>, mut data: String) -> (Client, String) {
         if let Some(headers) = headers {
             data = format!("{}\n{}", headers, data);
         }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -193,7 +193,7 @@ impl From<Record> for FlatS3EventMessage {
             size,
             e_tag: etag,
             sequencer,
-            version_id: version_id.unwrap_or_else(FlatS3EventMessage::default_version_id),
+            version_id: version_id.unwrap_or_else(default_version_id),
             // Head fields are fetched later.
             storage_class: None,
             last_modified_date: None,
@@ -224,6 +224,11 @@ impl From<Message> for FlatS3EventMessages {
                 }),
         )
     }
+}
+
+/// The default version id.
+pub fn default_version_id() -> String {
+    "null".to_string()
 }
 
 #[cfg(test)]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -191,7 +191,7 @@ impl From<Record> for FlatS3EventMessage {
             bucket,
             key,
             size,
-            e_tag: etag,
+            e_tag: etag.map(quote_e_tag),
             sequencer,
             version_id: version_id.unwrap_or_else(default_version_id),
             // Head fields are fetched later.
@@ -226,6 +226,20 @@ impl From<Message> for FlatS3EventMessages {
     }
 }
 
+/// Quote an e_tag if it has not already been quoted. This doesn't check the
+/// validity of an e_tag, it only applies quoting if it is missing.
+pub fn quote_e_tag(mut e_tag: String) -> String {
+    if !e_tag.starts_with('"') && !e_tag.starts_with("W/\"") {
+        e_tag.insert(0, '"');
+    }
+
+    if !e_tag.ends_with('"') || e_tag == "\"" || e_tag == "W/\"" {
+        e_tag.push('"');
+    }
+
+    e_tag
+}
+
 /// The default version id.
 pub fn default_version_id() -> String {
     "null".to_string()
@@ -233,8 +247,9 @@ pub fn default_version_id() -> String {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use serde_json::{json, Value};
 
+    use crate::events::aws::message::quote_e_tag;
     use crate::events::aws::message::EventType::Created;
     use crate::events::aws::tests::{
         assert_flat_s3_event, expected_event_bridge_record,
@@ -243,6 +258,28 @@ mod tests {
     };
     use crate::events::aws::EventType::Deleted;
     use crate::events::aws::FlatS3EventMessages;
+
+    #[test]
+    fn test_e_tag_quoting() {
+        // e_tag is already valid.
+        assert_eq!(quote_e_tag("\"e_tag\"".to_string()), "\"e_tag\"");
+        assert_eq!(quote_e_tag("W/\"e_tag\"".to_string()), "W/\"e_tag\"");
+        assert_eq!(quote_e_tag("\"\"".to_string()), "\"\"");
+        assert_eq!(quote_e_tag("W/\"\"".to_string()), "W/\"\"");
+
+        // No quoting present on e_tag.
+        assert_eq!(quote_e_tag("e_tag".to_string()), "\"e_tag\"");
+        assert_eq!(quote_e_tag("".to_string()), "\"\"");
+
+        // Partial quoting present on e_tag.
+        assert_eq!(quote_e_tag("\"e_tag".to_string()), "\"e_tag\"");
+        assert_eq!(quote_e_tag("e_tag\"".to_string()), "\"e_tag\"");
+        assert_eq!(quote_e_tag("W/\"e_tag".to_string()), "W/\"e_tag\"");
+
+        // Single quote character e_tag.
+        assert_eq!(quote_e_tag("\"".to_string()), "\"\"");
+        assert_eq!(quote_e_tag("W/\"".to_string()), "W/\"\"");
+    }
 
     #[test]
     fn deserialize_large_size() {
@@ -290,42 +327,17 @@ mod tests {
             false,
         );
     }
+
     #[test]
     fn deserialize_sqs_message() {
-        let record = expected_sqs_record();
-        let message = json!({
-           "Records": [record]
-        })
-        .to_string();
-
-        let result: FlatS3EventMessages = serde_json::from_str(&message).unwrap();
-        let first_message = result.into_inner().first().unwrap().clone();
-
-        assert_flat_s3_event(
-            first_message,
-            &Deleted,
-            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
-            None,
-            EXPECTED_VERSION_ID.to_string(),
-            false,
-        );
+        test_deserialize_sqs_message(expected_sqs_record(false));
+        test_deserialize_sqs_message(expected_sqs_record(true));
     }
 
     #[test]
     fn deserialize_event_bridge_message() {
-        let record = expected_event_bridge_record().to_string();
-
-        let result: FlatS3EventMessages = serde_json::from_str(&record).unwrap();
-        let first_message = result.into_inner().first().unwrap().clone();
-
-        assert_flat_s3_event(
-            first_message,
-            &Deleted,
-            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
-            None,
-            EXPECTED_VERSION_ID.to_string(),
-            false,
-        );
+        test_deserialize_event_bridge_message(&expected_event_bridge_record(false).to_string());
+        test_deserialize_event_bridge_message(&expected_event_bridge_record(true).to_string());
     }
 
     #[test]
@@ -347,7 +359,7 @@ mod tests {
 
     #[test]
     fn deserialize_sqs_message_delete_marker() {
-        let mut record = expected_sqs_record();
+        let mut record = expected_sqs_record(false);
         record["eventName"] = json!("ObjectRemoved:DeleteMarkerCreated");
         let message = json!({
            "Records": [record]
@@ -364,6 +376,39 @@ mod tests {
             None,
             EXPECTED_VERSION_ID.to_string(),
             true,
+        );
+    }
+
+    fn test_deserialize_sqs_message(record: Value) {
+        let message = json!({
+           "Records": [record]
+        })
+        .to_string();
+
+        let result: FlatS3EventMessages = serde_json::from_str(&message).unwrap();
+        let first_message = result.into_inner().first().unwrap().clone();
+
+        assert_flat_s3_event(
+            first_message,
+            &Deleted,
+            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
+            None,
+            EXPECTED_VERSION_ID.to_string(),
+            false,
+        );
+    }
+
+    fn test_deserialize_event_bridge_message(record: &str) {
+        let result: FlatS3EventMessages = serde_json::from_str(record).unwrap();
+        let first_message = result.into_inner().first().unwrap().clone();
+
+        assert_flat_s3_event(
+            first_message,
+            &Deleted,
+            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
+            None,
+            EXPECTED_VERSION_ID.to_string(),
+            false,
         );
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
@@ -628,6 +628,7 @@ pub(crate) mod tests {
     pub(crate) const EXPECTED_SEQUENCER_DELETED_TWO: &str = "0055AED6DCD90281E9"; // pragma: allowlist secret
 
     pub(crate) const EXPECTED_E_TAG: &str = "d41d8cd98f00b204e9800998ecf8427e"; // pragma: allowlist secret
+    pub(crate) const EXPECTED_QUOTED_E_TAG: &str = "\"d41d8cd98f00b204e9800998ecf8427e\""; // pragma: allowlist secret
 
     pub(crate) const EXPECTED_VERSION_ID: &str = "096fKKXTRTtl3on89fVO.nfljtsv6qko";
     pub(crate) const EXPECTED_SHA256: &str = "Y0sCextp4SQtQNU+MSs7SsdxD1W+gfKJtUlEbvZ3i+4="; // pragma: allowlist secret
@@ -757,7 +758,7 @@ pub(crate) mod tests {
         assert_eq!(event.key, "key");
         assert_eq!(event.version_id, version_id);
         assert_eq!(event.size, size);
-        assert_eq!(event.e_tag, Some(EXPECTED_E_TAG.to_string()));
+        assert_eq!(event.e_tag, Some(EXPECTED_QUOTED_E_TAG.to_string()));
         assert_eq!(event.sequencer, sequencer);
         assert_eq!(event.storage_class, None);
         assert_eq!(event.last_modified_date, None);
@@ -779,7 +780,10 @@ pub(crate) mod tests {
             events.version_ids[position],
             EXPECTED_VERSION_ID.to_string()
         );
-        assert_eq!(events.e_tags[position], Some(EXPECTED_E_TAG.to_string()));
+        assert_eq!(
+            events.e_tags[position],
+            Some(EXPECTED_QUOTED_E_TAG.to_string())
+        );
         assert_eq!(events.sequencers[position], Some(sequencer.to_string()));
         assert_eq!(events.storage_classes[position], None);
         assert_eq!(events.last_modified_dates[position], None);
@@ -864,7 +868,7 @@ pub(crate) mod tests {
     }
 
     /// https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
-    pub(crate) fn expected_event_bridge_record() -> Value {
+    pub(crate) fn expected_event_bridge_record(quote_e_tag: bool) -> Value {
         json!({
             "version": "0",
             "id": "2ee9cc15-d022-99ea-1fb8-1b1bac4850f9",
@@ -883,7 +887,7 @@ pub(crate) mod tests {
                 },
                 "object": {
                     "key": "key",
-                    "etag": EXPECTED_E_TAG,
+                    "etag": if quote_e_tag { EXPECTED_QUOTED_E_TAG } else { EXPECTED_E_TAG },
                     "version-id": EXPECTED_VERSION_ID,
                     "sequencer": EXPECTED_SEQUENCER_DELETED_ONE,
                 },
@@ -898,13 +902,13 @@ pub(crate) mod tests {
 
     /// https://docs.aws.amazon.com/AmazonS3/latest/userguide/ev-events.html
     pub(crate) fn expected_event_bridge_record_delete_marker() -> Value {
-        let mut value = expected_event_bridge_record();
+        let mut value = expected_event_bridge_record(false);
         value["detail"]["deletion-type"] = json!("Delete Marker Created");
         value
     }
 
     /// https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-content-structure.html
-    pub(crate) fn expected_sqs_record() -> Value {
+    pub(crate) fn expected_sqs_record(quote_e_tag: bool) -> Value {
         json!({
             "eventVersion": "2.2",
             "eventSource": "aws:s3",
@@ -933,7 +937,7 @@ pub(crate) mod tests {
                 },
                 "object": {
                     "key": "key",
-                    "eTag": EXPECTED_E_TAG,
+                    "eTag": if quote_e_tag { EXPECTED_QUOTED_E_TAG } else { EXPECTED_E_TAG },
                     "versionId": EXPECTED_VERSION_ID,
                     "sequencer": EXPECTED_SEQUENCER_DELETED_ONE,
                 }
@@ -948,7 +952,7 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn expected_event_record_full(is_delete_marker: bool) -> String {
-        let object = expected_sqs_record();
+        let object = expected_sqs_record(false);
 
         let mut object_created_one = object.clone();
         object_created_one["eventName"] = if is_delete_marker {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use message::EventMessage;
 
-use crate::events::aws::message::EventType;
+use crate::events::aws::message::{default_version_id, EventType};
 use crate::events::aws::EventType::{Created, Deleted, Other};
 use crate::uuid::UuidGenerator;
 
@@ -551,7 +551,7 @@ impl FlatS3EventMessage {
 
     /// Set the version id.
     pub fn with_default_version_id(mut self) -> Self {
-        self.version_id = Self::default_version_id();
+        self.version_id = default_version_id();
         self
     }
 
@@ -601,10 +601,6 @@ impl FlatS3EventMessage {
     pub fn with_sha256(mut self, sha256: Option<String>) -> Self {
         self.sha256 = sha256;
         self
-    }
-
-    pub fn default_version_id() -> String {
-        "null".to_string()
     }
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
@@ -209,6 +209,7 @@ pub(crate) mod tests {
     use sqlx::postgres::PgRow;
     use std::future::Future;
 
+    use super::*;
     use crate::database::aws::ingester::tests::{
         assert_row, expected_message, fetch_results, remove_version_ids, replace_sequencers,
         test_events, test_ingester,
@@ -222,6 +223,7 @@ pub(crate) mod tests {
         EXPECTED_LAST_MODIFIED_ONE, EXPECTED_LAST_MODIFIED_THREE, EXPECTED_LAST_MODIFIED_TWO,
         MANIFEST_BUCKET,
     };
+    use crate::events::aws::message::default_version_id;
     use crate::events::aws::message::EventType::Deleted;
     use crate::events::aws::tests::{
         expected_event_record_simple, EXPECTED_SEQUENCER_CREATED_ONE,
@@ -231,8 +233,6 @@ pub(crate) mod tests {
     use crate::events::aws::FlatS3EventMessage;
     use crate::events::EventSourceType::S3;
     use sqlx::PgPool;
-
-    use super::*;
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_receive_and_ingest(pool: PgPool) {
@@ -463,7 +463,7 @@ pub(crate) mod tests {
                 .with_bucket("bucket".to_string())
                 .with_key("inventory_test/key1".to_string())
                 .with_size(Some(0))
-                .with_version_id(FlatS3EventMessage::default_version_id().to_string())
+                .with_version_id(default_version_id())
                 .with_e_tag(Some(EXPECTED_E_TAG_EMPTY.to_string()))
                 .with_last_modified_date(Some(DateTime::default()))
                 .with_sha256(Some(EXPECTED_SHA256.to_string())),
@@ -521,7 +521,7 @@ pub(crate) mod tests {
             .with_bucket("bucket".to_string())
             .with_key(key)
             .with_size(Some(size))
-            .with_version_id(FlatS3EventMessage::default_version_id().to_string())
+            .with_version_id(default_version_id())
             .with_last_modified_date(Some(last_modified.parse().unwrap()))
             .with_e_tag(Some(e_tag.to_string()));
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
@@ -219,14 +219,14 @@ pub(crate) mod tests {
         expected_head_object, set_s3_client_expectations, set_sqs_client_expectations,
     };
     use crate::events::aws::inventory::tests::{
-        csv_manifest_from_key_expectations, EXPECTED_E_TAG_EMPTY, EXPECTED_E_TAG_KEY_2,
-        EXPECTED_LAST_MODIFIED_ONE, EXPECTED_LAST_MODIFIED_THREE, EXPECTED_LAST_MODIFIED_TWO,
+        csv_manifest_from_key_expectations, EXPECTED_LAST_MODIFIED_ONE,
+        EXPECTED_LAST_MODIFIED_THREE, EXPECTED_LAST_MODIFIED_TWO, EXPECTED_QUOTED_E_TAG_KEY_2,
         MANIFEST_BUCKET,
     };
     use crate::events::aws::message::default_version_id;
     use crate::events::aws::message::EventType::Deleted;
     use crate::events::aws::tests::{
-        expected_event_record_simple, EXPECTED_SEQUENCER_CREATED_ONE,
+        expected_event_record_simple, EXPECTED_QUOTED_E_TAG, EXPECTED_SEQUENCER_CREATED_ONE,
         EXPECTED_SEQUENCER_CREATED_TWO, EXPECTED_SEQUENCER_DELETED_ONE, EXPECTED_SHA256,
         EXPECTED_VERSION_ID,
     };
@@ -440,21 +440,21 @@ pub(crate) mod tests {
             "inventory_test/".to_string(),
             0,
             EXPECTED_LAST_MODIFIED_ONE,
-            EXPECTED_E_TAG_EMPTY,
+            EXPECTED_QUOTED_E_TAG,
         );
         assert_inventory_records(
             &s3_object_results[1],
             "inventory_test/key1".to_string(),
             0,
             EXPECTED_LAST_MODIFIED_TWO,
-            EXPECTED_E_TAG_EMPTY,
+            EXPECTED_QUOTED_E_TAG,
         );
         assert_inventory_records(
             &s3_object_results[2],
             "inventory_test/key2".to_string(),
             5,
             EXPECTED_LAST_MODIFIED_THREE,
-            EXPECTED_E_TAG_KEY_2,
+            EXPECTED_QUOTED_E_TAG_KEY_2,
         );
 
         (
@@ -464,7 +464,7 @@ pub(crate) mod tests {
                 .with_key("inventory_test/key1".to_string())
                 .with_size(Some(0))
                 .with_version_id(default_version_id())
-                .with_e_tag(Some(EXPECTED_E_TAG_EMPTY.to_string()))
+                .with_e_tag(Some(EXPECTED_QUOTED_E_TAG.to_string()))
                 .with_last_modified_date(Some(DateTime::default()))
                 .with_sha256(Some(EXPECTED_SHA256.to_string())),
         )
@@ -492,21 +492,21 @@ pub(crate) mod tests {
             "inventory_test/".to_string(),
             0,
             EXPECTED_LAST_MODIFIED_ONE,
-            EXPECTED_E_TAG_EMPTY,
+            EXPECTED_QUOTED_E_TAG,
         );
         assert_inventory_records(
             &s3_object_results[1],
             "inventory_test/key1".to_string(),
             0,
             EXPECTED_LAST_MODIFIED_TWO,
-            EXPECTED_E_TAG_EMPTY,
+            EXPECTED_QUOTED_E_TAG,
         );
         assert_inventory_records(
             &s3_object_results[2],
             "inventory_test/key2".to_string(),
             5,
             EXPECTED_LAST_MODIFIED_THREE,
-            EXPECTED_E_TAG_KEY_2,
+            EXPECTED_QUOTED_E_TAG_KEY_2,
         );
     }
 


### PR DESCRIPTION
Fixes #397 

Turns out that e_tags [should be double quoted](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) to distinguish between two different kinds of e_tags, weak and strong. An e_tag is quoted when received from an SDK `HeadObjectOutput`. However, EventBridge/SQS sends S3 events with unquoted e_tags, resulting in a mismatch when ingesting events.

### Changes
* Check/modify all e_tags to ensure that they are quoted before ingesting events.
* Move the `default_version_id` to `messages.rs`.