### PR TITLE
feat(filemanager): attribute updating API

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/Cargo.lock
+++ b/lib/workload/stateless/stacks/filemanager/Cargo.lock
@@ -2137,6 +2137,7 @@ dependencies = [
  "futures",
  "hex",
  "itertools 0.13.0",
+ "json-patch",
  "lambda_runtime",
  "lazy_static",
  "md5",
@@ -2273,6 +2274,15 @@ checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2908,6 +2918,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json-patch"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+dependencies = [
+ "jsonptr",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonptr"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+dependencies = [
+ "fluent-uri",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/lib/workload/stateless/stacks/filemanager/Cargo.lock
+++ b/lib/workload/stateless/stacks/filemanager/Cargo.lock
@@ -2138,7 +2138,6 @@ dependencies = [
  "hex",
  "itertools 0.13.0",
  "json-patch",
- "lambda_runtime",
  "lazy_static",
  "md5",
  "miette",
@@ -2947,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_http"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56eed1f61ea0efe7e89e1f018d95016959169b4194498a0283e950037bab6bb9"
+checksum = "67fe279be7f89f5f72c97c3a96f45c43db8edab1007320ecc6a5741273b4d6db"
 dependencies = [
  "aws_lambda_events",
  "base64 0.22.1",
@@ -2974,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "lambda_runtime"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a3eecde134218c7388f13079ab133552a251c319683a99495c048d30363927"
+checksum = "ed49669d6430292aead991e19bf13153135a884f916e68f32997c951af637ebe"
 dependencies = [
  "async-stream",
  "base64 0.22.1",
@@ -3290,14 +3289,13 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
  "mockall_derive",
  "predicates",
  "predicates-tree",
@@ -3305,9 +3303,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1" }
 axum = "0.7"
 
-lambda_http = "0.12"
-lambda_runtime = "0.12"
+lambda_http = "0.13"
+lambda_runtime = "0.13"
 
 filemanager = { path = "../filemanager" }

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/src/main.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/src/main.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 use filemanager::database::Client;
 use filemanager::handlers::aws::{create_database_pool, update_credentials};
 use filemanager::handlers::init_tracing;
-use filemanager::routes::{router, AppState, ErrorResponse, ErrorStatusCode};
+use filemanager::routes::error::{ErrorResponse, ErrorStatusCode};
+use filemanager::routes::{router, AppState};
 use lambda_http::run;
 use tracing::debug;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager-ingest-lambda/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-ingest-lambda/Cargo.toml
@@ -12,6 +12,6 @@ tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1" }
 
 aws_lambda_events = "0.15"
-lambda_runtime = "0.12"
+lambda_runtime = "0.13"
 
 filemanager = { path = "../filemanager" }

--- a/lib/workload/stateless/stacks/filemanager/filemanager-inventory-lambda/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-inventory-lambda/Cargo.toml
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1" }
 
-lambda_runtime = "0.12"
+lambda_runtime = "0.13"
 
 filemanager = { path = "../filemanager", features = ["migrate"] }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager-migrate-lambda/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-migrate-lambda/Cargo.toml
@@ -12,7 +12,7 @@ tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1" }
 
 aws_lambda_events = "0.15"
-lambda_runtime = "0.12"
+lambda_runtime = "0.13"
 
 filemanager = { path = "../filemanager", features = ["migrate"] }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filemanager"
-description = "Orcabus filemanager"
+description = "The orcabus filemanager ingests cloud storage event records and allows querying them."
 version = "0.1.0"
 authors.workspace = true
 license.workspace = true

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -42,7 +42,7 @@ json-patch = "2"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 uuid = { version = "1", features = ["v7"] }
-mockall = "0.12"
+mockall = "0.13"
 mockall_double = "0.3"
 itertools = "0.13"
 url = "2"
@@ -67,7 +67,6 @@ aws-sdk-s3 = "1"
 aws-credential-types = "1"
 aws-sigv4 = "1"
 aws-arn = "0.3"
-lambda_runtime = "0.12"
 aws_lambda_events = "0.15"
 
 [dev-dependencies]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -36,6 +36,7 @@ utoipa-swagger-ui = { version = "7", features = ["axum"] }
 tower = "0.4"
 tower-http = { version = "0.5", features = ["trace"] }
 serde_qs = { version = "0.13", features = ["axum"] }
+json-patch = "2"
 
 # General
 chrono = { version = "0.4", features = ["serde"] }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1"
 futures = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "json", "ansi"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "json", "ansi", "env-filter"] }
 
 # Database
 sqlx = { version = "0.7", features = ["postgres", "runtime-tokio", "tls-rustls", "chrono", "uuid"] }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
@@ -1,7 +1,7 @@
 //! Handles loading environment variables as config options for filemanager.
 //!
 
-use crate::error::Error::LoadingEnvironment;
+use crate::error::Error::ConfigError;
 use crate::error::Result;
 use envy::from_env;
 use serde::Deserialize;
@@ -31,9 +31,7 @@ impl Config {
             && config.pgport.is_none()
             && config.pguser.is_none()
         {
-            return Err(LoadingEnvironment(
-                "no database configuration found".to_string(),
-            ));
+            return Err(ConfigError("no database configuration found".to_string()));
         }
 
         Ok(config)
@@ -83,7 +81,7 @@ impl Config {
 
     /// Convert an optional value to a missing environment variable error.
     pub fn value_into_err<T>(value: Option<T>) -> Result<T> {
-        value.ok_or_else(|| LoadingEnvironment("missing environment variable".to_string()))
+        value.ok_or_else(|| ConfigError("missing environment variable".to_string()))
     }
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -4,16 +4,16 @@
 use sea_orm::{sqlx_error_to_query_err, DbErr};
 use std::{io, result};
 
-use crate::routes::ErrorStatusCode;
 use sqlx::migrate::MigrateError;
 use thiserror::Error;
+use uuid::Uuid;
 
 pub type Result<T> = result::Result<T, Error>;
 
 /// Error types for the filemanager.
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("Database error: `{0}`")]
+    #[error("database error: `{0}`")]
     DatabaseError(DbErr),
     #[error("SQL migrate error: `{0}`")]
     MigrateError(String),
@@ -21,7 +21,7 @@ pub enum Error {
     SQSError(String),
     #[error("deserialization error: `{0}`")]
     DeserializeError(String),
-    #[error("Loading environment variables: `{0}`")]
+    #[error("loading environment variables: `{0}`")]
     LoadingEnvironment(String),
     #[error("credential generator error: `{0}`")]
     CredentialGeneratorError(String),
@@ -29,16 +29,16 @@ pub enum Error {
     S3InventoryError(String),
     #[error("{0}")]
     IoError(#[from] io::Error),
-    #[error("Numerical operation overflowed")]
+    #[error("numerical operation overflowed")]
     OverflowError,
-    #[error("Numerical conversion failed: {0}")]
+    #[error("numerical conversion failed: `{0}`")]
     ConversionError(String),
-    #[error("API error")]
-    APIError(ErrorStatusCode),
-    #[error("Query error: {0}")]
+    #[error("query error: `{0}`")]
     QueryError(String),
-    #[error("Invalid input: {0}")]
+    #[error("invalid input: `{0}`")]
     InvalidQuery(String),
+    #[error("expected some value for id: `{0}`")]
+    ExpectedSomeValue(Uuid),
 }
 
 impl From<sqlx::Error> for Error {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -22,7 +22,7 @@ pub enum Error {
     #[error("deserialization error: `{0}`")]
     DeserializeError(String),
     #[error("loading environment variables: `{0}`")]
-    LoadingEnvironment(String),
+    ConfigError(String),
     #[error("credential generator error: `{0}`")]
     CredentialGeneratorError(String),
     #[error("S3 inventory error: `{0}`")]
@@ -67,6 +67,6 @@ impl From<serde_json::Error> for Error {
 
 impl From<envy::Error> for Error {
     fn from(error: envy::Error) -> Self {
-        Self::LoadingEnvironment(error.to_string())
+        Self::ConfigError(error.to_string())
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -4,6 +4,7 @@
 use sea_orm::{sqlx_error_to_query_err, DbErr};
 use std::{io, result};
 
+use crate::routes::ErrorStatusCode;
 use sqlx::migrate::MigrateError;
 use thiserror::Error;
 
@@ -32,6 +33,8 @@ pub enum Error {
     OverflowError,
     #[error("Numerical conversion failed: {0}")]
     ConversionError(String),
+    #[error("API error")]
+    APIError(ErrorStatusCode),
 }
 
 impl From<sqlx::Error> for Error {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -35,6 +35,10 @@ pub enum Error {
     ConversionError(String),
     #[error("API error")]
     APIError(ErrorStatusCode),
+    #[error("Query error: {0}")]
+    QueryError(String),
+    #[error("Invalid input: {0}")]
+    InvalidQuery(String),
 }
 
 impl From<sqlx::Error> for Error {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/mod.rs
@@ -1,11 +1,10 @@
 //! This module contains event handlers for filemanager functionality.
 //!
 
-use lambda_runtime::tracing::subscriber::EnvFilter;
 use tracing_subscriber::fmt::layer;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::Layer;
+use tracing_subscriber::{EnvFilter, Layer};
 
 pub mod aws;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/get.rs
@@ -4,10 +4,7 @@
 use sea_orm::{EntityTrait, Select};
 use uuid::Uuid;
 
-use crate::database::entities::object::Entity as ObjectEntity;
-use crate::database::entities::object::Model as Object;
-use crate::database::entities::s3_object::Entity as S3ObjectEntity;
-use crate::database::entities::s3_object::Model as S3Object;
+use crate::database::entities::{object, s3_object};
 use crate::database::Client;
 use crate::error::Result;
 
@@ -23,24 +20,24 @@ impl<'a> GetQueryBuilder<'a> {
     }
 
     /// Build a select query for finding an object by id.
-    pub fn build_object_by_id(id: Uuid) -> Select<ObjectEntity> {
-        ObjectEntity::find_by_id(id)
+    pub fn build_object_by_id(id: Uuid) -> Select<object::Entity> {
+        object::Entity::find_by_id(id)
     }
 
     /// Build a select query for finding an s3 object by id.
-    pub fn build_s3_object_by_id(id: Uuid) -> Select<S3ObjectEntity> {
-        S3ObjectEntity::find_by_id(id)
+    pub fn build_s3_object_by_id(id: Uuid) -> Select<s3_object::Entity> {
+        s3_object::Entity::find_by_id(id)
     }
 
     /// Get a specific object by id.
-    pub async fn get_object(&self, id: Uuid) -> Result<Option<Object>> {
+    pub async fn get_object(&self, id: Uuid) -> Result<Option<object::Model>> {
         Ok(Self::build_object_by_id(id)
             .one(self.client.connection_ref())
             .await?)
     }
 
     /// Get a specific s3 object by id.
-    pub async fn get_s3_object_by_id(&self, id: Uuid) -> Result<Option<S3Object>> {
+    pub async fn get_s3_object_by_id(&self, id: Uuid) -> Result<Option<s3_object::Model>> {
         Ok(Self::build_s3_object_by_id(id)
             .one(self.client.connection_ref())
             .await?)

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -84,7 +84,16 @@ impl<'a> ListQueryBuilder<'a, s3_object::Entity> {
     ///     ...;
     /// ```
     pub fn filter_all(mut self, filter: S3ObjectsFilterAll) -> Self {
-        let condition = Condition::all()
+        self.select = self.select.filter(Self::filter_condition(filter));
+
+        self.trace_query("filter_all");
+
+        self
+    }
+
+    /// Create a condition to filter a query.
+    pub fn filter_condition(filter: S3ObjectsFilterAll) -> Condition {
+        Condition::all()
             .add_option(
                 filter
                     .event_type
@@ -120,13 +129,7 @@ impl<'a> ListQueryBuilder<'a, s3_object::Entity> {
                 filter
                     .attributes
                     .map(|v| Expr::col(s3_object::Column::Attributes).contains(v)),
-            );
-
-        self.select = self.select.filter(condition);
-
-        self.trace_query("filter_all");
-
-        self
+            )
     }
 
     /// Update this query to find objects that represent the current state of S3 objects. That is,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod get;
 pub mod list;
+pub mod update;
 
 #[cfg(test)]
 pub(crate) mod tests {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
@@ -1,0 +1,126 @@
+//! Query builder to handle updating record columns.
+//!
+
+use crate::database::entities::object::Column as ObjectColumn;
+use crate::database::entities::s3_object::Column as S3ObjectColumn;
+use crate::database::Client;
+use crate::error::Result;
+use sea_orm::prelude::Expr;
+use sea_orm::sea_query::extension::postgres::PgExpr;
+use sea_orm::sea_query::PostgresQueryBuilder;
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, QueryTrait, UpdateMany};
+use tracing::trace;
+use uuid::Uuid;
+
+use crate::database::entities::object::{ActiveModel as ObjectActiveModel, Entity as ObjectEntity};
+use crate::database::entities::s3_object::Entity as S3ObjectEntity;
+use crate::routes::attributes::AttributeBody;
+
+/// A query builder for list operations.
+#[derive(Debug, Clone)]
+pub struct UpdateQueryBuilder<'a, E>
+where
+    E: EntityTrait,
+{
+    client: &'a Client,
+    update: UpdateMany<E>,
+}
+
+impl<'a> UpdateQueryBuilder<'a, ObjectEntity> {
+    /// Create a new query builder.
+    pub fn new(client: &'a Client) -> Self {
+        Self {
+            client,
+            update: Self::for_objects(),
+        }
+    }
+
+    /// Define an update query for finding values from objects.
+    pub fn for_objects() -> UpdateMany<ObjectEntity> {
+        ObjectEntity::update_many()
+    }
+
+    /// Update the attributes on an object replacing any existing keys in the attributes.
+    pub fn for_id(mut self, id: Uuid) -> Self {
+        self.update = self.update.filter(ObjectColumn::ObjectId.eq(id));
+
+        self.trace_query("for_id");
+
+        self
+    }
+
+    /// Update the attributes on an object replacing any existing keys in the attributes.
+    pub fn update_attributes_replace(mut self, attributes: AttributeBody) -> Self {
+        self.update = self.update.col_expr(
+            ObjectColumn::Attributes,
+            Expr::col(ObjectColumn::Attributes).concat(attributes.into_inner()),
+        );
+
+        self.trace_query("update_attributes_replace");
+
+        self
+    }
+}
+
+impl<'a, E, M> UpdateQueryBuilder<'a, E>
+where
+    E: EntityTrait<Model = M>,
+{
+    /// Execute the prepared query, returning all values.
+    pub async fn all(self) -> Result<Vec<M>> {
+        Ok(self
+            .update
+            .exec_with_returning(self.client.connection_ref())
+            .await?)
+    }
+
+    /// Execute the prepared query, returning one value.
+    pub async fn one(self) -> Result<Option<M>> {
+        Ok(self
+            .update
+            .exec_with_returning(self.client.connection_ref())
+            .await?
+            .into_iter()
+            .nth(0))
+    }
+
+    fn trace_query(&self, message: &str) {
+        println!("{}", self.update.as_query().to_string(PostgresQueryBuilder));
+        trace!(
+            "{message}: {}",
+            self.update.as_query().to_string(PostgresQueryBuilder)
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{json, Map};
+    use sqlx::PgPool;
+
+    use crate::database::aws::migration::tests::MIGRATOR;
+    use crate::queries::tests::initialize_database;
+
+    use super::*;
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_update_attributes_replace(pool: PgPool) {
+        let client = Client::from_pool(pool);
+        let entries = initialize_database(&client, 10).await.objects;
+
+        let builder = UpdateQueryBuilder::<ObjectEntity>::new(&client)
+            .for_id(entries[0].object_id)
+            .update_attributes_replace(AttributeBody::new(Map::from_iter(vec![(
+                "attribute_id".to_string(),
+                json!({ "nested_id": "attribute_id" }),
+            )])));
+        let result = builder.one().await.unwrap();
+
+        let mut expected = entries[0].clone();
+        expected.attributes = Some(
+            json!({"nested_id": {"attribute_id": "0"}, "attribute_id": {"nested_id": "attribute_id"}}),
+        );
+
+        assert_eq!(result.unwrap(), expected);
+    }
+}

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
@@ -1,22 +1,22 @@
 //! Query builder to handle updating record columns.
 //!
 
-use crate::database::entities::object::Column as ObjectColumn;
-use crate::database::entities::s3_object::Column as S3ObjectColumn;
-use crate::error::Result;
 use sea_orm::prelude::Expr;
 use sea_orm::sea_query::extension::postgres::PgExpr;
 use sea_orm::sea_query::{Func, FunctionCall, PostgresQueryBuilder};
 use sea_orm::{
-    ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryTrait, UpdateMany,
+    ColumnTrait, ConnectionTrait, EntityTrait, ModelTrait, QueryFilter, QueryTrait, UpdateMany,
 };
 use serde_json::json;
 use tracing::trace;
 use uuid::Uuid;
 
-use crate::database::entities::object::{ActiveModel as ObjectActiveModel, Entity as ObjectEntity};
-use crate::database::entities::s3_object::Entity as S3ObjectEntity;
-use crate::routes::attributes::AttributeBody;
+use crate::database::entities::object;
+use crate::error::Error::{InvalidQuery, QueryError};
+use crate::error::Result;
+use crate::queries::list::ListQueryBuilder;
+use crate::routes::attributes::{AttributeBody, MergeStrategy};
+use crate::routes::filtering::ObjectsFilterAll;
 
 /// A query builder for list operations.
 #[derive(Debug, Clone)]
@@ -28,7 +28,7 @@ where
     update: UpdateMany<E>,
 }
 
-impl<'a, C> UpdateQueryBuilder<'a, C, ObjectEntity>
+impl<'a, C> UpdateQueryBuilder<'a, C, object::Entity>
 where
     C: ConnectionTrait,
 {
@@ -36,58 +36,38 @@ where
     pub fn new(connection: &'a C) -> Self {
         Self {
             connection,
-            update: Self::for_objects(),
+            update: Self::build_for_objects(),
         }
     }
 
     /// Define an update query for finding values from objects.
-    pub fn for_objects() -> UpdateMany<ObjectEntity> {
-        ObjectEntity::update_many()
+    pub fn build_for_objects() -> UpdateMany<object::Entity> {
+        object::Entity::update_many()
     }
 
     /// Update the attributes on an object replacing any existing keys in the attributes.
     pub fn for_id(mut self, id: Uuid) -> Self {
-        self.update = self.update.filter(ObjectColumn::ObjectId.eq(id));
+        self.update = self.update.filter(object::Column::ObjectId.eq(id));
 
         self
     }
 
-    /// Update the attributes on an object replacing any existing keys in the attributes.
-    pub fn update_attributes_replace(mut self, attributes: AttributeBody) -> Self {
-        // Right-hand side replaces left-hand side, so the new attributes goes to
-        // the right for replacement.
-        self.update = self.update.col_expr(
-            ObjectColumn::Attributes,
-            Expr::expr(Self::coalesce_attributes()).concat(attributes.into_object()),
-        );
-
-        self.trace_query("update_attributes_replace");
-
+    /// Filter records by all fields in the filter variable.
+    pub fn filter_all(mut self, filter: ObjectsFilterAll) -> Self {
+        self.update = self
+            .update
+            .filter(ListQueryBuilder::filter_condition(filter));
         self
     }
 
-    /// Update the attributes on an object replacing any existing keys in the attributes.
-    pub fn update_attributes_insert(mut self, attributes: AttributeBody) -> Self {
-        // Right-hand side replaces left-hand side, so the old attributes goes to
-        // the right for insert.
-        self.update = self.update.col_expr(
-            ObjectColumn::Attributes,
-            Expr::expr(attributes.into_object()).concat(Self::coalesce_attributes()),
-        );
-
-        self.trace_query("update_attributes_insert");
-
-        self
-    }
-
-    /// Whenever updating attributes, this function should be called to coalesce
-    /// a possible null attribute value so that the update with new attributes
-    /// succeeds.
-    fn coalesce_attributes() -> FunctionCall {
-        Func::coalesce([
-            Expr::col(ObjectColumn::Attributes).into(),
-            Expr::val(json!({})).into(),
-        ])
+    /// Execute the prepared query according to the merge strategy.
+    pub async fn for_objects(
+        self,
+        attributes: AttributeBody,
+        merge_strategy: MergeStrategy,
+    ) -> Result<Vec<object::Model>> {
+        self.for_merge_strategy(attributes, merge_strategy, object::Column::Attributes)
+            .await
     }
 }
 
@@ -95,6 +75,7 @@ impl<'a, C, E, M> UpdateQueryBuilder<'a, C, E>
 where
     C: ConnectionTrait,
     E: EntityTrait<Model = M>,
+    M: ModelTrait,
 {
     /// Execute the prepared query, returning all values.
     pub async fn all(self) -> Result<Vec<M>> {
@@ -111,6 +92,139 @@ where
             .nth(0))
     }
 
+    /// Update the attributes on an object replacing any existing keys in the attributes.
+    /// This function should receive the attribute column to operate on, e.g. `Object::Attributes`.
+    pub fn update_attributes_replace(
+        mut self,
+        attributes: AttributeBody,
+        c: <M::Entity as EntityTrait>::Column,
+    ) -> Self {
+        // Right-hand side replaces left-hand side, so the new attributes goes to
+        // the right for replacement.
+        self.update = self.update.col_expr(
+            c,
+            Expr::expr(Self::coalesce_attributes(c)).concat(attributes.into_object()),
+        );
+
+        self.trace_query("update_attributes_replace");
+
+        self
+    }
+
+    /// Update the attributes on an object replacing any existing keys in the attributes.
+    /// This function should receive the attribute column to operate on, e.g. `Object::Attributes`.
+    pub fn update_attributes_insert(
+        mut self,
+        attributes: AttributeBody,
+        c: <M::Entity as EntityTrait>::Column,
+    ) -> Self {
+        // Right-hand side replaces left-hand side, so the old attributes goes to
+        // the right for insert.
+        self.update = self.update.col_expr(
+            c,
+            Expr::expr(attributes.into_object()).concat(Self::coalesce_attributes(c)),
+        );
+
+        self.trace_query("update_attributes_insert");
+
+        self
+    }
+
+    /// Whenever updating attributes, this function should be called to coalesce
+    /// a possible null attribute value so that the update with new attributes
+    /// succeeds. This function should receive the attribute column to operate on,
+    /// e.g. `Object::Attributes`.
+    fn coalesce_attributes(c: <M::Entity as EntityTrait>::Column) -> FunctionCall {
+        Func::coalesce([Expr::col(c).into(), Expr::val(json!({})).into()])
+    }
+
+    /// Execute the prepared query as an insert, returning an error if
+    /// any attribute keys already exist. This function should receive the
+    /// attribute column to operate on, e.g. `Object::Attributes`.
+    pub async fn for_insert(
+        self,
+        attributes: AttributeBody,
+        c: <M::Entity as EntityTrait>::Column,
+    ) -> Result<Vec<M>> {
+        let inserted = self
+            .update_attributes_insert(attributes.clone(), c)
+            .all()
+            .await?;
+
+        for model in &inserted {
+            let column = model.get(c);
+            let merged = column
+                .as_ref_json()
+                .ok_or_else(|| QueryError("expected JSON attributes column".to_string()))?;
+            let default = Default::default();
+            let merged = merged.as_object().unwrap_or(&default);
+
+            let conflict = attributes
+                .get_ref()
+                .into_iter()
+                .map(|(key, value)| {
+                    // If the new merged value does not equal the requested update attributes
+                    // then this means that the same key was present in the existing attributes.
+                    merged
+                        .get(key)
+                        .map(|merged_value| merged_value != value)
+                        .unwrap_or_default()
+                })
+                .find(|value| *value)
+                .unwrap_or_default();
+
+            if conflict {
+                return Err(InvalidQuery(
+                    "a key already exists using insert merge strategy".to_string(),
+                ));
+            }
+        }
+
+        Ok(inserted)
+    }
+
+    /// Execute the prepared query as an insert, where non-existent keys are merged
+    /// and any existing keys are ignored. This function should receive the
+    /// attribute column to operate on, e.g. `Object::Attributes`.
+    pub async fn for_insert_non_existent(
+        self,
+        attributes: AttributeBody,
+        c: <M::Entity as EntityTrait>::Column,
+    ) -> Result<Vec<M>> {
+        self.update_attributes_insert(attributes.clone(), c)
+            .all()
+            .await
+    }
+
+    /// Execute the prepared query as a replace, where all keys are merged and
+    /// existing keys are replaced. This function should receive the
+    /// attribute column to operate on, e.g. `Object::Attributes`.
+    pub async fn for_replace(
+        self,
+        attributes: AttributeBody,
+        c: <M::Entity as EntityTrait>::Column,
+    ) -> Result<Vec<M>> {
+        self.update_attributes_replace(attributes.clone(), c)
+            .all()
+            .await
+    }
+
+    /// Execute the prepared query according to the merge strategy. This
+    /// function should receive the attribute column to operate on,
+    /// e.g. `Object::Attributes`.
+    pub async fn for_merge_strategy(
+        self,
+        attributes: AttributeBody,
+        merge_strategy: MergeStrategy,
+        c: <M::Entity as EntityTrait>::Column,
+    ) -> Result<Vec<M>> {
+        match merge_strategy {
+            MergeStrategy::Insert => self.for_insert(attributes, c).await,
+            MergeStrategy::InsertNonExistent => self.for_insert_non_existent(attributes, c).await,
+            MergeStrategy::Replace => self.for_replace(attributes, c).await,
+        }
+    }
+
     fn trace_query(&self, message: &str) {
         trace!(
             "{message}: {}",
@@ -120,81 +234,143 @@ where
 }
 
 #[cfg(test)]
-mod tests {
-    use serde_json::Value;
-    use serde_json::{json, Map};
-    use sqlx::PgPool;
-
+pub(crate) mod tests {
+    use super::*;
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::database::entities::object::Model;
     use crate::database::Client;
     use crate::queries::tests::initialize_database;
+    use crate::queries::update::tests::TestStrategy::{
+        Insert, InsertNonExist, InsertNonExistNotNull, InsertNotNull, Replace, ReplaceNotNull,
+    };
+    use serde_json::Value;
+    use serde_json::{json, Map};
+    use sqlx::PgPool;
+    use std::future::Future;
 
-    use super::*;
+    /// Create parameterized tests for updating attributes.
+    #[derive(Debug)]
+    enum TestStrategy {
+        Replace,
+        ReplaceNotNull,
+        InsertNonExist,
+        InsertNonExistNotNull,
+        Insert,
+        InsertNotNull,
+    }
 
-    #[sqlx::test(migrator = "MIGRATOR")]
-    async fn test_update_attributes_replace_none(pool: PgPool) {
-        let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await.objects;
+    impl TestStrategy {
+        async fn assert<F, Fut>(&self, pool: PgPool, model_func: F)
+        where
+            F: Fn(Client, Vec<Model>, Vec<(String, Value)>) -> Fut,
+            Fut: Future<Output = Result<Vec<Model>>>,
+        {
+            let client = Client::from_pool(pool);
+            let entries = initialize_database(&client, 10).await.objects;
 
-        null_attributes(&client, &entries).await;
+            let input = vec![(
+                "attribute_id".to_string(),
+                json!({ "nested_id": "attribute_id" }),
+            )];
 
-        let input = vec![("another_id".to_string(), json!("attribute_id"))];
-        let result = test_update_replace(&client, &entries, input).await;
+            let result = model_func(client.clone(), entries.clone(), input).await;
 
-        let mut expected = entries[0].clone();
-        expected.attributes = Some(json!({"another_id": "attribute_id"}));
+            let mut expected = entries[0].clone();
+            match self {
+                Replace | ReplaceNotNull => {
+                    expected.attributes.as_mut().unwrap()["attribute_id"] =
+                        json!({"nested_id": "attribute_id"});
+                }
+                _ => {}
+            }
 
-        // A new value should be inserted.
-        assert_eq!(result.unwrap(), expected);
+            match self {
+                Insert | InsertNotNull => assert!(result.is_err()),
+                _ => assert_eq!(result.unwrap()[0], expected),
+            }
+
+            match self {
+                Replace | InsertNonExist | Insert => {
+                    null_attributes(&client, &entries[0]).await;
+                    expected = entries[0].clone();
+                    expected.attributes = Some(json!({"another_id": "0"}));
+                }
+                ReplaceNotNull | InsertNonExistNotNull | InsertNotNull => {
+                    expected.attributes.as_mut().unwrap()["another_id"] = json!("0");
+                }
+            }
+
+            let input = vec![("another_id".to_string(), json!("0"))];
+            let result = model_func(client.clone(), entries.clone(), input).await;
+
+            // A non-conflicting key should also insert.
+            assert_eq!(result.unwrap()[0], expected);
+
+            assert_correct_records(&client, entries, &[expected.object_id]).await;
+            clear_tables(&client).await;
+        }
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_update_attributes_replace(pool: PgPool) {
-        let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await.objects;
-
-        let input = vec![(
-            "attribute_id".to_string(),
-            json!({ "nested_id": "attribute_id" }),
-        )];
-        let result = test_update_replace(&client, &entries, input).await;
-
-        let mut expected = entries[0].clone();
-        expected.attributes.as_mut().unwrap()["attribute_id"] =
-            json!({"nested_id": "attribute_id"});
-
-        // A conflicting key should replace.
-        assert_eq!(result.unwrap(), expected);
-
-        let input = vec![("another_id".to_string(), json!("0"))];
-        let result = test_update_replace(&client, &entries, input).await;
-
-        expected.attributes.as_mut().unwrap()["another_id"] = json!("0");
-
-        // A non-conflicting key should also insert.
-        assert_eq!(result.unwrap(), expected);
-    }
-
-    #[sqlx::test(migrator = "MIGRATOR")]
-    async fn test_update_attributes_insert_none(pool: PgPool) {
-        let client = Client::from_pool(pool);
-        let entries = initialize_database(&client, 10).await.objects;
-
-        null_attributes(&client, &entries).await;
-
-        let input = vec![("another_id".to_string(), json!("attribute_id"))];
-        let result = test_update_insert(&client, &entries, input).await;
-
-        let mut expected = entries[0].clone();
-        expected.attributes = Some(json!({"another_id": "attribute_id"}));
-
-        // A new value should be inserted.
-        assert_eq!(result.unwrap(), expected);
+        ReplaceNotNull
+            .assert(pool.clone(), |client, entries, input| async move {
+                test_update_replace(&client, &entries, input).await
+            })
+            .await;
+        ReplaceNotNull
+            .assert(pool.clone(), |client, entries, input| async move {
+                test_merge_strategy_replace(&client, &entries, input).await
+            })
+            .await;
+        Replace
+            .assert(pool.clone(), |client, entries, input| async move {
+                test_update_replace(&client, &entries, input).await
+            })
+            .await;
+        Replace
+            .assert(pool, |client, entries, input| async move {
+                test_merge_strategy_replace(&client, &entries, input).await
+            })
+            .await;
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_update_attributes_insert(pool: PgPool) {
+        InsertNonExistNotNull
+            .assert(pool.clone(), |client, entries, input| async move {
+                test_update_insert(&client, &entries, input).await
+            })
+            .await;
+        InsertNonExistNotNull
+            .assert(pool.clone(), |client, entries, input| async move {
+                test_merge_strategy_insert_non_existent(&client, &entries, input).await
+            })
+            .await;
+        InsertNonExist
+            .assert(pool.clone(), |client, entries, input| async move {
+                test_update_insert(&client, &entries, input).await
+            })
+            .await;
+        InsertNonExist
+            .assert(pool.clone(), |client, entries, input| async move {
+                test_merge_strategy_insert_non_existent(&client, &entries, input).await
+            })
+            .await;
+        InsertNotNull
+            .assert(pool.clone(), |client, entries, input| async move {
+                test_merge_strategy_insert(&client, &entries, input).await
+            })
+            .await;
+        Insert
+            .assert(pool, |client, entries, input| async move {
+                test_merge_strategy_insert(&client, &entries, input).await
+            })
+            .await;
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn test_update_attributes_filter(pool: PgPool) {
         let client = Client::from_pool(pool);
         let entries = initialize_database(&client, 10).await.objects;
 
@@ -202,55 +378,163 @@ mod tests {
             "attribute_id".to_string(),
             json!({ "nested_id": "attribute_id" }),
         )];
-        let result = test_update_insert(&client, &entries, input).await;
+        let result = filter_all_objects_replace(
+            &client,
+            ObjectsFilterAll {
+                attributes: Some(json!({
+                    "attribute_id": "1"
+                })),
+            },
+            input.clone(),
+        )
+        .await;
 
-        // No Update expected as this key already exists.
-        let expected = entries[0].clone();
-        assert_eq!(result.unwrap(), expected);
+        let mut expected = entries[1].clone();
+        expected.attributes.as_mut().unwrap()["attribute_id"] =
+            json!({"nested_id": "attribute_id"});
 
-        let input = vec![("another_id".to_string(), json!("0"))];
-        let result = test_update_insert(&client, &entries, input).await;
+        assert_eq!(result, vec![expected]);
 
-        // Inserting without a conflict should proceed as normal.
-        let mut expected = entries[0].clone();
-        expected.attributes.as_mut().unwrap()["another_id"] = json!("0");
+        let result = filter_all_objects_replace(
+            &client,
+            ObjectsFilterAll {
+                attributes: Some(json!({
+                    "non_existent_id": "1"
+                })),
+            },
+            input,
+        )
+        .await;
+        assert!(result.is_empty());
+    }
 
-        assert_eq!(result.unwrap(), expected);
+    async fn clear_tables(client: &Client) {
+        client
+            .connection_ref()
+            .execute_unprepared("truncate table s3_object, object")
+            .await
+            .unwrap();
+    }
+
+    async fn filter_all_objects_replace(
+        client: &Client,
+        filter: ObjectsFilterAll,
+        input: Vec<(String, Value)>,
+    ) -> Vec<Model> {
+        UpdateQueryBuilder::new(client.connection_ref())
+            .filter_all(filter)
+            .update_attributes_replace(
+                AttributeBody::new(Map::from_iter(input)),
+                object::Column::Attributes,
+            )
+            .all()
+            .await
+            .unwrap()
     }
 
     async fn test_update_replace(
         client: &Client,
         entries: &[Model],
         input: Vec<(String, Value)>,
-    ) -> Option<Model> {
-        UpdateQueryBuilder::new(client.connection_ref())
+    ) -> Result<Vec<Model>> {
+        Ok(vec![UpdateQueryBuilder::new(client.connection_ref())
             .for_id(entries[0].object_id)
-            .update_attributes_replace(AttributeBody::new(Map::from_iter(input)))
+            .update_attributes_replace(
+                AttributeBody::new(Map::from_iter(input)),
+                object::Column::Attributes,
+            )
             .one()
             .await
             .unwrap()
+            .unwrap()])
+    }
+
+    async fn test_merge_strategy_replace(
+        client: &Client,
+        entries: &[Model],
+        input: Vec<(String, Value)>,
+    ) -> Result<Vec<Model>> {
+        UpdateQueryBuilder::new(client.connection_ref())
+            .for_id(entries[0].object_id)
+            .for_objects(
+                AttributeBody::new(Map::from_iter(input)),
+                MergeStrategy::Replace,
+            )
+            .await
+    }
+
+    async fn test_merge_strategy_insert(
+        client: &Client,
+        entries: &[Model],
+        input: Vec<(String, Value)>,
+    ) -> Result<Vec<Model>> {
+        UpdateQueryBuilder::new(client.connection_ref())
+            .for_id(entries[0].object_id)
+            .for_objects(
+                AttributeBody::new(Map::from_iter(input)),
+                MergeStrategy::Insert,
+            )
+            .await
+    }
+
+    async fn test_merge_strategy_insert_non_existent(
+        client: &Client,
+        entries: &[Model],
+        input: Vec<(String, Value)>,
+    ) -> Result<Vec<Model>> {
+        UpdateQueryBuilder::new(client.connection_ref())
+            .for_id(entries[0].object_id)
+            .for_objects(
+                AttributeBody::new(Map::from_iter(input)),
+                MergeStrategy::InsertNonExistent,
+            )
+            .await
     }
 
     async fn test_update_insert(
         client: &Client,
         entries: &[Model],
         input: Vec<(String, Value)>,
-    ) -> Option<Model> {
-        UpdateQueryBuilder::new(client.connection_ref())
+    ) -> Result<Vec<Model>> {
+        Ok(vec![UpdateQueryBuilder::new(client.connection_ref())
             .for_id(entries[0].object_id)
-            .update_attributes_insert(AttributeBody::new(Map::from_iter(input)))
+            .update_attributes_insert(
+                AttributeBody::new(Map::from_iter(input)),
+                object::Column::Attributes,
+            )
             .one()
             .await
             .unwrap()
+            .unwrap()])
     }
 
-    async fn null_attributes(client: &Client, entries: &[Model]) {
+    /// Make attributes null for an entry.
+    pub(crate) async fn null_attributes(client: &Client, entry: &Model) {
+        change_attributes(client, entry, "null").await;
+    }
+
+    /// Make attributes null for an entry.
+    pub(crate) async fn change_attributes(client: &Client, entry: &Model, value: &str) {
         UpdateQueryBuilder::new(client.connection_ref())
-            .for_id(entries[0].object_id)
+            .for_id(entry.object_id)
             .update
-            .col_expr(ObjectColumn::Attributes, Expr::cust("null"))
+            .col_expr(object::Column::Attributes, Expr::cust(value))
             .exec(client.connection_ref())
             .await
             .unwrap();
+    }
+
+    /// Assert that no existing records are updated.
+    pub(crate) async fn assert_correct_records(
+        client: &Client,
+        entries: Vec<Model>,
+        affected: &[Uuid],
+    ) {
+        let mut objects = ListQueryBuilder::<object::Entity>::new(client)
+            .all()
+            .await
+            .unwrap();
+        objects.retain(|object| !affected.contains(&object.object_id));
+        assert_eq!(objects, entries[affected.len()..]);
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/attributes.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/attributes.rs
@@ -7,6 +7,7 @@ use crate::routes::ErrorStatusCode::BadRequest;
 use crate::routes::{AppState, ErrorResponse, ErrorStatusCode};
 use axum::extract::{Path, Query, State};
 use axum::Json;
+use sea_orm::TransactionTrait;
 use serde::Deserialize;
 use serde_json::{Map, Value};
 use utoipa::{IntoParams, ToSchema};
@@ -15,14 +16,17 @@ use uuid::Uuid;
 /// The type of merge strategy to use when updating attributes.
 #[derive(Debug, Default, Deserialize, ToSchema)]
 pub enum MergeStrategy {
-    /// Insert the attributes and return a 400 error if the attribute key already exists.
+    /// Insert the attributes and return a 400 error if any of the keys already exist.
+    /// This does not update any keys if an error is returned, even if some of those
+    /// keys do not conflict with the attributes. 
     #[default]
     Insert,
-    /// Insert the attributes only if the key does not already exist. Does not update
-    /// the attributes if the key does exist and no error is returned.
-    InsertIfNotExists,
-    /// Insert the attributes if the key does not exist or replace the existing attributes
-    /// under the same key if it does exist.
+    /// Insert the attributes only for keys that do not already exist without returning
+    /// an error. Does not update the keys that do exist. This results in a partial update
+    /// where only the non-conflicting keys are inserted.
+    InsertNonExistent,
+    /// Insert the attributes if the keys do not exist or replace the existing attributes
+    /// under the same key if they do exist.
     Replace,
 }
 
@@ -100,17 +104,25 @@ pub async fn update_object_attributes(
     Query(update_attributes): Query<UpdateAttributesParams>,
     Json(request): Json<AttributeBody>,
 ) -> Result<Json<FileObject>> {
-    let query = UpdateQueryBuilder::new(&state.client);
-
     match update_attributes.merge_strategy {
         MergeStrategy::Insert => {
             unimplemented!()
         }
-        MergeStrategy::InsertIfNotExists => {
-            unimplemented!()
+        MergeStrategy::InsertNonExistent => {
+            let query = 
+              UpdateQueryBuilder::new(state.client.connection_ref())
+                .update_attributes_insert(request);
+
+            Ok(Json(query.one().await?.ok_or_else(|| {
+                APIError(BadRequest(ErrorResponse {
+                    message: format!("object with id {} not found", id),
+                }))
+            })?))
         }
         MergeStrategy::Replace => {
-            let query = query.update_attributes_replace(request);
+            let query = 
+              UpdateQueryBuilder::new(state.client.connection_ref())
+              .update_attributes_replace(request);
 
             Ok(Json(query.one().await?.ok_or_else(|| {
                 APIError(BadRequest(ErrorResponse {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/attributes.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/attributes.rs
@@ -1,0 +1,117 @@
+use crate::database::entities::object::Model as FileObject;
+use crate::database::entities::s3_object::Model as FileS3Object;
+use crate::error::Error::APIError;
+use crate::error::Result;
+use crate::queries::update::UpdateQueryBuilder;
+use crate::routes::ErrorStatusCode::BadRequest;
+use crate::routes::{AppState, ErrorResponse, ErrorStatusCode};
+use axum::extract::{Path, Query, State};
+use axum::Json;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use utoipa::{IntoParams, ToSchema};
+use uuid::Uuid;
+
+/// The type of merge strategy to use when updating attributes.
+#[derive(Debug, Default, Deserialize, ToSchema)]
+pub enum MergeStrategy {
+    /// Insert the attributes and return a 400 error if the attribute key already exists.
+    #[default]
+    Insert,
+    /// Insert the attributes only if the key does not already exist. Does not update
+    /// the attributes if the key does exist and no error is returned.
+    InsertIfNotExists,
+    /// Insert the attributes if the key does not exist or replace the existing attributes
+    /// under the same key if it does exist.
+    Replace,
+}
+
+/// The attributes to update for the request. This gets merged into the existing attributes
+/// according to the `MergeStrategy`. The body of the request must be a valid JSON
+/// Object type in order to perform merging. That is, the outer type of the JSON input
+/// must be an Object with at least one key, e.g.
+///
+/// ```json
+/// {
+///     "attribute_id": "id"
+/// }
+/// ```
+///
+/// This means that other JSON types in the outer JSON body are not supported. It's not possible
+/// to merge outer array types, however arrays inside an Object type are supported. E.g. this will
+/// return an error:
+///
+/// ```json
+/// ["1", "2", "3"]
+/// ```
+///
+/// And this is a valid request:
+///
+/// ```json
+/// {
+///     "some_array": ["1", "2", "3"]
+/// }
+/// ```
+#[derive(Debug, Deserialize, Default)]
+pub struct AttributeBody(Map<String, Value>);
+
+impl AttributeBody {
+    /// Create a new attribute body.
+    pub fn new(inner: Map<String, Value>) -> Self {
+        Self(inner)
+    }
+
+    /// Get the inner JSON value.
+    pub fn into_inner(self) -> Value {
+        Value::Object(self.0)
+    }
+}
+
+/// Params for an update to attributes.
+#[derive(Debug, Deserialize, Default, IntoParams)]
+#[serde(default)]
+#[into_params(parameter_in = Query)]
+pub struct UpdateAttributesParams {
+    /// The type of merge strategy to use when updating attributes.
+    #[param(nullable)]
+    merge_strategy: MergeStrategy,
+}
+
+/// Update the object attributes using a patch request.
+#[utoipa::path(
+    patch,
+    path = "/objects/{id}",
+    responses(
+        (status = OK, description = "Update the object attributes", body = FileObject),
+        ErrorStatusCode,
+    ),
+    params(UpdateAttributesParams),
+    request_body = AttributeBody,
+    context_path = "/api/v1",
+)]
+pub async fn update_object_attributes(
+    state: State<AppState>,
+    Path(id): Path<Uuid>,
+    Query(update_attributes): Query<UpdateAttributesParams>,
+    Json(request): Json<AttributeBody>,
+) -> Result<Json<FileObject>> {
+    let query = UpdateQueryBuilder::new(&state.client);
+
+    match update_attributes.merge_strategy {
+        MergeStrategy::Insert => {
+            unimplemented!()
+        }
+        MergeStrategy::InsertIfNotExists => {
+            unimplemented!()
+        }
+        MergeStrategy::Replace => {
+            let query = query.update_attributes_replace(request);
+
+            Ok(Json(query.one().await?.ok_or_else(|| {
+                APIError(BadRequest(ErrorResponse {
+                    message: format!("object with id {} not found", id),
+                }))
+            })?))
+        }
+    }
+}

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/attributes.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/attributes.rs
@@ -61,8 +61,13 @@ impl AttributeBody {
         Self(inner)
     }
 
-    /// Get the inner JSON value.
-    pub fn into_inner(self) -> Value {
+    /// Get the inner map.
+    pub fn into_inner(self) -> Map<String, Value> {
+        self.0
+    }
+    
+    /// Get the inner JSON object.
+    pub fn into_object(self) -> Value {
         Value::Object(self.0)
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/error.rs
@@ -1,0 +1,106 @@
+//! Error related parsing code specific to HTTP routes and responses.
+//!
+
+use crate::error::Error;
+use aws_lambda_events::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use sea_orm::DbErr;
+use serde::Serialize;
+use utoipa::{IntoResponses, ToSchema};
+
+/// The fallback route, returns `NOT_FOUND`.
+pub async fn fallback() -> impl IntoResponse {
+    (
+        StatusCode::NOT_FOUND,
+        Json(ErrorResponse::new("not found".to_string())),
+    )
+        .into_response()
+}
+
+/// The error response format returned in the API.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ErrorResponse {
+    message: String,
+}
+
+/// An enum representing http status code errors returned by the API.
+#[derive(Debug, IntoResponses)]
+pub enum ErrorStatusCode {
+    #[response(
+        status = BAD_REQUEST,
+        description = "the request could not be parsed or the request triggered a constraint error in the database",
+        example = json!({"message": "JSON Error: parsing json"}),
+    )]
+    BadRequest(ErrorResponse),
+    #[response(
+        status = NOT_FOUND,
+        description = "the resource or route could not be found",
+        example = json!({"message": "expected some value for id: `00000000-0000-0000-0000-000000000000`"}),
+    )]
+    NotFound(ErrorResponse),
+    #[response(
+        status = INTERNAL_SERVER_ERROR,
+        description = "an unexpected error occurred in the server",
+        example = json!({"message": "Failed to acquire connection from pool: Connection pool timed out"}),
+    )]
+    InternalServerError(ErrorResponse),
+}
+
+impl IntoResponse for ErrorStatusCode {
+    fn into_response(self) -> Response {
+        match self {
+            ErrorStatusCode::BadRequest(err) => {
+                (StatusCode::BAD_REQUEST, Json(err)).into_response()
+            }
+            ErrorStatusCode::InternalServerError(err) => {
+                (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response()
+            }
+            ErrorStatusCode::NotFound(err) => (StatusCode::NOT_FOUND, Json(err)).into_response(),
+        }
+    }
+}
+
+impl From<DbErr> for ErrorStatusCode {
+    fn from(err: DbErr) -> Self {
+        if let Some(err) = err.sql_err() {
+            Self::BadRequest(ErrorResponse::new(err.to_string()))
+        } else {
+            Self::InternalServerError(err.to_string().into())
+        }
+    }
+}
+
+impl From<Error> for ErrorStatusCode {
+    fn from(err: Error) -> Self {
+        match err {
+            Error::DatabaseError(err) => Self::from(err),
+            Error::OverflowError | Error::ConversionError(_) => {
+                Self::BadRequest(err.to_string().into())
+            }
+            Error::InvalidQuery(_) => Self::BadRequest(err.to_string().into()),
+            Error::QueryError(_) => Self::InternalServerError(err.to_string().into()),
+            Error::ExpectedSomeValue(_) => Self::NotFound(err.to_string().into()),
+            _ => Self::InternalServerError("unexpected error".to_string().into()),
+        }
+    }
+}
+
+impl From<String> for ErrorResponse {
+    fn from(err: String) -> Self {
+        ErrorResponse::new(err)
+    }
+}
+
+impl ErrorResponse {
+    /// Create an error response.
+    pub fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
+impl IntoResponse for Error {
+    fn into_response(self) -> Response {
+        ErrorStatusCode::from(self).into_response()
+    }
+}

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
@@ -66,7 +66,7 @@ mod tests {
     use crate::database::entities::object::Model as Object;
     use crate::database::entities::s3_object::Model as S3Object;
     use crate::queries::tests::initialize_database;
-    use crate::routes::list::tests::response_from;
+    use crate::routes::list::tests::response_from_get;
     use crate::routes::AppState;
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -75,7 +75,8 @@ mod tests {
         let entries = initialize_database(state.client(), 10).await.objects;
 
         let first = entries.first().unwrap();
-        let result: Object = response_from(state, &format!("/objects/{}", first.object_id)).await;
+        let result: Object =
+            response_from_get(state, &format!("/objects/{}", first.object_id)).await;
         assert_eq!(&result, first);
     }
 
@@ -86,7 +87,7 @@ mod tests {
 
         let first = entries.first().unwrap();
         let result: S3Object =
-            response_from(state, &format!("/s3_objects/{}", first.s3_object_id)).await;
+            response_from_get(state, &format!("/s3_objects/{}", first.s3_object_id)).await;
         assert_eq!(&result, first);
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
@@ -2,72 +2,89 @@
 //!
 
 use axum::extract::{Path, State};
-use axum::Json;
-use serde::Deserialize;
+use axum::routing::get;
+use axum::{Json, Router};
 use uuid::Uuid;
 
 use crate::database::entities::object::Model as FileObject;
 use crate::database::entities::s3_object::Model as FileS3Object;
+use crate::error::Error::ExpectedSomeValue;
 use crate::error::Result;
 use crate::queries::get::GetQueryBuilder;
-use crate::routes::{AppState, ErrorStatusCode};
+use crate::routes::error::ErrorStatusCode;
+use crate::routes::AppState;
 
-/// Params for a get object by id request.
-#[derive(Debug, Deserialize)]
-pub struct GetObjectById {}
-
-/// The get object handler.
+/// Get an object given it's id.
 #[utoipa::path(
     get,
     path = "/objects/{id}",
     responses(
-        (status = OK, description = "Get an object by its object_id", body = Option<FileObject>),
+        (status = OK, description = "The object for the given id", body = FileObject),
         ErrorStatusCode,
     ),
     context_path = "/api/v1",
+    tag = "get",
 )]
 pub async fn get_object_by_id(
     state: State<AppState>,
     Path(id): Path<Uuid>,
-) -> Result<Json<Option<FileObject>>> {
+) -> Result<Json<FileObject>> {
     let query = GetQueryBuilder::new(&state.client);
 
-    Ok(Json(query.get_object(id).await?))
+    Ok(Json(
+        query
+            .get_object(id)
+            .await?
+            .ok_or_else(|| ExpectedSomeValue(id))?,
+    ))
 }
 
-/// Params for a get s3 objects by id request.
-#[derive(Debug, Deserialize)]
-pub struct GetS3ObjectById {}
-
-/// The get s3 objects handler.
+/// Get an s3_object given it's id.
 #[utoipa::path(
     get,
     path = "/s3_objects/{id}",
     responses(
-        (status = OK, description = "Get an s3object by its s3_object_id", body = Option<FileS3Object>),
+        (status = OK, description = "The s3_object for the given id", body = FileS3Object),
         ErrorStatusCode,
     ),
     context_path = "/api/v1",
+    tag = "get",
 )]
 pub async fn get_s3_object_by_id(
     state: State<AppState>,
     Path(id): Path<Uuid>,
-) -> Result<Json<Option<FileS3Object>>> {
+) -> Result<Json<FileS3Object>> {
     let query = GetQueryBuilder::new(&state.client);
 
-    Ok(Json(query.get_s3_object_by_id(id).await?))
+    Ok(Json(
+        query
+            .get_s3_object_by_id(id)
+            .await?
+            .ok_or_else(|| ExpectedSomeValue(id))?,
+    ))
+}
+
+/// The router for getting object records.
+pub fn get_router() -> Router<AppState> {
+    Router::new()
+        .route("/objects/:id", get(get_object_by_id))
+        .route("/s3_objects/:id", get(get_s3_object_by_id))
 }
 
 #[cfg(test)]
 mod tests {
+    use axum::body::Body;
+    use axum::http::{Method, StatusCode};
     use sqlx::PgPool;
 
     use crate::database::aws::migration::tests::MIGRATOR;
-    use crate::database::entities::object::Model as Object;
-    use crate::database::entities::s3_object::Model as S3Object;
     use crate::queries::tests::initialize_database;
-    use crate::routes::list::tests::response_from_get;
+    use crate::routes::list::tests::{response_from, response_from_get};
     use crate::routes::AppState;
+    use crate::uuid::UuidGenerator;
+    use serde_json::Value;
+
+    use super::*;
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn get_objects_api(pool: PgPool) {
@@ -75,7 +92,7 @@ mod tests {
         let entries = initialize_database(state.client(), 10).await.objects;
 
         let first = entries.first().unwrap();
-        let result: Object =
+        let result: FileObject =
             response_from_get(state, &format!("/objects/{}", first.object_id)).await;
         assert_eq!(&result, first);
     }
@@ -86,8 +103,31 @@ mod tests {
         let entries = initialize_database(state.client(), 10).await.s3_objects;
 
         let first = entries.first().unwrap();
-        let result: S3Object =
+        let result: FileS3Object =
             response_from_get(state, &format!("/s3_objects/{}", first.s3_object_id)).await;
         assert_eq!(&result, first);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn get_non_existent(pool: PgPool) {
+        let state = AppState::from_pool(pool);
+
+        let (status_code, _) = response_from::<Value>(
+            state.clone(),
+            &format!("/objects/{}", UuidGenerator::generate()),
+            Method::GET,
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(status_code, StatusCode::NOT_FOUND);
+
+        let (status_code, _) = response_from::<Value>(
+            state,
+            &format!("/s3_objects/{}", UuidGenerator::generate()),
+            Method::GET,
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(status_code, StatusCode::NOT_FOUND);
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -82,7 +82,7 @@ pub async fn list_objects(
     Query(pagination): Query<Pagination>,
     QsQuery(filter_all): QsQuery<ObjectsFilterAll>,
 ) -> Result<Json<ListResponse<FileObject>>> {
-    let response = ListQueryBuilder::<object::Entity>::new(&state.client)
+    let response = ListQueryBuilder::<_, object::Entity>::new(state.client.connection_ref())
         .filter_all(filter_all)
         .paginate_to_list_response(pagination)
         .await?;
@@ -106,7 +106,7 @@ pub async fn count_objects(
     state: State<AppState>,
     QsQuery(filter_all): QsQuery<ObjectsFilterAll>,
 ) -> Result<Json<ListCount>> {
-    let response = ListQueryBuilder::<object::Entity>::new(&state.client)
+    let response = ListQueryBuilder::<_, object::Entity>::new(state.client.connection_ref())
         .filter_all(filter_all)
         .to_list_count()
         .await?;
@@ -131,6 +131,18 @@ pub struct ListS3ObjectsParams {
     current_state: bool,
 }
 
+impl ListS3ObjectsParams {
+    /// Create the current state struct.
+    pub fn new(current_state: bool) -> Self {
+        Self { current_state }
+    }
+
+    /// Get the current state.
+    pub fn current_state(&self) -> bool {
+        self.current_state
+    }
+}
+
 /// List all s3_objects according to the parameters.
 #[utoipa::path(
     get,
@@ -149,8 +161,8 @@ pub async fn list_s3_objects(
     Query(list): Query<ListS3ObjectsParams>,
     QsQuery(filter_all): QsQuery<S3ObjectsFilterAll>,
 ) -> Result<Json<ListResponse<FileS3Object>>> {
-    let mut response =
-        ListQueryBuilder::<s3_object::Entity>::new(&state.client).filter_all(filter_all);
+    let mut response = ListQueryBuilder::<_, s3_object::Entity>::new(state.client.connection_ref())
+        .filter_all(filter_all);
 
     if list.current_state {
         response = response.current_state();
@@ -176,8 +188,8 @@ pub async fn count_s3_objects(
     Query(list): Query<ListS3ObjectsParams>,
     QsQuery(filter_all): QsQuery<S3ObjectsFilterAll>,
 ) -> Result<Json<ListCount>> {
-    let mut response =
-        ListQueryBuilder::<s3_object::Entity>::new(&state.client).filter_all(filter_all);
+    let mut response = ListQueryBuilder::<_, s3_object::Entity>::new(state.client.connection_ref())
+        .filter_all(filter_all);
 
     if list.current_state {
         response = response.current_state();

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -410,6 +410,8 @@ pub(crate) mod tests {
             .unwrap()
             .to_vec();
 
+        println!("{:#?}", String::from_utf8(bytes.clone()));
+
         (status, from_slice::<T>(bytes.as_slice()).unwrap())
     }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
@@ -17,7 +17,10 @@ use crate::database::Client;
 use crate::env::Config;
 use crate::error::Error;
 use crate::error::Error::InvalidQuery;
-use crate::routes::attributes::{update_object_attributes, update_object_collection_attributes};
+use crate::routes::attributes::{
+    update_object_attributes, update_object_collection_attributes, update_s3_object_attributes,
+    update_s3_object_collection_attributes,
+};
 use crate::routes::get::*;
 use crate::routes::ingest::ingest_from_sqs;
 use crate::routes::list::*;
@@ -80,6 +83,8 @@ pub fn api_router(state: AppState) -> Router {
         .route("/ingest_from_sqs", post(ingest_from_sqs))
         .route("/objects/:id", patch(update_object_attributes))
         .route("/objects", patch(update_object_collection_attributes))
+        .route("/s3_objects/:id", patch(update_s3_object_attributes))
+        .route("/s3_objects", patch(update_s3_object_collection_attributes))
         .with_state(state)
         .layer(TraceLayer::new_for_http())
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
@@ -20,6 +20,7 @@ use crate::routes::ingest::ingest_from_sqs;
 use crate::routes::list::*;
 use crate::routes::openapi::swagger_ui;
 
+pub mod attributes;
 pub mod filtering;
 pub mod get;
 pub mod ingest;
@@ -140,6 +141,7 @@ impl From<Error> for ErrorStatusCode {
             Error::OverflowError | Error::ConversionError(_) => {
                 Self::BadRequest(err.to_string().into())
             }
+            Error::APIError(err) => err,
             _ => Self::InternalServerError("unexpected error".to_string().into()),
         }
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
@@ -3,36 +3,27 @@
 
 use std::sync::Arc;
 
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
-use axum::routing::{get, patch, post};
-use axum::{Json, Router};
-use sea_orm::DbErr;
-use serde::Serialize;
+use axum::Router;
 use sqlx::PgPool;
 use tower_http::trace::TraceLayer;
-use utoipa::{IntoResponses, ToSchema};
 
 use crate::database::Client;
 use crate::env::Config;
-use crate::error::Error;
-use crate::error::Error::InvalidQuery;
-use crate::routes::attributes::{
-    update_object_attributes, update_object_collection_attributes, update_s3_object_attributes,
-    update_s3_object_collection_attributes,
-};
+use crate::routes::error::fallback;
 use crate::routes::get::*;
-use crate::routes::ingest::ingest_from_sqs;
+use crate::routes::ingest::ingest_router;
 use crate::routes::list::*;
 use crate::routes::openapi::swagger_ui;
+use crate::routes::update::update_router;
 
-pub mod attributes;
+pub mod error;
 pub mod filtering;
 pub mod get;
 pub mod ingest;
 pub mod list;
 pub mod openapi;
 pub mod pagination;
+pub mod update;
 
 /// App state containing database client.
 #[derive(Debug, Clone)]
@@ -74,108 +65,12 @@ pub fn router(state: AppState) -> Router {
 /// The main filemanager router for requests.
 pub fn api_router(state: AppState) -> Router {
     Router::new()
-        .route("/objects", get(list_objects))
-        .route("/objects/:id", get(get_object_by_id))
-        .route("/objects/count", get(count_objects))
-        .route("/s3_objects", get(list_s3_objects))
-        .route("/s3_objects/:id", get(get_s3_object_by_id))
-        .route("/s3_objects/count", get(count_s3_objects))
-        .route("/ingest_from_sqs", post(ingest_from_sqs))
-        .route("/objects/:id", patch(update_object_attributes))
-        .route("/objects", patch(update_object_collection_attributes))
-        .route("/s3_objects/:id", patch(update_s3_object_attributes))
-        .route("/s3_objects", patch(update_s3_object_collection_attributes))
+        .merge(get_router())
+        .merge(ingest_router())
+        .merge(list_router())
+        .merge(update_router())
         .with_state(state)
         .layer(TraceLayer::new_for_http())
-}
-
-/// The fallback route.
-async fn fallback() -> impl IntoResponse {
-    (
-        StatusCode::NOT_FOUND,
-        Json(ErrorResponse::new("not found".to_string())),
-    )
-        .into_response()
-}
-
-/// The error response format returned in the API.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct ErrorResponse {
-    message: String,
-}
-
-/// An enum representing http status code errors returned by the API.
-#[derive(Debug, IntoResponses)]
-pub enum ErrorStatusCode {
-    #[response(
-        status = BAD_REQUEST,
-        description = "the request could not be parsed or the request triggered a constraint error in the database",
-        example = json!({"message": "Json Error: parsing json"}),
-    )]
-    BadRequest(ErrorResponse),
-    #[response(
-        status = INTERNAL_SERVER_ERROR,
-        description = "an unexpected error occurred in the server",
-        example = json!({"message": "Failed to acquire connection from pool: Connection pool timed out"}),
-    )]
-    InternalServerError(ErrorResponse),
-}
-
-impl IntoResponse for ErrorStatusCode {
-    fn into_response(self) -> Response {
-        match self {
-            ErrorStatusCode::BadRequest(err) => {
-                (StatusCode::BAD_REQUEST, Json(err)).into_response()
-            }
-            ErrorStatusCode::InternalServerError(err) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response()
-            }
-        }
-    }
-}
-
-impl From<DbErr> for ErrorStatusCode {
-    fn from(err: DbErr) -> Self {
-        if let Some(err) = err.sql_err() {
-            Self::BadRequest(ErrorResponse::new(err.to_string()))
-        } else {
-            Self::InternalServerError(err.to_string().into())
-        }
-    }
-}
-
-impl From<Error> for ErrorStatusCode {
-    fn from(err: Error) -> Self {
-        match err {
-            Error::DatabaseError(err) => Self::from(err),
-            Error::OverflowError | Error::ConversionError(_) => {
-                Self::BadRequest(err.to_string().into())
-            }
-            InvalidQuery(_) => Self::BadRequest(err.to_string().into()),
-            Error::APIError(err) => err,
-            Error::QueryError(_) => Self::InternalServerError(err.to_string().into()),
-            _ => Self::InternalServerError("unexpected error".to_string().into()),
-        }
-    }
-}
-
-impl From<String> for ErrorResponse {
-    fn from(err: String) -> Self {
-        ErrorResponse::new(err)
-    }
-}
-
-impl ErrorResponse {
-    /// Create an error response.
-    pub fn new(message: String) -> Self {
-        Self { message }
-    }
-}
-
-impl IntoResponse for Error {
-    fn into_response(self) -> Response {
-        ErrorStatusCode::from(self).into_response()
-    }
 }
 
 #[cfg(test)]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
@@ -3,7 +3,7 @@
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use axum::routing::{get, post};
+use axum::routing::{get, patch, post};
 use axum::{Json, Router};
 use sea_orm::DbErr;
 use serde::Serialize;
@@ -15,6 +15,7 @@ use utoipa::{IntoResponses, ToSchema};
 use crate::database::Client;
 use crate::env::Config;
 use crate::error::Error;
+use crate::routes::attributes::update_object_attributes;
 use crate::routes::get::*;
 use crate::routes::ingest::ingest_from_sqs;
 use crate::routes::list::*;
@@ -75,6 +76,7 @@ pub fn api_router(state: AppState) -> Router {
         .route("/s3_objects/:id", get(get_s3_object_by_id))
         .route("/s3_objects/count", get(count_s3_objects))
         .route("/ingest_from_sqs", post(ingest_from_sqs))
+        .route("/objects/:id", patch(update_object_attributes))
         .with_state(state)
         .layer(TraceLayer::new_for_http())
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -11,10 +11,11 @@ use crate::database::entities::object::Model as FileObject;
 use crate::database::entities::s3_object::Model as FileS3Object;
 use crate::database::entities::sea_orm_active_enums::EventType;
 use crate::database::entities::sea_orm_active_enums::StorageClass;
+use crate::routes::error::ErrorResponse;
 use crate::routes::get::*;
 use crate::routes::ingest::*;
 use crate::routes::list::*;
-use crate::routes::ErrorResponse;
+use crate::routes::update::*;
 
 /// A newtype equivalent to a `DateTime` with a time zone.
 #[derive(ToSchema)]
@@ -37,6 +38,10 @@ pub struct Json(pub Value);
         get_s3_object_by_id,
         count_s3_objects,
         ingest_from_sqs,
+        update_object_attributes,
+        update_object_collection_attributes,
+        update_s3_object_attributes,
+        update_s3_object_collection_attributes,
     ),
     components(
         schemas(
@@ -51,6 +56,8 @@ pub struct Json(pub Value);
             Json,
             ListResponseObject,
             ListResponseS3Object,
+            PatchBody,
+            Patch
         )
     ),
     modifiers(&SecurityAddon),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -11,7 +11,6 @@ use crate::database::entities::object::Model as FileObject;
 use crate::database::entities::s3_object::Model as FileS3Object;
 use crate::database::entities::sea_orm_active_enums::EventType;
 use crate::database::entities::sea_orm_active_enums::StorageClass;
-use crate::routes::attributes::*;
 use crate::routes::get::*;
 use crate::routes::ingest::*;
 use crate::routes::list::*;
@@ -52,7 +51,6 @@ pub struct Json(pub Value);
             Json,
             ListResponseObject,
             ListResponseS3Object,
-            MergeStrategy,
         )
     ),
     modifiers(&SecurityAddon),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -11,6 +11,7 @@ use crate::database::entities::object::Model as FileObject;
 use crate::database::entities::s3_object::Model as FileS3Object;
 use crate::database::entities::sea_orm_active_enums::EventType;
 use crate::database::entities::sea_orm_active_enums::StorageClass;
+use crate::routes::attributes::*;
 use crate::routes::get::*;
 use crate::routes::ingest::*;
 use crate::routes::list::*;
@@ -51,6 +52,7 @@ pub struct Json(pub Value);
             Json,
             ListResponseObject,
             ListResponseS3Object,
+            MergeStrategy,
         )
     ),
     modifiers(&SecurityAddon),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
@@ -71,7 +71,7 @@ mod tests {
     use crate::database::entities::object::Model as Object;
     use crate::database::entities::s3_object::Model as S3Object;
     use crate::queries::tests::{initialize_database, initialize_database_reorder};
-    use crate::routes::list::tests::response_from;
+    use crate::routes::list::tests::response_from_get;
     use crate::routes::list::ListResponse;
     use crate::routes::AppState;
 
@@ -81,7 +81,7 @@ mod tests {
         let entries = initialize_database(state.client(), 10).await.objects;
 
         let result: ListResponse<Object> =
-            response_from(state, "/objects?page=2&page_size=2").await;
+            response_from_get(state, "/objects?page=2&page_size=2").await;
         assert_eq!(result.next_page(), Some(3));
         assert_eq!(result.results(), &entries[4..6]);
     }
@@ -92,12 +92,12 @@ mod tests {
         let entries = initialize_database(state.client(), 10).await.objects;
 
         let result: ListResponse<Object> =
-            response_from(state.clone(), "/objects?page=0&page_size=20").await;
+            response_from_get(state.clone(), "/objects?page=0&page_size=20").await;
         assert!(result.next_page().is_none());
         assert_eq!(result.results(), entries);
 
         let result: ListResponse<Object> =
-            response_from(state, "/objects?page=20&page_size=1").await;
+            response_from_get(state, "/objects?page=20&page_size=1").await;
         assert!(result.next_page().is_none());
         assert!(result.results().is_empty());
     }
@@ -107,7 +107,8 @@ mod tests {
         let state = AppState::from_pool(pool);
         let entries = initialize_database(state.client(), 10).await.objects;
 
-        let result: ListResponse<Object> = response_from(state, "/s3_objects?page_size=0").await;
+        let result: ListResponse<Object> =
+            response_from_get(state, "/s3_objects?page_size=0").await;
         assert_eq!(result.next_page(), None);
         assert_eq!(result.results(), entries);
     }
@@ -120,7 +121,7 @@ mod tests {
             .s3_objects;
 
         let result: ListResponse<S3Object> =
-            response_from(state, "/s3_objects?page=1&page_size=2").await;
+            response_from_get(state, "/s3_objects?page=1&page_size=2").await;
         assert_eq!(result.next_page(), Some(2));
         assert_eq!(result.results(), &entries[2..4]);
     }
@@ -133,12 +134,12 @@ mod tests {
             .s3_objects;
 
         let result: ListResponse<S3Object> =
-            response_from(state.clone(), "/s3_objects?page=0&page_size=20").await;
+            response_from_get(state.clone(), "/s3_objects?page=0&page_size=20").await;
         assert!(result.next_page().is_none());
         assert_eq!(result.results(), entries);
 
         let result: ListResponse<S3Object> =
-            response_from(state, "/s3_objects?page=20&page_size=1").await;
+            response_from_get(state, "/s3_objects?page=20&page_size=1").await;
         assert!(result.next_page().is_none());
         assert!(result.results().is_empty());
     }
@@ -150,7 +151,8 @@ mod tests {
             .await
             .s3_objects;
 
-        let result: ListResponse<S3Object> = response_from(state, "/s3_objects?page_size=0").await;
+        let result: ListResponse<S3Object> =
+            response_from_get(state, "/s3_objects?page_size=0").await;
         assert_eq!(result.next_page(), None);
         assert_eq!(result.results(), entries);
     }


### PR DESCRIPTION
Closes #423 

### Changes
* Adds multiple PATCH routes which allow updating the attributes column for a single `s3_object`/`object`, or a collection of records.
    * This uses JSON patch to perform the update by first querying the database for the correct records to update, then applying the patch to the attributes column, and writing the attributes back to the database.
* Add tests for the new endpoints and update the openapi docs.
* Return `NOT_FOUND` for getting/updating single records if the supplied `id` does not exist.
* Bump a few dependencies.

### To do

This is part of the change that allows attribute linking. In theory, any service can now add whatever attributes they want to a filemanager record. Still to do is implementing a rule system to submit jobs for linking attributes on filemanager records, and allowing attributes to be updated using the EventBus instead of a PATCH request.
