### PR TITLE
fix(filemanager): Dockerfile caching layer and debug build

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/Dockerfile
+++ b/lib/workload/stateless/stacks/filemanager/Dockerfile
@@ -25,14 +25,12 @@ COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook
 
 COPY . .
-# This must be release so that swagger_ui can work.
-# See https://github.com/juhaku/utoipa/issues/527.
-RUN cargo build --release --bin filemanager-api-server
+RUN cargo build --bin filemanager-api-server
 
 FROM debian:bookworm-slim AS runtime
 
 # curl is used for healthcheck.
 RUN apt -y update && apt -y install curl
 
-COPY --from=builder /app/target/release/filemanager-api-server /usr/local/bin
+COPY --from=builder /app/target/debug/filemanager-api-server /usr/local/bin
 ENTRYPOINT ["/usr/local/bin/filemanager-api-server"]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -32,7 +32,7 @@ strum = { version = "0.26", features = ["derive"] }
 # Query server
 axum = "0.7"
 utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid"] }
-utoipa-swagger-ui = { version = "7", features = ["axum"] }
+utoipa-swagger-ui = { version = "7", features = ["axum", "debug-embed"] }
 tower = "0.4"
 tower-http = { version = "0.5", features = ["trace"] }
 serde_qs = { version = "0.13", features = ["axum"] }


### PR DESCRIPTION
This is in relation to #429.

### Changes
* Fixes the Dockerfile definition which was caching dependency compilations for a debug target, when the main filemanager build was release.
    * All targets now use debug.
    * This halved my compilation times because now things aren't compiling twice accidentally.

Initially I had this compiling release because of embedded files in swagger UI: https://github.com/juhaku/utoipa?tab=readme-ov-file#swagger-ui-returns-404-notfound-from-built-binary. Instead, it's now compiling as debug with the `debug-embed` flag enabled for `utoipa-swagger-ui`, which should be faster.