### PR TITLE
fix: add filemanager to local API setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ start-all-service:
 	@(cd lib/workload/stateless/stacks/metadata-manager && $(MAKE) s3-load)
 	@(cd lib/workload/stateless/stacks/sequence-run-manager && $(MAKE) s3-load)
 	@(cd lib/workload/stateless/stacks/workflow-manager && $(MAKE) s3-load)
+	@(cd lib/workload/stateless/stacks/filemanager && $(MAKE) s3-load)
 
 	# Running the rest of the µ-service server
 	docker compose up --wait -d

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ You can run all microservice APIs locally at once using Docker Compose provided 
 make start-all-service
 ```
 
+This command loads SQL data dumps from S3 in the dev account, and assumes that the shell is logged in to AWS. The SQL
+dumps generally contain all records from the dev database, except for filemanager, which has 100000 of the most recent
+records (due to it's size).
+
 To stop the services, use:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ The APIs will run on `localhost` with the following port assignments:
 
 | Microservice         | Local Endpoint          |
 |----------------------|-------------------------|
-| File Manager         | <http://localhost:8000> |
 | Metadata Manager     | <http://localhost:8100> |
 | Workflow Manager     | <http://localhost:8200> |
 | Sequence Run Manager | <http://localhost:8300> |
+| File Manager         | <http://localhost:8400> |
 
 ### Typography
 

--- a/compose.yml
+++ b/compose.yml
@@ -63,3 +63,26 @@ services:
       interval: 10s
       timeout: 2s
       retries: 5
+
+  # PORT 8400 ~ filemanager
+  filemanager:
+    environment:
+      # Container database address for running server inside a docker container.
+      - DATABASE_URL=postgresql://orcabus:orcabus@db:5432/filemanager
+      - RUST_LOG=debug
+    ports:
+      - '8400:8000'
+    build:
+      context: ./lib/workload/stateless/stacks/filemanager
+      dockerfile: Dockerfile
+      args:
+        # The build itself needs access to the database.
+        DATABASE_URL: postgresql://orcabus:orcabus@host.docker.internal:5432/filemanager # pragma: allowlist secret
+    depends_on:
+      - db
+    healthcheck:
+      test: "curl http://localhost:8000/api/v1/s3_objects/count"
+      start_period: 30s
+      interval: 10s
+      timeout: 2s
+      retries: 5

--- a/lib/workload/stateless/stacks/filemanager/.dockerignore
+++ b/lib/workload/stateless/stacks/filemanager/.dockerignore
@@ -1,0 +1,3 @@
+target
+.env
+.env.example

--- a/lib/workload/stateless/stacks/filemanager/.env.example
+++ b/lib/workload/stateless/stacks/filemanager/.env.example
@@ -1,4 +1,5 @@
 # Example env file which sets the DATABASE_URL to a local postgres instance.
 FILEMANAGER_DATABASE_HOST=0.0.0.0
 FILEMANAGER_DATABASE_PORT=4321
+
 DATABASE_URL=postgresql://filemanager:filemanager@${FILEMANAGER_DATABASE_HOST}:${FILEMANAGER_DATABASE_PORT}/filemanager #pragma: allowlist secret

--- a/lib/workload/stateless/stacks/filemanager/.gitignore
+++ b/lib/workload/stateless/stacks/filemanager/.gitignore
@@ -3,3 +3,4 @@ target/
 /volume/
 .build
 target-cdk-bundling*
+/data/

--- a/lib/workload/stateless/stacks/filemanager/Dockerfile
+++ b/lib/workload/stateless/stacks/filemanager/Dockerfile
@@ -1,0 +1,38 @@
+# This Dockerfile is intended to be used as part of a Docker Compose setup.
+# When running this microservice from the Docker Compose root, this Dockerfile
+# will build the image, install dependencies, and start the server
+
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+
+ARG DATABASE_URL
+ENV DATABASE_URL $DATABASE_URL
+
+WORKDIR /app
+
+# rustfmt is used for code gen.
+RUN rustup component add rustfmt
+
+FROM chef AS planner
+
+COPY . .
+RUN cargo chef prepare
+
+FROM chef AS builder
+
+COPY --from=planner /app/recipe.json recipe.json
+
+# Cargo chef caches compilation.
+RUN cargo chef cook
+
+COPY . .
+# This must be release so that swagger_ui can work.
+# See https://github.com/juhaku/utoipa/issues/527.
+RUN cargo build --release --bin filemanager-api-server
+
+FROM debian:bookworm-slim AS runtime
+
+# curl is used for healthcheck.
+RUN apt -y update && apt -y install curl
+
+COPY --from=builder /app/target/release/filemanager-api-server /usr/local/bin
+ENTRYPOINT ["/usr/local/bin/filemanager-api-server"]

--- a/lib/workload/stateless/stacks/filemanager/Makefile
+++ b/lib/workload/stateless/stacks/filemanager/Makefile
@@ -4,12 +4,11 @@
 FILEMANAGER_DATABASE_HOST ?= 0.0.0.0
 ## Database port
 FILEMANAGER_DATABASE_PORT ?= 4321
+
 ## Database connection url
 DATABASE_URL ?= postgresql://filemanager:filemanager@${FILEMANAGER_DATABASE_HOST}:${FILEMANAGER_DATABASE_PORT}/filemanager #pragma: allowlist secret
 ## Override the default project name
 DOCKER_PROJECT_NAME ?= filemanager
-## The default local API server addr
-FILEMANAGER_API_SERVER_ADDR ?= localhost:8080
 
 
 ## Default target
@@ -20,15 +19,15 @@ all: build
 
 ## Docker related targets
 up:
-	@docker compose -p "$(DOCKER_PROJECT_NAME)" up --wait -d
+	@docker compose -p "$(DOCKER_PROJECT_NAME)" up --wait -d postgres
 down:
 	@docker compose -p "$(DOCKER_PROJECT_NAME)" down
 docker-postgres:
-	@docker compose -p "$(DOCKER_PROJECT_NAME)" up --wait -d postgres --build
+	@docker compose -p "$(DOCKER_PROJECT_NAME)" up --wait -d postgres --build postgres
 docker-clean:
-	@docker compose -p "$(DOCKER_PROJECT_NAME)" down --volumes
+	@docker compose -p "$(DOCKER_PROJECT_NAME)" down --volumes postgres
 docker-build:
-	@docker compose -p "$(DOCKER_PROJECT_NAME)" build
+	@docker compose -p "$(DOCKER_PROJECT_NAME)" build postgres
 docker-run: docker-build
 	# Run the filemanager postgres service using an arbitrary host and port.
 	@FILEMANAGER_DATABASE_HOST=0.0.0.0 FILEMANAGER_DATABASE_PORT=0 \
@@ -36,6 +35,9 @@ docker-run: docker-build
 docker-find:
 	# Find a running filemanager docker container.
 	@docker ps --filter name=$(DOCKER_PROJECT_NAME) --latest --format "{{.ID}}" | xargs -I {} docker port {} 4321
+docker-api: docker-postgres
+	# Run the local API server in a docker container.
+	@docker compose -p "$(DOCKER_PROJECT_NAME)" up api
 
 ## Build related commands
 build: docker-postgres
@@ -51,7 +53,7 @@ lint:
 lint-fix:
 	@cargo fmt
 clippy: docker-postgres
-	cargo clippy --all-targets --all-features
+	@cargo clippy --all-targets --all-features
 check: lint clippy
 check-fix: lint-fix clippy
 
@@ -63,9 +65,37 @@ clean: docker-clean
 psql:
 	@docker compose exec postgres psql filemanager -U filemanager
 
+## Targets related to top-level database management and S3.
+apply-schema:
+	@for file in database/migrations/*; do \
+  	 	docker exec -e PGPASSWORD=orcabus -it orcabus_db psql -h $(FILEMANAGER_DATABASE_HOST) -U orcabus -d filemanager -c "$$(cat $$file)"; \
+  	 done
+reset-db:
+	@docker exec -e PGPASSWORD=orcabus -it orcabus_db psql -h $(FILEMANAGER_DATABASE_HOST) -U orcabus -d orcabus -c "DROP DATABASE IF EXISTS filemanager;" && \
+	docker exec -e PGPASSWORD=orcabus -it orcabus_db psql -h $(FILEMANAGER_DATABASE_HOST) -U orcabus -d orcabus -c "CREATE DATABASE filemanager;"
+s3-dump-upload:
+	@aws s3 cp data/fm_objects_100000.csv.gz s3://orcabus-test-data-843407916570-ap-southeast-2/file-manager/fm_objects_100000.csv.gz && \
+	aws s3 cp data/fm_s3_objects_100000.csv.gz s3://orcabus-test-data-843407916570-ap-southeast-2/file-manager/fm_s3_objects_100000.csv.gz
+s3-dump-download:
+	@aws s3 cp s3://orcabus-test-data-843407916570-ap-southeast-2/file-manager/fm_objects_100000.csv.gz data/fm_objects_100000.csv.gz && \
+	aws s3 cp s3://orcabus-test-data-843407916570-ap-southeast-2/file-manager/fm_s3_objects_100000.csv.gz data/fm_s3_objects_100000.csv.gz
+db-load-data: reset-db apply-schema
+	@gunzip -c data/fm_objects_100000.csv.gz | \
+ 	 docker exec -i orcabus_db psql -U orcabus -d filemanager -c "copy object from stdin with (format csv, header);" && \
+ 	 gunzip -c data/fm_s3_objects_100000.csv.gz | \
+     docker exec -i orcabus_db psql -U orcabus -d filemanager -c "copy s3_object from stdin with (format csv, header);"
+s3-dump-download-if-not-exists:
+	@if [ -f "data/fm_objects_100000.csv.gz" ] && [ -f "data/fm_s3_objects_100000.csv.gz" ]; then \
+		echo "Using existing sql dumps from 'data/fm_objects_100000.csv.gz' and './data/fm_s3_objects_100000.csv.gz"; \
+	else \
+		echo "Downloading sql dumps"; \
+		$(MAKE) s3-dump-download; \
+	fi
+s3-load: s3-dump-download-if-not-exists db-load-data
+
 ## Local API server.
-api: build
-	cargo run -p filemanager-api-server $(ARGS)
+api: docker-postgres
+	@cargo run -p filemanager-api-server $(ARGS)
 
 ## Help text
 help:

--- a/lib/workload/stateless/stacks/filemanager/compose.yml
+++ b/lib/workload/stateless/stacks/filemanager/compose.yml
@@ -9,3 +9,18 @@ services:
       - PGPORT=4321
     ports:
       - "${FILEMANAGER_DATABASE_HOST}:${FILEMANAGER_DATABASE_PORT}:4321"
+  api:
+    build:
+      context: .
+      args:
+        # The build itself needs access to the database.
+        DATABASE_URL: postgresql://filemanager:filemanager@host.docker.internal:4321/filemanager # pragma: allowlist secret
+    environment:
+      # Container database address for running server inside a docker container.
+      - DATABASE_URL=postgresql://filemanager:filemanager@postgres:4321/filemanager
+      - RUST_LOG=debug
+    ports:
+      - "8000:8000"
+    depends_on:
+      - postgres
+    restart: always

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-server/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-server/Cargo.toml
@@ -11,7 +11,7 @@ tracing = "0.1"
 axum = "0.7"
 dotenvy = "0.15"
 http = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 sea-orm = { version = "0.12", features = ["sqlx-postgres", "runtime-tokio-rustls"] }
 
-filemanager = { path = "../filemanager" }
+filemanager = { path = "../filemanager", features = ["migrate"] }


### PR DESCRIPTION
Following up from #425

### Changes
* Add Dockerfile for building filemanager.
* Add filemanager to the local microservices setup from the top-level directory.
    * This loads the most recent 100000 records from the dev database. 
* Fix env variable parsing for `filemanager-api-server`.

This was a bit tougher than I expected. One of the problems is that the filemanager relies on having access to a database to generate code for types/schemas at compile time. This is challenging in a Docker context, because the build process is not run in the compose network, and there is no straightforward way to have a database running before building the filemanager Dockerfile.

In the future, I think I might remove the compile-time database requirement from filemanager. It seems like it often gets in the way, and tools seem to expect that no database is required to compile/build code.