### PR TITLE
feat: filemanager filter query parameters

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/Cargo.lock
+++ b/lib/workload/stateless/stacks/filemanager/Cargo.lock
@@ -2149,6 +2149,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "serde_qs",
  "serde_with",
  "sqlx",
  "strum 0.26.2",
@@ -4716,6 +4717,19 @@ checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd34f36fe4c5ba9654417139a9b3a20d2e1de6012ee678ad14d240c22c78d8d6"
+dependencies = [
+ "axum",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -35,6 +35,7 @@ utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
 tower = "0.4"
 tower-http = { version = "0.5", features = ["trace"] }
+serde_qs = { version = "0.13", features = ["axum"] }
 
 # General
 chrono = { version = "0.4", features = ["serde"] }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/get.rs
@@ -60,27 +60,27 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_get_object(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await;
+        let entries = initialize_database(&client, 10).await.objects;
 
         let first = entries.first().unwrap();
         let builder = GetQueryBuilder::new(&client);
-        let result = builder.get_object(first.0.object_id).await.unwrap();
+        let result = builder.get_object(first.object_id).await.unwrap();
 
-        assert_eq!(result.as_ref(), Some(&first.0));
+        assert_eq!(result.as_ref(), Some(first));
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await;
+        let entries = initialize_database(&client, 10).await.s3_objects;
 
         let first = entries.first().unwrap();
         let builder = GetQueryBuilder::new(&client);
         let result = builder
-            .get_s3_object_by_id(first.1.s3_object_id)
+            .get_s3_object_by_id(first.s3_object_id)
             .await
             .unwrap();
 
-        assert_eq!(result.as_ref(), Some(&first.1));
+        assert_eq!(result.as_ref(), Some(first));
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -1,7 +1,7 @@
 //! Query builder involving list operations on the database.
 //!
 
-use sea_orm::{EntityTrait, FromQueryResult, PaginatorTrait, QueryOrder, QuerySelect, Select};
+use sea_orm::{EntityTrait, FromQueryResult, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, Select};
 
 use crate::database::entities::object::Entity as ObjectEntity;
 use crate::database::entities::s3_object::Column as S3Column;
@@ -9,6 +9,7 @@ use crate::database::entities::s3_object::Entity as S3ObjectEntity;
 use crate::database::Client;
 use crate::error::Error::OverflowError;
 use crate::error::{Error, Result};
+use crate::routes::filtering::ObjectsFilterByAll;
 use crate::routes::list::{ListCount, ListResponse};
 use crate::routes::pagination::Pagination;
 
@@ -49,6 +50,11 @@ impl<'a> ListQueryBuilder<'a, S3ObjectEntity> {
     /// Build a select query for finding values from s3 objects.
     pub fn build_object() -> Select<S3ObjectEntity> {
         S3ObjectEntity::find().order_by_asc(S3Column::Sequencer)
+    }
+    
+    pub async fn filter_all(mut self, filter: ObjectsFilterByAll) -> Self {
+        self.select.filter()
+        self
     }
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -9,7 +9,8 @@ use crate::database::entities::s3_object::Entity as S3ObjectEntity;
 use crate::database::Client;
 use crate::error::Error::OverflowError;
 use crate::error::{Error, Result};
-use crate::routes::list::{ListCount, ListResponse, Pagination};
+use crate::routes::list::{ListCount, ListResponse};
+use crate::routes::pagination::Pagination;
 
 /// A query builder for list operations.
 #[derive(Debug, Clone)]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -14,7 +14,7 @@ use crate::database::entities::s3_object::{Column as S3ObjectColumn, Column as O
 use crate::database::Client;
 use crate::error::Error::OverflowError;
 use crate::error::{Error, Result};
-use crate::routes::filtering::{ObjectsFilterByAll, S3ObjectsFilterByAll};
+use crate::routes::filtering::{ObjectsFilterAll, S3ObjectsFilterAll};
 use crate::routes::list::{ListCount, ListResponse};
 use crate::routes::pagination::Pagination;
 
@@ -43,7 +43,7 @@ impl<'a> ListQueryBuilder<'a, ObjectEntity> {
     }
 
     /// Filter records by all fields in the filter variable.
-    pub fn filter_all(mut self, filter: ObjectsFilterByAll) -> Self {
+    pub fn filter_all(mut self, filter: ObjectsFilterAll) -> Self {
         let condition = Condition::all().add_option(
             filter
                 .attributes
@@ -70,7 +70,7 @@ impl<'a> ListQueryBuilder<'a, S3ObjectEntity> {
     }
 
     /// Filter records by all fields in the filter variable.
-    pub fn filter_all(mut self, filter: S3ObjectsFilterByAll) -> Self {
+    pub fn filter_all(mut self, filter: S3ObjectsFilterAll) -> Self {
         let condition = Condition::all()
             .add_option(filter.event_type.map(|v| S3ObjectColumn::EventType.eq(v)))
             .add_option(filter.bucket.map(|v| S3ObjectColumn::Bucket.eq(v)))
@@ -173,8 +173,9 @@ mod tests {
     use sqlx::PgPool;
 
     use crate::database::aws::migration::tests::MIGRATOR;
+    use crate::database::entities::object::Model as ObjectModel;
+    use crate::database::entities::s3_object::Model as S3ObjectModel;
     use crate::database::entities::sea_orm_active_enums::EventType;
-    use crate::database::Client;
     use crate::queries::tests::{initialize_database, initialize_database_reorder};
 
     use super::*;
@@ -182,97 +183,64 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await;
+        let entries = initialize_database(&client, 10).await.objects;
 
         let builder = ListQueryBuilder::<ObjectEntity>::new(&client);
         let result = builder.all().await.unwrap();
 
-        assert_eq!(
-            result,
-            entries
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()
-        );
+        assert_eq!(result, entries);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_objects_filter_attributes(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await;
+        let entries = initialize_database(&client, 10).await.objects;
 
-        let builder = ListQueryBuilder::<ObjectEntity>::new(&client);
-
-        let result = builder
-            .clone()
-            .filter_all(ObjectsFilterByAll {
+        let result = filter_all_objects_from(
+            &client,
+            ObjectsFilterAll {
                 attributes: Some(json!({
                     "attribute_id": "1"
                 })),
-            })
-            .all()
-            .await
-            .unwrap();
-        assert_eq!(
-            result,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+            },
+        )
+        .await;
+        assert_eq!(result, vec![entries[1].clone()]);
 
-        let result = builder
-            .clone()
-            .filter_all(ObjectsFilterByAll {
+        let result = filter_all_objects_from(
+            &client,
+            ObjectsFilterAll {
                 attributes: Some(json!({
                     "nested_id": {
                         "attribute_id": "1"
                     }
                 })),
-            })
-            .all()
-            .await
-            .unwrap();
-        assert_eq!(
-            result,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+            },
+        )
+        .await;
+        assert_eq!(result, vec![entries[1].clone()]);
 
-        let result = builder
-            .filter_all(ObjectsFilterByAll {
+        let result = filter_all_objects_from(
+            &client,
+            ObjectsFilterAll {
                 attributes: Some(json!({
                     "non_existent_id": "1"
                 })),
-            })
-            .all()
-            .await
-            .unwrap();
+            },
+        )
+        .await;
         assert!(result.is_empty());
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_paginate_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await;
+        let entries = initialize_database(&client, 10).await.objects;
 
         let builder = ListQueryBuilder::<ObjectEntity>::new(&client);
 
         let result = paginate_all(builder.clone(), 3, 3).await;
-        assert_eq!(
-            result,
-            &entries
-                .clone()
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()[9..]
-        );
+        assert_eq!(result, entries[9..]);
         // Empty result when paginating above the collection size.
         assert!(paginate_all(builder.clone(), 10, 2).await.is_empty());
 
@@ -282,53 +250,38 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.next_page(), Some(1));
-        assert_eq!(
-            result.results(),
-            &entries
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()[0..2]
-        );
+        assert_eq!(result.results(), &entries[0..2]);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await;
+        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
 
         let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client);
         let result = builder.all().await.unwrap();
 
-        assert_eq!(
-            result,
-            entries
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()
-        );
+        assert_eq!(result, entries);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects_filter_event_type(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await;
+        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
 
-        let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client);
-        let result = builder
-            .filter_all(S3ObjectsFilterByAll {
+        let result = filter_all_s3_objects_from(
+            &client,
+            S3ObjectsFilterAll {
                 event_type: Some(EventType::Created),
                 ..Default::default()
-            })
-            .all()
-            .await
-            .unwrap();
-
+            },
+        )
+        .await;
         assert_eq!(result.len(), 5);
         assert_eq!(
             result,
             entries
                 .into_iter()
-                .map(|(_, entry)| entry)
                 .filter(|entry| entry.event_type == EventType::Created)
                 .collect::<Vec<_>>()
         );
@@ -337,144 +290,99 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects_multiple_filters(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await;
+        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
 
-        let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client);
-        let result = builder
-            .filter_all(S3ObjectsFilterByAll {
+        let result = filter_all_s3_objects_from(
+            &client,
+            S3ObjectsFilterAll {
                 bucket: Some("0".to_string()),
                 key: Some("1".to_string()),
                 ..Default::default()
-            })
-            .all()
-            .await
-            .unwrap();
-
-        assert_eq!(
-            result,
-            vec![entries
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+            },
+        )
+        .await;
+        assert_eq!(result, vec![entries[1].clone()]);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects_filter_attributes(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await;
+        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
 
-        let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client);
-
-        let result = builder
-            .clone()
-            .filter_all(S3ObjectsFilterByAll {
+        let result = filter_all_s3_objects_from(
+            &client,
+            S3ObjectsFilterAll {
                 attributes: Some(json!({
                     "attribute_id": "1"
                 })),
                 ..Default::default()
-            })
-            .all()
-            .await
-            .unwrap();
-        assert_eq!(
-            result,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+            },
+        )
+        .await;
+        assert_eq!(result, vec![entries[1].clone()]);
 
-        let result = builder
-            .clone()
-            .filter_all(S3ObjectsFilterByAll {
+        let result = filter_all_s3_objects_from(
+            &client,
+            S3ObjectsFilterAll {
                 attributes: Some(json!({
                     "nested_id": {
-                        "attribute_id": "1"
+                        "attribute_id": "2"
                     }
                 })),
                 ..Default::default()
-            })
-            .all()
-            .await
-            .unwrap();
-        assert_eq!(
-            result,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+            },
+        )
+        .await;
+        assert_eq!(result, vec![entries[2].clone()]);
 
-        let result = builder
-            .clone()
-            .filter_all(S3ObjectsFilterByAll {
+        let result = filter_all_s3_objects_from(
+            &client,
+            S3ObjectsFilterAll {
                 attributes: Some(json!({
                     "non_existent_id": "1"
                 })),
                 ..Default::default()
-            })
-            .all()
-            .await
-            .unwrap();
+            },
+        )
+        .await;
         assert!(result.is_empty());
 
-        let result = builder
-            .clone()
-            .filter_all(S3ObjectsFilterByAll {
+        let result = filter_all_s3_objects_from(
+            &client,
+            S3ObjectsFilterAll {
                 attributes: Some(json!({
                     "attribute_id": "1"
                 })),
                 key: Some("2".to_string()),
                 ..Default::default()
-            })
-            .all()
-            .await
-            .unwrap();
+            },
+        )
+        .await;
         assert!(result.is_empty());
 
-        let result = builder
-            .filter_all(S3ObjectsFilterByAll {
+        let result = filter_all_s3_objects_from(
+            &client,
+            S3ObjectsFilterAll {
                 attributes: Some(json!({
-                    "attribute_id": "1"
+                    "attribute_id": "3"
                 })),
-                key: Some("1".to_string()),
+                key: Some("3".to_string()),
                 ..Default::default()
-            })
-            .all()
-            .await
-            .unwrap();
-        assert_eq!(
-            result,
-            vec![entries
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+            },
+        )
+        .await;
+        assert_eq!(result, vec![entries[3].clone()]);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_paginate_s3_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await;
+        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
 
         let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client);
 
         let result = paginate_all(builder.clone(), 3, 3).await;
-        assert_eq!(
-            result,
-            &entries
-                .clone()
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[9..]
-        );
+        assert_eq!(result, entries[9..]);
         // Empty result when paginating above the collection size.
         assert!(paginate_all(builder.clone(), 10, 2).await.is_empty());
 
@@ -484,13 +392,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.next_page(), Some(1));
-        assert_eq!(
-            result.results(),
-            &entries
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[0..2]
-        );
+        assert_eq!(result.results(), &entries[0..2]);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -531,5 +433,23 @@ mod tests {
             .all()
             .await
             .unwrap()
+    }
+
+    async fn filter_all_objects_from(
+        client: &Client,
+        filter: ObjectsFilterAll,
+    ) -> Vec<ObjectModel> {
+        let builder = ListQueryBuilder::<ObjectEntity>::new(client);
+
+        builder.clone().filter_all(filter).all().await.unwrap()
+    }
+
+    async fn filter_all_s3_objects_from(
+        client: &Client,
+        filter: S3ObjectsFilterAll,
+    ) -> Vec<S3ObjectModel> {
+        let builder = ListQueryBuilder::<S3ObjectEntity>::new(client);
+
+        builder.clone().filter_all(filter).all().await.unwrap()
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod tests {
     use rand::thread_rng;
     use sea_orm::Set;
     use sea_orm::{ActiveModelTrait, TryIntoModel};
+    use serde_json::json;
     use strum::EnumCount;
 
     use crate::database::entities::object::ActiveModel as ActiveObject;
@@ -80,11 +81,17 @@ pub(crate) mod tests {
         let object_id = UuidGenerator::generate();
         let event = event_type(index);
         let date = || Set(Some(DateTime::default().add(Days::new(index as u64))));
+        let attributes = Some(json!({
+            "attribute_id": format!("{}", index),
+            "nested_id": {
+                "attribute_id": format!("{}", index)
+            }
+        }));
 
         (
             ActiveObject {
                 object_id: Set(object_id),
-                attributes: Set(None),
+                attributes: Set(attributes.clone()),
             },
             ActiveS3Object {
                 s3_object_id: Set(UuidGenerator::generate()),
@@ -104,7 +111,7 @@ pub(crate) mod tests {
                 sequencer: Set(Some(index.to_string())),
                 is_delete_marker: Set(false),
                 number_duplicate_events: Set(0),
-                attributes: Set(None),
+                attributes: Set(attributes),
                 deleted_date: if event == EventType::Deleted {
                     date()
                 } else {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filtering.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filtering.rs
@@ -14,41 +14,41 @@ use utoipa::{IntoParams, ToSchema};
 pub struct S3ObjectsFilterByAll {
     #[param(nullable)]
     /// Query by event type.
-    event_type: Option<EventType>,
+    pub(crate) event_type: Option<EventType>,
     #[param(nullable)]
     /// Query by bucket.
-    bucket: Option<String>,
+    pub(crate) bucket: Option<String>,
     #[param(nullable)]
     /// Query by key.
-    key: Option<String>,
+    pub(crate) key: Option<String>,
     #[param(nullable)]
     /// Query by version_id.
-    version_id: Option<String>,
+    pub(crate) version_id: Option<String>,
     #[param(nullable)]
     /// Query by date.
-    date: Option<DateTimeWithTimeZone>,
+    pub(crate) date: Option<DateTimeWithTimeZone>,
     #[param(nullable)]
     /// Query by size.
-    size: Option<i64>,
+    pub(crate) size: Option<i64>,
     #[param(nullable)]
     /// Query by the sha256 checksum.
-    sha256: Option<String>,
+    pub(crate) sha256: Option<String>,
     #[param(nullable)]
     /// Query by the last modified date.
-    last_modified_date: Option<DateTimeWithTimeZone>,
+    pub(crate) last_modified_date: Option<DateTimeWithTimeZone>,
     #[param(nullable)]
     /// Query by the e_tag.
-    e_tag: Option<String>,
+    pub(crate) e_tag: Option<String>,
     #[param(nullable)]
     /// Query by the storage class.
-    storage_class: Option<StorageClass>,
+    pub(crate) storage_class: Option<StorageClass>,
     #[param(nullable)]
     /// Query by the object delete marker.
-    is_delete_marker: bool,
+    pub(crate) is_delete_marker: Option<bool>,
     #[param(nullable)]
     /// Query by JSON attributes. Supports nested syntax to access inner
     /// fields, e.g. `?attributes[attribute_id]=...`
-    attributes: Option<Json>
+    pub(crate) attributes: Option<Json>,
 }
 
 /// The available fields to filter `object` queries by. Each query parameter represents
@@ -60,5 +60,5 @@ pub struct ObjectsFilterByAll {
     #[param(nullable)]
     /// Query by JSON attributes. Supports nested syntax to access inner
     /// fields, e.g. `?attributes[attribute_id]=...`
-    attributes: Option<Json>
+    pub(crate) attributes: Option<Json>,
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filtering.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filtering.rs
@@ -11,43 +11,47 @@ use utoipa::{IntoParams, ToSchema};
 /// JSON attributes.
 #[derive(Serialize, Deserialize, Debug, Default, IntoParams, ToSchema)]
 #[serde(default)]
-pub struct S3ObjectsFilterByAll {
-    #[param(nullable)]
+#[into_params(parameter_in = Query)]
+pub struct S3ObjectsFilterAll {
+    #[param(required = false)]
     /// Query by event type.
     pub(crate) event_type: Option<EventType>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by bucket.
     pub(crate) bucket: Option<String>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by key.
     pub(crate) key: Option<String>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by version_id.
     pub(crate) version_id: Option<String>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by date.
     pub(crate) date: Option<DateTimeWithTimeZone>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by size.
     pub(crate) size: Option<i64>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by the sha256 checksum.
     pub(crate) sha256: Option<String>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by the last modified date.
     pub(crate) last_modified_date: Option<DateTimeWithTimeZone>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by the e_tag.
     pub(crate) e_tag: Option<String>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by the storage class.
     pub(crate) storage_class: Option<StorageClass>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by the object delete marker.
     pub(crate) is_delete_marker: Option<bool>,
-    #[param(nullable)]
+    #[param(required = false)]
     /// Query by JSON attributes. Supports nested syntax to access inner
-    /// fields, e.g. `?attributes[attribute_id]=...`
+    /// fields, e.g. `attributes[attribute_id]=...`. This only deserializes
+    /// into string fields, and does not support other JSON types. E.g.
+    /// `attributes[attribute_id]=1` converts to `{ "attribute_id" = "1" }`
+    /// rather than `{ "attribute_id" = 1 }`.
     pub(crate) attributes: Option<Json>,
 }
 
@@ -56,9 +60,13 @@ pub struct S3ObjectsFilterByAll {
 /// JSON attributes.
 #[derive(Serialize, Deserialize, Debug, Default, IntoParams, ToSchema)]
 #[serde(default)]
-pub struct ObjectsFilterByAll {
-    #[param(nullable)]
+#[into_params(parameter_in = Query)]
+pub struct ObjectsFilterAll {
+    #[param(required = false)]
     /// Query by JSON attributes. Supports nested syntax to access inner
-    /// fields, e.g. `?attributes[attribute_id]=...`
+    /// fields, e.g. `attributes[attribute_id]=...`. This only deserializes
+    /// into string fields, and does not support other JSON types. E.g.
+    /// `attributes[attribute_id]=1` converts to `{ "attribute_id" = "1" }`
+    /// rather than `{ "attribute_id" = 1 }`.
     pub(crate) attributes: Option<Json>,
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filtering.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filtering.rs
@@ -1,0 +1,64 @@
+//! API filtering related query logic.
+//!
+
+use crate::database::entities::sea_orm_active_enums::{EventType, StorageClass};
+use sea_orm::prelude::{DateTimeWithTimeZone, Json};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+/// The available fields to filter `s3_object` queries by. Each query parameter represents
+/// an `and` clause in the SQL statement. Nested query string style syntax is supported on
+/// JSON attributes.
+#[derive(Serialize, Deserialize, Debug, Default, IntoParams, ToSchema)]
+#[serde(default)]
+pub struct S3ObjectsFilterByAll {
+    #[param(nullable)]
+    /// Query by event type.
+    event_type: Option<EventType>,
+    #[param(nullable)]
+    /// Query by bucket.
+    bucket: Option<String>,
+    #[param(nullable)]
+    /// Query by key.
+    key: Option<String>,
+    #[param(nullable)]
+    /// Query by version_id.
+    version_id: Option<String>,
+    #[param(nullable)]
+    /// Query by date.
+    date: Option<DateTimeWithTimeZone>,
+    #[param(nullable)]
+    /// Query by size.
+    size: Option<i64>,
+    #[param(nullable)]
+    /// Query by the sha256 checksum.
+    sha256: Option<String>,
+    #[param(nullable)]
+    /// Query by the last modified date.
+    last_modified_date: Option<DateTimeWithTimeZone>,
+    #[param(nullable)]
+    /// Query by the e_tag.
+    e_tag: Option<String>,
+    #[param(nullable)]
+    /// Query by the storage class.
+    storage_class: Option<StorageClass>,
+    #[param(nullable)]
+    /// Query by the object delete marker.
+    is_delete_marker: bool,
+    #[param(nullable)]
+    /// Query by JSON attributes. Supports nested syntax to access inner
+    /// fields, e.g. `?attributes[attribute_id]=...`
+    attributes: Option<Json>
+}
+
+/// The available fields to filter `object` queries by. Each query parameter represents
+/// an `and` clause in the SQL statement. Nested query string style syntax is supported on
+/// JSON attributes.
+#[derive(Serialize, Deserialize, Debug, Default, IntoParams, ToSchema)]
+#[serde(default)]
+pub struct ObjectsFilterByAll {
+    #[param(nullable)]
+    /// Query by JSON attributes. Supports nested syntax to access inner
+    /// fields, e.g. `?attributes[attribute_id]=...`
+    attributes: Option<Json>
+}

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -4,6 +4,7 @@
 use axum::extract::{Query, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
+use serde_qs::axum::QsQuery;
 use utoipa::ToSchema;
 
 use crate::database::entities::object::Entity as ObjectEntity;
@@ -12,6 +13,7 @@ use crate::database::entities::s3_object::Entity as S3ObjectEntity;
 use crate::database::entities::s3_object::Model as FileS3Object;
 use crate::error::Result;
 use crate::queries::list::ListQueryBuilder;
+use crate::routes::filtering::{ObjectsFilterByAll, S3ObjectsFilterByAll};
 use crate::routes::pagination::Pagination;
 use crate::routes::{AppState, ErrorStatusCode};
 
@@ -75,12 +77,13 @@ impl<M> ListResponse<M> {
         (status = OK, description = "List all objects", body = Vec<FileObject>),
         ErrorStatusCode,
     ),
-    params(Pagination),
+    params(Pagination, ObjectsFilterByAll),
     context_path = "/api/v1",
 )]
 pub async fn list_objects(
     state: State<AppState>,
     Query(pagination): Query<Pagination>,
+    QsQuery(filter_by_all): QsQuery<ObjectsFilterByAll>,
 ) -> Result<Json<ListResponse<FileObject>>> {
     let response = ListQueryBuilder::<ObjectEntity>::new(&state.client)
         .paginate_to_list_response(pagination)
@@ -119,12 +122,13 @@ pub struct ListS3ObjectsParams {}
         (status = OK, description = "List all s3 objects", body = Vec<FileS3Object>),
         ErrorStatusCode,
     ),
-    params(Pagination),
+    params(Pagination, S3ObjectsFilterByAll),
     context_path = "/api/v1",
 )]
 pub async fn list_s3_objects(
     state: State<AppState>,
     Query(pagination): Query<Pagination>,
+    QsQuery(filter_by_all): QsQuery<S3ObjectsFilterByAll>,
 ) -> Result<Json<ListResponse<FileS3Object>>> {
     let response = ListQueryBuilder::<S3ObjectEntity>::new(&state.client)
         .paginate_to_list_response(pagination)

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -13,7 +13,7 @@ use crate::database::entities::s3_object::Entity as S3ObjectEntity;
 use crate::database::entities::s3_object::Model as FileS3Object;
 use crate::error::Result;
 use crate::queries::list::ListQueryBuilder;
-use crate::routes::filtering::{ObjectsFilterByAll, S3ObjectsFilterByAll};
+use crate::routes::filtering::{ObjectsFilterAll, S3ObjectsFilterAll};
 use crate::routes::pagination::Pagination;
 use crate::routes::{AppState, ErrorStatusCode};
 
@@ -77,16 +77,16 @@ impl<M> ListResponse<M> {
         (status = OK, description = "List all objects", body = Vec<FileObject>),
         ErrorStatusCode,
     ),
-    params(Pagination, ObjectsFilterByAll),
+    params(Pagination, ObjectsFilterAll),
     context_path = "/api/v1",
 )]
 pub async fn list_objects(
     state: State<AppState>,
     Query(pagination): Query<Pagination>,
-    QsQuery(filter_by_all): QsQuery<ObjectsFilterByAll>,
+    QsQuery(filter_all): QsQuery<ObjectsFilterAll>,
 ) -> Result<Json<ListResponse<FileObject>>> {
     let response = ListQueryBuilder::<ObjectEntity>::new(&state.client)
-        .filter_all(filter_by_all)
+        .filter_all(filter_all)
         .paginate_to_list_response(pagination)
         .await?;
 
@@ -123,16 +123,16 @@ pub struct ListS3ObjectsParams {}
         (status = OK, description = "List all s3 objects", body = Vec<FileS3Object>),
         ErrorStatusCode,
     ),
-    params(Pagination, S3ObjectsFilterByAll),
+    params(Pagination, S3ObjectsFilterAll),
     context_path = "/api/v1",
 )]
 pub async fn list_s3_objects(
     state: State<AppState>,
     Query(pagination): Query<Pagination>,
-    QsQuery(filter_by_all): QsQuery<S3ObjectsFilterByAll>,
+    QsQuery(filter_all): QsQuery<S3ObjectsFilterAll>,
 ) -> Result<Json<ListResponse<FileS3Object>>> {
     let response = ListQueryBuilder::<S3ObjectEntity>::new(&state.client)
-        .filter_all(filter_by_all)
+        .filter_all(filter_all)
         .paginate_to_list_response(pagination)
         .await?;
 
@@ -158,11 +158,11 @@ pub async fn count_s3_objects(state: State<AppState>) -> Result<Json<ListCount>>
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use axum::body::to_bytes;
     use axum::body::Body;
     use axum::http::Request;
-    use parquet::data_type::AsBytes;
+    use serde::de::DeserializeOwned;
     use serde_json::from_slice;
     use sqlx::PgPool;
     use tower::ServiceExt;
@@ -172,188 +172,65 @@ mod tests {
     use crate::database::entities::s3_object::Model as S3Object;
     use crate::database::entities::sea_orm_active_enums::EventType;
     use crate::queries::tests::{initialize_database, initialize_database_reorder};
-    use crate::routes::list::{ListCount, ListResponse};
-    use crate::routes::{api_router, AppState};
+    use crate::routes::api_router;
+
+    use super::*;
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_objects_api(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
+        let entries = initialize_database(state.client(), 10).await.objects;
 
-        let app = api_router(state);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/objects")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let result = from_slice::<ListResponse<Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
+        let result: ListResponse<Object> = response_from(state, "/objects").await;
         assert!(result.next_page.is_none());
-        assert_eq!(
-            result.results,
-            entries
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()
-        );
+        assert_eq!(result.results, entries);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_objects_api_filter_attributes(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
+        let entries = initialize_database(state.client(), 10).await.objects;
 
-        let app = api_router(state);
+        let result: ListResponse<Object> =
+            response_from(state.clone(), "/objects?attributes[attribute_id]=1").await;
+        assert_eq!(result.results, vec![entries[1].clone()]);
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/objects?attributes[attribute_id]=1")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
+        let result: ListResponse<Object> = response_from(
+            state.clone(),
+            "/objects?attributes[nested_id][attribute_id]=2",
         )
-        .unwrap();
-        assert_eq!(
-            result.results,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+        .await;
+        assert_eq!(result.results, vec![entries[2].clone()]);
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/objects?attributes[nested_id][attribute_id]=1")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-        assert_eq!(
-            result.results,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/objects?attributes[non_existent_id]=1")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
+        let result: ListResponse<Object> =
+            response_from(state.clone(), "/objects?attributes[non_existent_id]=1").await;
         assert!(result.results.is_empty());
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_api(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database_reorder(state.client(), 10).await;
-
-        let app = api_router(state);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+        let entries = initialize_database_reorder(state.client(), 10)
             .await
-            .unwrap();
+            .s3_objects;
 
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
+        let result: ListResponse<S3Object> = response_from(state, "/s3_objects").await;
         assert!(result.next_page.is_none());
-        assert_eq!(
-            result.results,
-            entries
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()
-        );
+        assert_eq!(result.results, entries);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_filter_event_type(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
+        let entries = initialize_database(state.client(), 10).await.s3_objects;
 
-        let app = api_router(state);
-
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?event_type=Deleted")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
+        let result: ListResponse<S3Object> =
+            response_from(state, "/s3_objects?event_type=Deleted").await;
         assert_eq!(result.results().len(), 5);
         assert_eq!(
             result.results,
             entries
                 .into_iter()
-                .map(|(_, entry)| entry)
                 .filter(|entry| entry.event_type == EventType::Deleted)
                 .collect::<Vec<_>>()
         );
@@ -362,162 +239,43 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_multiple_filters(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
+        let entries = initialize_database(state.client(), 10).await.s3_objects;
 
-        let app = api_router(state);
-
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?bucket=1&key=2")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-        assert_eq!(
-            result.results,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[2]
-                .clone()]
-        );
+        let result: ListResponse<S3Object> =
+            response_from(state, "/s3_objects?bucket=1&key=2").await;
+        assert_eq!(result.results, vec![entries[2].clone()]);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_filter_attributes(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
+        let entries = initialize_database(state.client(), 10).await.s3_objects;
 
-        let app = api_router(state);
+        let result: ListResponse<S3Object> =
+            response_from(state.clone(), "/s3_objects?attributes[attribute_id]=1").await;
+        assert_eq!(result.results, vec![entries[1].clone()]);
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?attributes[attribute_id]=1")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
+        let result: ListResponse<S3Object> = response_from(
+            state.clone(),
+            "/s3_objects?attributes[nested_id][attribute_id]=4",
         )
-        .unwrap();
-        assert_eq!(
-            result.results,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+        .await;
+        assert_eq!(result.results, vec![entries[4].clone()]);
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?attributes[nested_id][attribute_id]=1")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-        assert_eq!(
-            result.results,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
-
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?attributes[non_existent_id]=1")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
+        let result: ListResponse<S3Object> =
+            response_from(state.clone(), "/s3_objects?attributes[non_existent_id]=1").await;
         assert!(result.results.is_empty());
 
-        let response = app
-            .clone()
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?attributes[attribute_id]=1&key=2")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
+        let result: ListResponse<S3Object> = response_from(
+            state.clone(),
+            "/s3_objects?attributes[attribute_id]=1&key=2",
         )
-        .unwrap();
+        .await;
         assert!(result.results.is_empty());
 
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?attributes[attribute_id]=1&key=1")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-        assert_eq!(
-            result.results,
-            vec![entries
-                .clone()
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[1]
-                .clone()]
-        );
+        let result: ListResponse<S3Object> =
+            response_from(state, "/s3_objects?attributes[attribute_id]=1&key=1").await;
+        assert_eq!(result.results, vec![entries[1].clone()]);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -525,25 +283,7 @@ mod tests {
         let state = AppState::from_pool(pool);
         initialize_database(state.client(), 10).await;
 
-        let app = api_router(state);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/objects/count")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let result = from_slice::<ListCount>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
+        let result: ListCount = response_from(state, "/objects/count").await;
         assert_eq!(result.n_records, 10);
     }
 
@@ -552,25 +292,21 @@ mod tests {
         let state = AppState::from_pool(pool);
         initialize_database(state.client(), 10).await;
 
+        let result: ListCount = response_from(state, "/s3_objects/count").await;
+        assert_eq!(result.n_records, 10);
+    }
+
+    pub(crate) async fn response_from<T: DeserializeOwned>(state: AppState, uri: &str) -> T {
         let app = api_router(state);
         let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects/count")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
             .await
             .unwrap();
 
-        let result = from_slice::<ListCount>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
-        assert_eq!(result.n_records, 10);
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap()
+            .to_vec();
+        from_slice::<T>(bytes.as_slice()).unwrap()
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -86,6 +86,8 @@ pub async fn list_objects(
     QsQuery(filter_by_all): QsQuery<ObjectsFilterByAll>,
 ) -> Result<Json<ListResponse<FileObject>>> {
     let response = ListQueryBuilder::<ObjectEntity>::new(&state.client)
+        .filter_all(filter_by_all)
+        .await
         .paginate_to_list_response(pagination)
         .await?;
 
@@ -131,6 +133,8 @@ pub async fn list_s3_objects(
     QsQuery(filter_by_all): QsQuery<S3ObjectsFilterByAll>,
 ) -> Result<Json<ListResponse<FileS3Object>>> {
     let response = ListQueryBuilder::<S3ObjectEntity>::new(&state.client)
+        .filter_all(filter_by_all)
+        .await
         .paginate_to_list_response(pagination)
         .await?;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -3,9 +3,8 @@
 
 use axum::extract::{Query, State};
 use axum::Json;
-use serde::{Deserialize, Deserializer, Serialize};
-use std::result;
-use utoipa::{IntoParams, ToSchema};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::database::entities::object::Entity as ObjectEntity;
 use crate::database::entities::object::Model as FileObject;
@@ -13,6 +12,7 @@ use crate::database::entities::s3_object::Entity as S3ObjectEntity;
 use crate::database::entities::s3_object::Model as FileS3Object;
 use crate::error::Result;
 use crate::queries::list::ListQueryBuilder;
+use crate::routes::pagination::Pagination;
 use crate::routes::{AppState, ErrorStatusCode};
 
 /// The return value for count operations showing the number of records in the database.
@@ -37,55 +37,6 @@ impl ListCount {
 /// Params for a list objects request.
 #[derive(Debug, Deserialize)]
 pub struct ListObjectsParams {}
-
-/// Pagination query parameters for list operations.
-#[derive(Debug, Deserialize, IntoParams)]
-#[serde(default)]
-pub struct Pagination {
-    /// The zero-indexed page to fetch from the list of objects.
-    /// Increments by 1 starting from 0.
-    /// Defaults to the beginning of the collection.
-    #[param(nullable, default = 0)]
-    page: u64,
-    /// The page to fetch from the list of objects.
-    /// If this is zero then the default is used.
-    #[param(nullable, default = 1000)]
-    #[serde(deserialize_with = "deserialize_zero_page_as_default")]
-    page_size: u64,
-}
-
-impl Pagination {
-    /// Create a new pagination struct.
-    pub fn new(page: u64, page_size: u64) -> Self {
-        Self { page, page_size }
-    }
-
-    /// Get the page.
-    pub fn page(&self) -> u64 {
-        self.page
-    }
-
-    /// Get the page size.
-    pub fn page_size(&self) -> u64 {
-        self.page_size
-    }
-}
-
-/// The default page size.
-const DEFAULT_PAGE_SIZE: u64 = 1000;
-
-/// Deserializer to convert a 0 value to the default pagination size.
-fn deserialize_zero_page_as_default<'de, D>(deserializer: D) -> result::Result<u64, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let value: u64 = Deserialize::deserialize(deserializer)?;
-    if value == 0 {
-        Ok(DEFAULT_PAGE_SIZE)
-    } else {
-        Ok(value)
-    }
-}
 
 /// The response type for list operations.
 #[derive(Debug, Deserialize, Serialize, ToSchema, Eq, PartialEq)]
@@ -113,15 +64,6 @@ impl<M> ListResponse<M> {
     /// Get the next page.
     pub fn next_page(&self) -> Option<u64> {
         self.next_page
-    }
-}
-
-impl Default for Pagination {
-    fn default() -> Self {
-        Self {
-            page: 0,
-            page_size: DEFAULT_PAGE_SIZE,
-        }
     }
 }
 
@@ -261,74 +203,6 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
-    async fn list_objects_api_paginate(pool: PgPool) {
-        let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
-
-        let app = api_router(state);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/objects?page=2&page_size=2")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let result = from_slice::<ListResponse<Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
-        assert_eq!(result.next_page, Some(3));
-        assert_eq!(
-            result.results,
-            entries
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()[4..6]
-        );
-    }
-
-    #[sqlx::test(migrator = "MIGRATOR")]
-    async fn list_objects_api_zero_page_size(pool: PgPool) {
-        let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await;
-
-        let app = api_router(state);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?page_size=0")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let result = from_slice::<ListResponse<Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
-        assert_eq!(result.next_page, None);
-        assert_eq!(
-            result.results,
-            entries
-                .into_iter()
-                .map(|(entry, _)| entry)
-                .collect::<Vec<_>>()
-        );
-    }
-
-    #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_api(pool: PgPool) {
         let state = AppState::from_pool(pool);
         let entries = initialize_database_reorder(state.client(), 10).await;
@@ -353,74 +227,6 @@ mod tests {
         .unwrap();
 
         assert!(result.next_page.is_none());
-        assert_eq!(
-            result.results,
-            entries
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()
-        );
-    }
-
-    #[sqlx::test(migrator = "MIGRATOR")]
-    async fn list_s3_objects_api_paginate(pool: PgPool) {
-        let state = AppState::from_pool(pool);
-        let entries = initialize_database_reorder(state.client(), 10).await;
-
-        let app = api_router(state);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?page=1&page_size=2")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
-        assert_eq!(result.next_page, Some(2));
-        assert_eq!(
-            result.results,
-            entries
-                .into_iter()
-                .map(|(_, entry)| entry)
-                .collect::<Vec<_>>()[2..4]
-        );
-    }
-
-    #[sqlx::test(migrator = "MIGRATOR")]
-    async fn list_s3_objects_api_zero_page_size(pool: PgPool) {
-        let state = AppState::from_pool(pool);
-        let entries = initialize_database_reorder(state.client(), 10).await;
-
-        let app = api_router(state);
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/s3_objects?page_size=0")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        let result = from_slice::<ListResponse<S3Object>>(
-            to_bytes(response.into_body(), usize::MAX)
-                .await
-                .unwrap()
-                .as_bytes(),
-        )
-        .unwrap();
-
-        assert_eq!(result.next_page, None);
         assert_eq!(
             result.results,
             entries

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
@@ -21,9 +21,10 @@ use crate::routes::list::*;
 use crate::routes::openapi::swagger_ui;
 
 pub mod get;
-mod ingest;
+pub mod ingest;
 pub mod list;
 pub mod openapi;
+pub mod pagination;
 
 /// App state containing database client.
 #[derive(Debug, Clone)]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
@@ -20,6 +20,7 @@ use crate::routes::ingest::ingest_from_sqs;
 use crate::routes::list::*;
 use crate::routes::openapi::swagger_ui;
 
+pub mod filtering;
 pub mod get;
 pub mod ingest;
 pub mod list;

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -50,7 +50,7 @@ pub struct Json(pub Value);
             DateTimeWithTimeZone,
             Json,
             ListResponseObject,
-            ListResponseS3Object
+            ListResponseS3Object,
         )
     ),
     modifiers(&SecurityAddon),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
@@ -2,10 +2,10 @@
 //!
 
 use serde::{Deserialize, Deserializer};
-use utoipa::IntoParams;
+use utoipa::{IntoParams, ToSchema};
 
 /// Pagination query parameters for list operations.
-#[derive(Debug, Deserialize, IntoParams)]
+#[derive(Debug, Deserialize, IntoParams, ToSchema)]
 #[serde(default)]
 pub struct Pagination {
     /// The zero-indexed page to fetch from the list of objects.

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
@@ -1,0 +1,217 @@
+//! Pagination structs and logic for API routes.
+//!
+
+use serde::{Deserialize, Deserializer};
+use utoipa::IntoParams;
+
+/// Pagination query parameters for list operations.
+#[derive(Debug, Deserialize, IntoParams)]
+#[serde(default)]
+pub struct Pagination {
+    /// The zero-indexed page to fetch from the list of objects.
+    /// Increments by 1 starting from 0.
+    /// Defaults to the beginning of the collection.
+    #[param(nullable, default = 0)]
+    page: u64,
+    /// The page to fetch from the list of objects.
+    /// If this is zero then the default is used.
+    #[param(nullable, default = 1000)]
+    #[serde(deserialize_with = "deserialize_zero_page_as_default")]
+    page_size: u64,
+}
+
+impl Pagination {
+    /// Create a new pagination struct.
+    pub fn new(page: u64, page_size: u64) -> Self {
+        Self { page, page_size }
+    }
+
+    /// Get the page.
+    pub fn page(&self) -> u64 {
+        self.page
+    }
+
+    /// Get the page size.
+    pub fn page_size(&self) -> u64 {
+        self.page_size
+    }
+}
+
+/// The default page size.
+const DEFAULT_PAGE_SIZE: u64 = 1000;
+
+/// Deserializer to convert a 0 value to the default pagination size.
+fn deserialize_zero_page_as_default<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value: u64 = Deserialize::deserialize(deserializer)?;
+    if value == 0 {
+        Ok(DEFAULT_PAGE_SIZE)
+    } else {
+        Ok(value)
+    }
+}
+
+impl Default for Pagination {
+    fn default() -> Self {
+        Self {
+            page: 0,
+            page_size: DEFAULT_PAGE_SIZE,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::to_bytes;
+    use axum::body::Body;
+    use axum::http::Request;
+    use parquet::data_type::AsBytes;
+    use serde_json::from_slice;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+
+    use crate::database::aws::migration::tests::MIGRATOR;
+    use crate::database::entities::object::Model as Object;
+    use crate::database::entities::s3_object::Model as S3Object;
+    use crate::queries::tests::{initialize_database, initialize_database_reorder};
+    use crate::routes::list::ListResponse;
+    use crate::routes::{api_router, AppState};
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn list_objects_api_paginate(pool: PgPool) {
+        let state = AppState::from_pool(pool);
+        let entries = initialize_database(state.client(), 10).await;
+
+        let app = api_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/objects?page=2&page_size=2")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let result = from_slice::<ListResponse<Object>>(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(result.next_page(), Some(3));
+        assert_eq!(
+            result.results(),
+            &entries
+                .into_iter()
+                .map(|(entry, _)| entry)
+                .collect::<Vec<_>>()[4..6]
+        );
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn list_objects_api_zero_page_size(pool: PgPool) {
+        let state = AppState::from_pool(pool);
+        let entries = initialize_database(state.client(), 10).await;
+
+        let app = api_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/s3_objects?page_size=0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let result = from_slice::<ListResponse<Object>>(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(result.next_page(), None);
+        assert_eq!(
+            result.results(),
+            entries
+                .into_iter()
+                .map(|(entry, _)| entry)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn list_s3_objects_api_paginate(pool: PgPool) {
+        let state = AppState::from_pool(pool);
+        let entries = initialize_database_reorder(state.client(), 10).await;
+
+        let app = api_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/s3_objects?page=1&page_size=2")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let result = from_slice::<ListResponse<S3Object>>(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(result.next_page(), Some(2));
+        assert_eq!(
+            result.results(),
+            &entries
+                .into_iter()
+                .map(|(_, entry)| entry)
+                .collect::<Vec<_>>()[2..4]
+        );
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn list_s3_objects_api_zero_page_size(pool: PgPool) {
+        let state = AppState::from_pool(pool);
+        let entries = initialize_database_reorder(state.client(), 10).await;
+
+        let app = api_router(state);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/s3_objects?page_size=0")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let result = from_slice::<ListResponse<S3Object>>(
+            to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+
+        assert_eq!(result.next_page(), None);
+        assert_eq!(
+            result.results(),
+            entries
+                .into_iter()
+                .map(|(_, entry)| entry)
+                .collect::<Vec<_>>()
+        );
+    }
+}


### PR DESCRIPTION
Closes #407 

### Changes
* Adds query parameter filtering on most columns for list operations on objects.
* Adds JSON contains operation for attributes which can be accessed using nested notation, e.g: `attributes[attribute_id]=id`.
    * This uses https://github.com/samscott89/serde_qs and has similar syntax to https://github.com/ljharb/qs.
* Move `Pagination` to its own module to avoid a large `list.rs` file.
* Refactor tests to reduce code duplication.