### PR TITLE
Chore: Upgrade OpenAPI3 for DRF Microservice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ start-all-service:
 	@(cd lib/workload/stateless/stacks/workflow-manager && $(MAKE) s3-load)
 
 	# Running the rest of the µ-service server
-	docker compose up --wait -d
+	docker compose up --wait -d --build
 
 stop-all-service:
 	docker compose down

--- a/lib/workload/stateless/stacks/metadata-manager/app/settings/local.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/settings/local.py
@@ -32,7 +32,7 @@ SPECTACULAR_SETTINGS = {
     'TITLE': 'Metadata Manager API',
     'DESCRIPTION': 'The Metadata Manager API for UMCCR.',
     'VERSION': '0.0.1',
-    'SERVE_INCLUDE_SCHEMA': True,
+    'SERVE_INCLUDE_SCHEMA': False,
     'SECURITY': [
         {
             "type": "http",
@@ -46,6 +46,10 @@ SPECTACULAR_SETTINGS = {
     },
     "LICENSE": {
         "name": "MIT License",
+    },
+    "EXTERNAL_DOCS": {
+        "description": "Terms of service",
+        "url": "https://umccr.org/",
     },
 }
 

--- a/lib/workload/stateless/stacks/metadata-manager/app/settings/local.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/settings/local.py
@@ -31,7 +31,7 @@ REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
 SPECTACULAR_SETTINGS = {
     'TITLE': 'Metadata Manager API',
     'DESCRIPTION': 'The Metadata Manager API for UMCCR.',
-    'VERSION': '0.0.0',
+    'VERSION': '0.0.1',
     'SERVE_INCLUDE_SCHEMA': True,
     'SECURITY': [
         {

--- a/lib/workload/stateless/stacks/metadata-manager/app/urls/local.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/urls/local.py
@@ -1,14 +1,9 @@
 from django.urls import path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-from django.contrib import admin
-
 from .base import urlpatterns as base_urlpatterns
 
-
 urlpatterns = base_urlpatterns + [
-    path("admin/", admin.site.urls),
     path('schema/', SpectacularAPIView.as_view(), name='schema'),
     path('schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
-
 ]

--- a/lib/workload/stateless/stacks/metadata-manager/app/urls/local.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/urls/local.py
@@ -5,5 +5,6 @@ from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
     path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
-    path('schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    path('swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'),
+         name='swagger-ui'),
 ]

--- a/lib/workload/stateless/stacks/metadata-manager/app/urls/local.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/urls/local.py
@@ -1,9 +1,9 @@
 from django.urls import path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
 
 from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
-    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
     path('schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]

--- a/lib/workload/stateless/stacks/metadata-manager/deps/requirements-dev.txt
+++ b/lib/workload/stateless/stacks/metadata-manager/deps/requirements-dev.txt
@@ -1,1 +1,2 @@
 -r requirements-test.txt
+django_extensions==3.2.3

--- a/lib/workload/stateless/stacks/metadata-manager/deps/requirements-slim.txt
+++ b/lib/workload/stateless/stacks/metadata-manager/deps/requirements-slim.txt
@@ -7,7 +7,6 @@ Django==5.0.7
 django-cors-headers==4.3.1
 django-environ==0.11.2
 django-simple-history==3.5.0
-django_extensions==3.2.3
 drf-spectacular==0.27.2
 
 # See psycopg[binary] or psycopg[c] impl https://www.psycopg.org/psycopg3/docs/basic/install.html

--- a/lib/workload/stateless/stacks/sequence-run-manager/deps/requirements-dev.txt
+++ b/lib/workload/stateless/stacks/sequence-run-manager/deps/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements-test.txt
-
+django_extensions==3.2.3
 openapi-spec-validator

--- a/lib/workload/stateless/stacks/sequence-run-manager/deps/requirements-dev.txt
+++ b/lib/workload/stateless/stacks/sequence-run-manager/deps/requirements-dev.txt
@@ -1,4 +1,3 @@
 -r requirements-test.txt
-django_extensions==3.2.3
-drf_yasg==1.21.7
+
 openapi-spec-validator

--- a/lib/workload/stateless/stacks/sequence-run-manager/deps/requirements.txt
+++ b/lib/workload/stateless/stacks/sequence-run-manager/deps/requirements.txt
@@ -7,7 +7,6 @@ djangorestframework==3.15.1
 django-cors-headers==4.3.1
 django-environ==0.11.2
 djangorestframework-camel-case==1.4.2
-django_extensions==3.2.3
 drf-spectacular==0.27.2
 
 # See psycopg[binary] or psycopg[c] impl https://www.psycopg.org/psycopg3/docs/basic/install.html

--- a/lib/workload/stateless/stacks/sequence-run-manager/deps/requirements.txt
+++ b/lib/workload/stateless/stacks/sequence-run-manager/deps/requirements.txt
@@ -7,6 +7,9 @@ djangorestframework==3.15.1
 django-cors-headers==4.3.1
 django-environ==0.11.2
 djangorestframework-camel-case==1.4.2
+django_extensions==3.2.3
+drf-spectacular==0.27.2
+
 # See psycopg[binary] or psycopg[c] impl https://www.psycopg.org/psycopg3/docs/basic/install.html
 psycopg[binary]==3.1.18
 Werkzeug==3.0.3

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/pagination.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/pagination.py
@@ -31,3 +31,31 @@ class StandardResultsSetPagination(PageNumberPagination):
                 "results": data,
             }
         )
+
+    def get_paginated_response_schema(self, schema):
+        return {
+            "type": "object",
+            'required': ['links', 'pagination', 'results'],
+            "properties": {
+                "links": {
+                    "type": "object",
+                    "properties": {
+                        "next": {"type": "string", "format": "uri", "nullable": True,
+                                 'example': 'http://api.example.org/accounts/?{page_query_param}=4'.format(
+                                     page_query_param=self.page_query_param)},
+                        "previous": {"type": "string", "format": "uri", "nullable": True,
+                                     'example': 'http://api.example.org/accounts/?{page_query_param}=2'.format(
+                                         page_query_param=self.page_query_param)},
+                    },
+                },
+                "pagination": {
+                    "type": "object",
+                    "properties": {
+                        PaginationConstant.COUNT: {"type": "integer"},
+                        PaginationConstant.PAGE: {"type": "integer"},
+                        PaginationConstant.ROWS_PER_PAGE: {"type": "integer"},
+                    },
+                },
+                "results": schema
+            },
+        }

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/base.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/base.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import aws_xray_sdk
 from corsheaders.defaults import default_headers
 
+API_VERSION = "v1"
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/local.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/local.py
@@ -9,7 +9,7 @@ import sys
 from environ import Env
 
 from .base import *  # noqa
-
+# from sequence_run_manager.urls.base import api_version
 db_conn_cfg = Env.db_url_config(
     # pragma: allowlist nextline secret
     os.getenv("DB_URL", "postgresql://orcabus:orcabus@localhost:5432/orcabus")
@@ -19,22 +19,34 @@ DATABASES = {"default": db_conn_cfg}
 
 INSTALLED_APPS += (
     "django_extensions",
-    "drf_yasg",
+    "drf_spectacular",
 )
 
 ROOT_URLCONF = "sequence_run_manager.urls.local"
 
 RUNSERVER_PLUS_PRINT_SQL_TRUNCATE = sys.maxsize
 
-# --- drf_yasg swagger and redoc settings
+# --- drf-spectacular settings
 
-SWAGGER_SETTINGS = {
-    "SECURITY_DEFINITIONS": {
-        "Bearer": {"type": "apiKey", "name": "Authorization", "in": "header"}
+REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'UMCCR OrcaBus sequence_run_manager API',
+    'DESCRIPTION': 'UMCCR OrcaBus sequence_run_manager API',
+    'VERSION': API_VERSION,
+    'SERVE_INCLUDE_SCHEMA': True,
+    'SECURITY': [
+        {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
+    ],
+    'CONTACT': {
+        'name': 'UMCCR',
+        'email': 'services@umccr.org'
     },
-    "USE_SESSION_AUTH": False,
-}
-
-REDOC_SETTINGS = {
-    "LAZY_RENDERING": False,
+    "LICENSE": {
+        "name": "MIT License",
+    },
 }

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/local.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/local.py
@@ -9,7 +9,6 @@ import sys
 from environ import Env
 
 from .base import *  # noqa
-# from sequence_run_manager.urls.base import api_version
 db_conn_cfg = Env.db_url_config(
     # pragma: allowlist nextline secret
     os.getenv("DB_URL", "postgresql://orcabus:orcabus@localhost:5432/orcabus")

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/local.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/local.py
@@ -33,7 +33,7 @@ SPECTACULAR_SETTINGS = {
     'TITLE': 'UMCCR OrcaBus sequence_run_manager API',
     'DESCRIPTION': 'UMCCR OrcaBus sequence_run_manager API',
     'VERSION': API_VERSION,
-    'SERVE_INCLUDE_SCHEMA': True,
+    'SERVE_INCLUDE_SCHEMA': False,
     'SECURITY': [
         {
             "type": "http",
@@ -47,5 +47,9 @@ SPECTACULAR_SETTINGS = {
     },
     "LICENSE": {
         "name": "MIT License",
+    },
+    "EXTERNAL_DOCS": {
+        "description": "Terms of service",
+        "url": "https://umccr.org/",
     },
 }

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/base.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/base.py
@@ -2,9 +2,10 @@ from django.urls import path, include
 
 from sequence_run_manager.routers import OptionalSlashDefaultRouter
 from sequence_run_manager.viewsets.sequence import SequenceViewSet
+from sequence_run_manager.settings.base import API_VERSION
 
 api_namespace = "srm"
-api_version = "v1"
+api_version = API_VERSION
 api_base = f"{api_namespace}/{api_version}/"
 
 router = OptionalSlashDefaultRouter()

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/local.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/local.py
@@ -1,10 +1,10 @@
 from django.urls import path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
 
 from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
-    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
     path('schema/swagger-ui/',
          SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/local.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/local.py
@@ -1,40 +1,10 @@
-from django.urls import path, include, re_path
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
-from rest_framework import permissions
+from django.urls import path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-from .base import urlpatterns as base_urlpatterns, router, api_base, api_version
-
-schema_view = get_schema_view(
-    openapi.Info(
-        title="UMCCR OrcaBus sequence_run_manager API",
-        default_version=f"{api_version}",
-        description="UMCCR OrcaBus sequence_run_manager API",
-        terms_of_service="https://umccr.org/",
-        contact=openapi.Contact(email="services@umccr.org"),
-        license=openapi.License(name="MIT License"),
-    ),
-    public=True,
-    permission_classes=[
-        permissions.AllowAny,
-    ],
-    patterns=[
-        path(f"{api_base}", include(router.urls)),
-    ],
-)
+from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
-    re_path(
-        r"^swagger(?P<format>\.json|\.yaml)$",
-        schema_view.without_ui(cache_timeout=0),
-        name="schema-json",
-    ),
-    re_path(
-        r"^swagger/$",
-        schema_view.with_ui("swagger", cache_timeout=0),
-        name="schema-swagger-ui",
-    ),
-    re_path(
-        r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"
-    ),
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/swagger-ui/',
+         SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/local.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/local.py
@@ -5,6 +5,6 @@ from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
     path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
-    path('schema/swagger-ui/',
+    path('swagger-ui/',
          SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]

--- a/lib/workload/stateless/stacks/workflow-manager/deps/requirements-dev.txt
+++ b/lib/workload/stateless/stacks/workflow-manager/deps/requirements-dev.txt
@@ -1,4 +1,3 @@
 -r requirements-test.txt
 django_extensions==3.2.3
-drf_yasg==1.21.7
 openapi-spec-validator

--- a/lib/workload/stateless/stacks/workflow-manager/deps/requirements.txt
+++ b/lib/workload/stateless/stacks/workflow-manager/deps/requirements.txt
@@ -7,6 +7,8 @@ djangorestframework==3.15.1
 django-cors-headers==4.3.1
 django-environ==0.11.2
 djangorestframework-camel-case==1.4.2
+drf-spectacular==0.27.2
+
 # See psycopg[binary] or psycopg[c] impl https://www.psycopg.org/psycopg3/docs/basic/install.html
 psycopg[binary]==3.1.18
 Werkzeug==3.0.3

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/pagination.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/pagination.py
@@ -31,3 +31,31 @@ class StandardResultsSetPagination(PageNumberPagination):
                 "results": data,
             }
         )
+
+    def get_paginated_response_schema(self, schema):
+        return {
+            "type": "object",
+            'required': ['links', 'pagination', 'results'],
+            "properties": {
+                "links": {
+                    "type": "object",
+                    "properties": {
+                        "next": {"type": "string", "format": "uri", "nullable": True,
+                                 'example': 'http://api.example.org/accounts/?{page_query_param}=4'.format(
+                                     page_query_param=self.page_query_param)},
+                        "previous": {"type": "string", "format": "uri", "nullable": True,
+                                     'example': 'http://api.example.org/accounts/?{page_query_param}=2'.format(
+                                         page_query_param=self.page_query_param)},
+                    },
+                },
+                "pagination": {
+                    "type": "object",
+                    "properties": {
+                        PaginationConstant.COUNT: {"type": "integer"},
+                        PaginationConstant.PAGE: {"type": "integer"},
+                        PaginationConstant.ROWS_PER_PAGE: {"type": "integer"},
+                    },
+                },
+                "results": schema
+            },
+        }

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/base.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/base.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import aws_xray_sdk
 from corsheaders.defaults import default_headers
 
+API_VERSION = "v1"
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/local.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/local.py
@@ -19,22 +19,34 @@ DATABASES = {"default": db_conn_cfg}
 
 INSTALLED_APPS += (
     "django_extensions",
-    "drf_yasg",
+    "drf_spectacular",
 )
 
 ROOT_URLCONF = "workflow_manager.urls.local"
 
 RUNSERVER_PLUS_PRINT_SQL_TRUNCATE = sys.maxsize
 
-# --- drf_yasg swagger and redoc settings
+# --- drf-spectacular settings
 
-SWAGGER_SETTINGS = {
-    "SECURITY_DEFINITIONS": {
-        "Bearer": {"type": "apiKey", "name": "Authorization", "in": "header"}
+REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'UMCCR OrcaBus sequence_run_manager API',
+    'DESCRIPTION': 'UMCCR OrcaBus sequence_run_manager API',
+    'VERSION': API_VERSION,
+    'SERVE_INCLUDE_SCHEMA': True,
+    'SECURITY': [
+        {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
+    ],
+    'CONTACT': {
+        'name': 'UMCCR',
+        'email': 'services@umccr.org'
     },
-    "USE_SESSION_AUTH": False,
-}
-
-REDOC_SETTINGS = {
-    "LAZY_RENDERING": False,
+    "LICENSE": {
+        "name": "MIT License",
+    },
 }

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/local.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/local.py
@@ -34,7 +34,7 @@ SPECTACULAR_SETTINGS = {
     'TITLE': 'UMCCR OrcaBus sequence_run_manager API',
     'DESCRIPTION': 'UMCCR OrcaBus sequence_run_manager API',
     'VERSION': API_VERSION,
-    'SERVE_INCLUDE_SCHEMA': True,
+    'SERVE_INCLUDE_SCHEMA': False,
     'SECURITY': [
         {
             "type": "http",
@@ -48,5 +48,9 @@ SPECTACULAR_SETTINGS = {
     },
     "LICENSE": {
         "name": "MIT License",
+    },
+    "EXTERNAL_DOCS": {
+        "description": "Terms of service",
+        "url": "https://umccr.org/",
     },
 }

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/base.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/base.py
@@ -4,9 +4,10 @@ from workflow_manager.routers import OptionalSlashDefaultRouter
 from workflow_manager.viewsets.workflow import WorkflowViewSet
 from workflow_manager.viewsets.workflow_run import WorkflowRunViewSet
 from workflow_manager.viewsets.payload import PayloadViewSet
+from workflow_manager.settings.base import API_VERSION
 
 api_namespace = "wfm"
-api_version = "v1"
+api_version = API_VERSION
 api_base = f"{api_namespace}/{api_version}/"
 
 router = OptionalSlashDefaultRouter()

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/local.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/local.py
@@ -1,10 +1,10 @@
 from django.urls import path
-from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
+from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
 
 from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
-    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
     path('schema/swagger-ui/',
          SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/local.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/local.py
@@ -5,6 +5,6 @@ from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
     path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
-    path('schema/swagger-ui/',
+    path('swagger-ui/',
          SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/local.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/local.py
@@ -1,26 +1,10 @@
-from django.urls import path, include, re_path
-from drf_yasg import openapi
-from drf_yasg.views import get_schema_view
-from rest_framework import permissions
+from django.urls import path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-from .base import urlpatterns as base_urlpatterns, router, api_version, api_base
-
-schema_view = get_schema_view(
-    openapi.Info(
-        title="UMCCR OrcaBus workflow_manager API",
-        default_version=f"{api_version}",
-        description="UMCCR OrcaBus workflow_manager API",
-        terms_of_service="https://umccr.org/",
-        contact=openapi.Contact(email="services@umccr.org"),
-        license=openapi.License(name="MIT License"),
-    ),
-    public=True,
-    permission_classes=[permissions.AllowAny, ],
-    patterns=[path(f"{api_base}", include(router.urls)), ],
-)
+from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
-    re_path(r"^swagger(?P<format>\.json|\.yaml)$", schema_view.without_ui(cache_timeout=0), name="schema-json"),
-    re_path(r"^swagger/$", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
-    re_path(r"^redoc/$", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    path('schema/', SpectacularAPIView.as_view(), name='schema'),
+    path('schema/swagger-ui/',
+         SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]


### PR DESCRIPTION
Upgrade OpenAPI to V3 for Django microservice (SRM, WFM, MM). Replaces the [drf_yasg](https://drf-yasg.readthedocs.io/en/stable/) with [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/).

Note: [The Built-in OpenAPI generator from the Django Rest framework is deprecated.](https://www.django-rest-framework.org/topics/documenting-your-api/#built-in-openapi-schema-generation-deprecated)