### PR TITLE
feat(filemanager): add database mocking to local API server

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/Cargo.lock
+++ b/lib/workload/stateless/stacks/filemanager/Cargo.lock
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db83dced34638ad474f39f250d7fea9598bdd239eaced1bdf45d597da0f433f"
+checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1323,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.7"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e204572485eb3fbf28f871612191521df159bc3e15a9f5064c66dba3a8c05f"
+checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1335,9 +1335,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.5"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c780290ccf4fb26629baa7a1081e68ced113f1d3ec302fa5948f1c381ebf06c6"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2182,9 +2182,11 @@ name = "filemanager-api-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "clap",
  "dotenvy",
  "filemanager",
  "http 1.1.0",
+ "sea-orm",
  "tokio",
  "tracing",
 ]

--- a/lib/workload/stateless/stacks/filemanager/Makefile
+++ b/lib/workload/stateless/stacks/filemanager/Makefile
@@ -65,7 +65,7 @@ psql:
 
 ## Local API server.
 api: build
-	cargo run -p filemanager-api-server
+	cargo run -p filemanager-api-server $(ARGS)
 
 ## Help text
 help:

--- a/lib/workload/stateless/stacks/filemanager/README.md
+++ b/lib/workload/stateless/stacks/filemanager/README.md
@@ -92,6 +92,16 @@ To use the local API server, run:
 make api
 ```
 
+The local database server instance can generate mock data and import existing `.sql` dumps using command line options.
+To pass in command line options use `make`, or run the server directly with cargo when `DATABASE_URL` is set:
+
+```sh
+# Pass in command line options using make.
+make api ARGS="--help"
+# Or run directly using cargo, which requires`DATABASE_URL` to be set.
+cargo run -p filemanager-api-server -- --help
+```
+
 ### Compilation and migrations
 
 Locally, database schemas are updated by passing migration scripts to the special `/docker-entrypoint-initdb.d/` directory

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-server/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-server/Cargo.toml
@@ -6,10 +6,12 @@ edition.workspace = true
 authors.workspace = true
 
 [dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1", features = ["fs", "rt-multi-thread", "macros"] }
 tracing = "0.1"
 axum = "0.7"
 dotenvy = "0.15"
 http = "1"
+clap = { version = "4", features = ["derive"] }
+sea-orm = { version = "0.12", features = ["sqlx-postgres", "runtime-tokio-rustls"] }
 
 filemanager = { path = "../filemanager" }

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-server/src/main.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-server/src/main.rs
@@ -1,20 +1,67 @@
 use axum::serve;
+use clap::{Parser, Subcommand};
 use filemanager::database::Client;
 use filemanager::env::Config;
 use filemanager::error::Error::IoError;
 use filemanager::error::Result;
 use filemanager::handlers::init_tracing_with_format;
 use filemanager::handlers::Format::Pretty;
+use filemanager::queries::EntriesBuilder;
 use filemanager::routes::{router, AppState};
 use http::Uri;
+use sea_orm::ConnectionTrait;
 use std::io;
+use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
 use tracing::{debug, info};
+
+/// Run the filemanager API server locally to explore the API.
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// The address to run the server at.
+    #[arg(short, long, default_value = "localhost:8080")]
+    api_server_addr: String,
+    /// Load an .sql dump into the filemanager database. This executes an unprepared
+    /// .sql script from the file specified.
+    #[arg(short, long)]
+    load_sql_file: Option<PathBuf>,
+    /// Mock testing data for the API to use. Records are generated incrementally
+    /// with integers as buckets and keys.
+    #[command(subcommand)]
+    mock_data: Option<MockData>,
+}
+
+/// Mock data into the filemanager database.
+#[derive(Subcommand, Debug)]
+pub enum MockData {
+    /// Mock data into the filemanager database. Note that this should only be run once on the same
+    /// postgres database to avoid duplicate key errors.
+    Mock {
+        /// The number of records to generate.
+        #[arg(short, long, default_value_t = 1000)]
+        n_records: usize,
+        /// The ratio of buckets to use when generating records. A higher number here means
+        /// that less buckets will be generated.
+        #[arg(short, long, default_value_t = 100)]
+        bucket_divisor: usize,
+        /// The ratio of keys to use when generating records. A higher number here means
+        /// that less keys will be generated.
+        #[arg(short, long, default_value_t = 10)]
+        key_divisor: usize,
+        /// Whether to shuffle the generated records to simulate out of order events.
+        #[arg(short, long, default_value_t = true)]
+        shuffle: bool,
+    },
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let _ = dotenvy::dotenv();
+    let args = Args::parse();
 
     init_tracing_with_format(Pretty);
 
@@ -24,11 +71,45 @@ async fn main() -> Result<()> {
     let client = Client::from_config(&config).await?;
     let state = AppState::new(client, config.clone());
 
+    if let Some(load) = args.load_sql_file {
+        info!(
+            from = load.to_string_lossy().as_ref(),
+            "loading .sql script"
+        );
+
+        let mut script = String::new();
+        File::open(load).await?.read_to_string(&mut script).await?;
+
+        state
+            .client()
+            .connection_ref()
+            .execute_unprepared(&script)
+            .await?;
+    }
+
+    if let Some(MockData::Mock {
+        n_records,
+        bucket_divisor,
+        key_divisor,
+        shuffle,
+    }) = args.mock_data
+    {
+        info!("generating mock database records");
+
+        EntriesBuilder::default()
+            .with_n(n_records)
+            .with_bucket_divisor(bucket_divisor)
+            .with_key_divisor(key_divisor)
+            .with_shuffle(shuffle)
+            .build(state.client())
+            .await;
+    }
+
     let app = router(state);
-    let listener = TcpListener::bind(config.api_server_addr().unwrap_or("localhost:8080")).await?;
+    let listener = TcpListener::bind(args.api_server_addr).await?;
 
     let local_addr = listener.local_addr()?;
-    debug!("listening on {}", listener.local_addr()?);
+    info!("listening on {}", listener.local_addr()?);
 
     let docs = Uri::builder()
         .scheme("http")

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -47,6 +47,7 @@ itertools = "0.13"
 url = "2"
 bytes = "1.6"
 envy = "0.4"
+rand = "0.8"
 
 # Inventory
 csv = "1"
@@ -70,7 +71,6 @@ aws_lambda_events = "0.15"
 
 [dev-dependencies]
 lazy_static = "1"
-rand = "0.8"
 
 aws-smithy-runtime-api = "1"
 aws-smithy-mocks-experimental = "0.2"

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/credentials.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/credentials.rs
@@ -211,7 +211,6 @@ mod tests {
             pguser: Some("filemanager".to_string()),
             sqs_url: None,
             paired_ingest_mode: false,
-            api_server_addr: Some("127.0.0.1:8080".to_string()),
         };
 
         test_generate_iam_token(|config| async {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
@@ -18,8 +18,6 @@ pub struct Config {
     pub(crate) sqs_url: Option<String>,
     #[serde(default, rename = "filemanager_paired_ingest_mode")]
     pub(crate) paired_ingest_mode: bool,
-    #[serde(default, rename = "filemanager_api_server_addr")]
-    pub(crate) api_server_addr: Option<String>,
 }
 
 impl Config {
@@ -76,11 +74,6 @@ impl Config {
         self.paired_ingest_mode
     }
 
-    /// Get the api server address.
-    pub fn api_server_addr(&self) -> Option<&str> {
-        self.api_server_addr.as_deref()
-    }
-
     /// Get the value from an optional, or else try and get a different value, unwrapping into a Result.
     pub fn value_or_else<T>(value: Option<T>, or_else: Option<T>) -> Result<T> {
         value
@@ -127,7 +120,6 @@ mod tests {
                 pguser: Some("user".to_string()),
                 sqs_url: Some("url".to_string()),
                 paired_ingest_mode: true,
-                api_server_addr: Some("127.0.0.1:8080".to_string()),
             }
         )
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/get.rs
@@ -51,16 +51,15 @@ impl<'a> GetQueryBuilder<'a> {
 mod tests {
     use sqlx::PgPool;
 
+    use super::*;
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::database::Client;
-    use crate::queries::tests::initialize_database;
-
-    use super::*;
+    use crate::queries::EntriesBuilder;
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_get_object(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await.objects;
+        let entries = EntriesBuilder::default().build(&client).await.objects;
 
         let first = entries.first().unwrap();
         let builder = GetQueryBuilder::new(&client);
@@ -72,7 +71,7 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await.s3_objects;
+        let entries = EntriesBuilder::default().build(&client).await.s3_objects;
 
         let first = entries.first().unwrap();
         let builder = GetQueryBuilder::new(&client);

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -253,20 +253,17 @@ mod tests {
     use serde_json::json;
     use sqlx::PgPool;
 
+    use super::*;
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::database::entities::object::Model as ObjectModel;
     use crate::database::entities::s3_object::Model as S3ObjectModel;
     use crate::database::entities::sea_orm_active_enums::EventType;
-    use crate::queries::tests::{
-        initialize_database, initialize_database_ratios_reorder, initialize_database_reorder,
-    };
-
-    use super::*;
+    use crate::queries::EntriesBuilder;
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await.objects;
+        let entries = EntriesBuilder::default().build(&client).await.objects;
 
         let builder = ListQueryBuilder::<ObjectEntity>::new(&client);
         let result = builder.all().await.unwrap();
@@ -278,7 +275,11 @@ mod tests {
     async fn test_current_s3_objects_10(pool: PgPool) {
         let client = Client::from_pool(pool);
 
-        let entries = initialize_database_ratios_reorder(&client, 10, 4, 3)
+        let entries = EntriesBuilder::default()
+            .with_bucket_divisor(4)
+            .with_key_divisor(3)
+            .with_shuffle(true)
+            .build(&client)
             .await
             .s3_objects;
         let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client).current_state();
@@ -291,7 +292,12 @@ mod tests {
     async fn test_current_s3_objects_30(pool: PgPool) {
         let client = Client::from_pool(pool);
 
-        let entries = initialize_database_ratios_reorder(&client, 30, 8, 5)
+        let entries = EntriesBuilder::default()
+            .with_n(30)
+            .with_bucket_divisor(8)
+            .with_key_divisor(5)
+            .with_shuffle(true)
+            .build(&client)
             .await
             .s3_objects;
         let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client).current_state();
@@ -307,7 +313,11 @@ mod tests {
     async fn test_current_s3_objects_with_paginate_10(pool: PgPool) {
         let client = Client::from_pool(pool);
 
-        let entries = initialize_database_ratios_reorder(&client, 10, 4, 3)
+        let entries = EntriesBuilder::default()
+            .with_bucket_divisor(4)
+            .with_key_divisor(3)
+            .with_shuffle(true)
+            .build(&client)
             .await
             .s3_objects;
 
@@ -333,7 +343,12 @@ mod tests {
     async fn test_current_s3_objects_with_filter(pool: PgPool) {
         let client = Client::from_pool(pool);
 
-        let entries = initialize_database_ratios_reorder(&client, 30, 8, 5)
+        let entries = EntriesBuilder::default()
+            .with_n(30)
+            .with_bucket_divisor(8)
+            .with_key_divisor(5)
+            .with_shuffle(true)
+            .build(&client)
             .await
             .s3_objects;
 
@@ -360,7 +375,7 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_objects_filter_attributes(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await.objects;
+        let entries = EntriesBuilder::default().build(&client).await.objects;
 
         let result = filter_all_objects_from(
             &client,
@@ -401,7 +416,7 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_paginate_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await.objects;
+        let entries = EntriesBuilder::default().build(&client).await.objects;
 
         let builder = ListQueryBuilder::<ObjectEntity>::new(&client);
 
@@ -422,7 +437,11 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(&client)
+            .await
+            .s3_objects;
 
         let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client);
         let result = builder.all().await.unwrap();
@@ -433,7 +452,11 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects_filter_event_type(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(&client)
+            .await
+            .s3_objects;
 
         let result = filter_all_s3_objects_from(
             &client,
@@ -456,7 +479,11 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects_multiple_filters(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(&client)
+            .await
+            .s3_objects;
 
         let result = filter_all_s3_objects_from(
             &client,
@@ -473,7 +500,11 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3_objects_filter_attributes(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(&client)
+            .await
+            .s3_objects;
 
         let result = filter_all_s3_objects_from(
             &client,
@@ -543,7 +574,11 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_paginate_s3_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = initialize_database_reorder(&client, 10).await.s3_objects;
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(&client)
+            .await
+            .s3_objects;
 
         let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client);
 
@@ -564,7 +599,10 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_count_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        initialize_database(&client, 10).await;
+        EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(&client)
+            .await;
 
         let builder = ListQueryBuilder::<ObjectEntity>::new(&client);
 
@@ -575,7 +613,10 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_count_s3_objects(pool: PgPool) {
         let client = Client::from_pool(pool);
-        initialize_database(&client, 10).await;
+        EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(&client)
+            .await;
 
         let builder = ListQueryBuilder::<S3ObjectEntity>::new(&client);
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
@@ -65,14 +65,17 @@ mod tests {
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::database::entities::object::Model as Object;
     use crate::database::entities::s3_object::Model as S3Object;
-    use crate::queries::tests::initialize_database;
+    use crate::queries::EntriesBuilder;
     use crate::routes::list::tests::response_from;
     use crate::routes::AppState;
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn get_objects_api(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await.objects;
+        let entries = EntriesBuilder::default()
+            .build(state.client())
+            .await
+            .objects;
 
         let first = entries.first().unwrap();
         let result: Object = response_from(state, &format!("/objects/{}", first.object_id)).await;
@@ -82,7 +85,10 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn get_s3_objects_api(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await.s3_objects;
+        let entries = EntriesBuilder::default()
+            .build(state.client())
+            .await
+            .s3_objects;
 
         let first = entries.first().unwrap();
         let result: S3Object =

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
@@ -70,7 +70,7 @@ mod tests {
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::database::entities::object::Model as Object;
     use crate::database::entities::s3_object::Model as S3Object;
-    use crate::queries::tests::{initialize_database, initialize_database_reorder};
+    use crate::queries::EntriesBuilder;
     use crate::routes::list::tests::response_from;
     use crate::routes::list::ListResponse;
     use crate::routes::AppState;
@@ -78,7 +78,10 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_objects_api_paginate(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await.objects;
+        let entries = EntriesBuilder::default()
+            .build(state.client())
+            .await
+            .objects;
 
         let result: ListResponse<Object> =
             response_from(state, "/objects?page=2&page_size=2").await;
@@ -89,7 +92,10 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_objects_api_paginate_large(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await.objects;
+        let entries = EntriesBuilder::default()
+            .build(state.client())
+            .await
+            .objects;
 
         let result: ListResponse<Object> =
             response_from(state.clone(), "/objects?page=0&page_size=20").await;
@@ -105,7 +111,10 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_objects_api_zero_page_size(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database(state.client(), 10).await.objects;
+        let entries = EntriesBuilder::default()
+            .build(state.client())
+            .await
+            .objects;
 
         let result: ListResponse<Object> = response_from(state, "/s3_objects?page_size=0").await;
         assert_eq!(result.next_page(), None);
@@ -115,7 +124,9 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_api_paginate(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database_reorder(state.client(), 10)
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(state.client())
             .await
             .s3_objects;
 
@@ -128,7 +139,9 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_api_paginate_large(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database_reorder(state.client(), 10)
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(state.client())
             .await
             .s3_objects;
 
@@ -146,7 +159,9 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_objects_api_zero_page_size(pool: PgPool) {
         let state = AppState::from_pool(pool);
-        let entries = initialize_database_reorder(state.client(), 10)
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(state.client())
             .await
             .s3_objects;
 


### PR DESCRIPTION
Closes #417 

### Changes
* Add database loading and mocking command line options to the `filemanager-api-server`.

This is basically is just re-using the data generation component I had for testing [here](https://github.com/umccr/orcabus/blob/6d0bc9068fbe666bc1eaf2a6b9dc46afe47d94be/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs#L111-L115), except with a bit of a tidy of the function API/interface. 