### PR TITLE
feat: filemanager current state

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -241,7 +241,6 @@ where
     }
 
     fn trace_query(&self, message: &str) {
-        println!("{}", self.select.as_query().to_string(PostgresQueryBuilder));
         trace!(
             "{message}: {}",
             self.select.as_query().to_string(PostgresQueryBuilder)

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -5,7 +5,7 @@ use axum::extract::{Query, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 use serde_qs::axum::QsQuery;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 use crate::database::entities::object::Entity as ObjectEntity;
 use crate::database::entities::object::Model as FileObject;
@@ -35,10 +35,6 @@ impl ListCount {
         self.n_records
     }
 }
-
-/// Params for a list objects request.
-#[derive(Debug, Deserialize)]
-pub struct ListObjectsParams {}
 
 /// The response type for list operations.
 #[derive(Debug, Deserialize, Serialize, ToSchema, Eq, PartialEq)]
@@ -112,8 +108,17 @@ pub async fn count_objects(state: State<AppState>) -> Result<Json<ListCount>> {
 }
 
 /// Params for a list s3 objects request.
-#[derive(Debug, Deserialize)]
-pub struct ListS3ObjectsParams {}
+#[derive(Debug, Deserialize, Default, IntoParams)]
+#[serde(default)]
+#[into_params(parameter_in = Query)]
+pub struct ListS3ObjectsParams {
+    /// Fetch the current state of objects in storage.
+    /// This ensures that only `Created` events which represent current
+    /// objects in storage are returned, and any historical `Deleted`
+    /// or `Created`events are omitted.
+    #[param(nullable, default = false)]
+    current_state: bool,
+}
 
 /// The list s3 objects handler.
 #[utoipa::path(
@@ -123,20 +128,23 @@ pub struct ListS3ObjectsParams {}
         (status = OK, description = "List all s3 objects", body = Vec<FileS3Object>),
         ErrorStatusCode,
     ),
-    params(Pagination, S3ObjectsFilterAll),
+    params(Pagination, ListS3ObjectsParams, S3ObjectsFilterAll),
     context_path = "/api/v1",
 )]
 pub async fn list_s3_objects(
     state: State<AppState>,
     Query(pagination): Query<Pagination>,
+    Query(list): Query<ListS3ObjectsParams>,
     QsQuery(filter_all): QsQuery<S3ObjectsFilterAll>,
 ) -> Result<Json<ListResponse<FileS3Object>>> {
-    let response = ListQueryBuilder::<S3ObjectEntity>::new(&state.client)
-        .filter_all(filter_all)
-        .paginate_to_list_response(pagination)
-        .await?;
+    let mut response =
+        ListQueryBuilder::<S3ObjectEntity>::new(&state.client).filter_all(filter_all);
 
-    Ok(Json(response))
+    if list.current_state {
+        response = response.current_state();
+    }
+
+    Ok(Json(response.paginate_to_list_response(pagination).await?))
 }
 
 /// The count s3 objects handler.
@@ -171,7 +179,9 @@ pub(crate) mod tests {
     use crate::database::entities::object::Model as Object;
     use crate::database::entities::s3_object::Model as S3Object;
     use crate::database::entities::sea_orm_active_enums::EventType;
-    use crate::queries::tests::{initialize_database, initialize_database_reorder};
+    use crate::queries::tests::{
+        initialize_database, initialize_database_ratios_reorder, initialize_database_reorder,
+    };
     use crate::routes::api_router;
 
     use super::*;
@@ -217,6 +227,35 @@ pub(crate) mod tests {
         let result: ListResponse<S3Object> = response_from(state, "/s3_objects").await;
         assert!(result.next_page.is_none());
         assert_eq!(result.results, entries);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn list_current_s3_objects_paginate(pool: PgPool) {
+        let state = AppState::from_pool(pool);
+        let entries = initialize_database_ratios_reorder(state.client(), 10, 4, 3)
+            .await
+            .s3_objects;
+
+        let result: ListResponse<S3Object> =
+            response_from(state, "/s3_objects?current_state=true&page_size=1&page=0").await;
+        assert_eq!(result.next_page, Some(1));
+        assert_eq!(result.results, vec![entries[2].clone()]);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn list_current_s3_objects_filter(pool: PgPool) {
+        let state = AppState::from_pool(pool);
+        let entries = initialize_database_ratios_reorder(state.client(), 30, 8, 5)
+            .await
+            .s3_objects;
+
+        let result: ListResponse<S3Object> = response_from(
+            state,
+            "/s3_objects?current_state=true&size=4&page_size=1&page=0",
+        )
+        .await;
+        assert!(result.next_page.is_none());
+        assert_eq!(result.results, vec![entries[24].clone()]);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]


### PR DESCRIPTION
Closes #414 

### Changes
* Add `current_state` query and API parameter.
* Add some missing tests and allow `/s3_object/count`/`object/count` requests to use filtering and the `current_state` query parameters