### PR TITLE
feat: filemanager presigned route

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -70,6 +70,9 @@ services:
       # Container database address for running server inside a docker container.
       - DATABASE_URL=postgresql://orcabus:orcabus@db:5432/filemanager
       - RUST_LOG=debug
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-access_key_id}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-secret_access_key}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-ap-southeast-2}
     ports:
       - '8400:8000'
     build:

--- a/lib/workload/stateless/stacks/filemanager/compose.yml
+++ b/lib/workload/stateless/stacks/filemanager/compose.yml
@@ -19,6 +19,9 @@ services:
       # Container database address for running server inside a docker container.
       - DATABASE_URL=postgresql://filemanager:filemanager@postgres:4321/filemanager
       - RUST_LOG=debug
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-access_key_id}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-secret_access_key}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-ap-southeast-2}
     ports:
       - "8000:8000"
     depends_on:

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -159,6 +159,30 @@ For example, count the total records:
 curl -H "Authorization: Bearer $TOKEN" "https://file.dev.umccr.org/api/v1/s3/count" | jq
 ```
 
+## Presigned URLs
+
+The filemanager API can also generate presigned URLs. Presigned URLs can only be generated for objects that currently
+exist in S3.
+
+For example, generate a presigned URL for a single record:
+
+```sh
+curl -H "Authorization: Bearer $TOKEN" "https://file.dev.umccr.org/api/v1/s3/presign/0190465f-68fa-76e4-9c36-12bdf1a1571d" | jq
+```
+
+Or, for multiple records, which supports the same query parameters as list operations (except `currentState` as that is implied):
+
+```sh
+curl -H "Authorization: Bearer $TOKEN" "https://file.dev.umccr.org/api/v1/s3/presign?page=10&rowsPerPage=50" | jq
+```
+
+Specify `responseContentDisposition` for either of the above routes to change the `response-content-disposition` for the
+presigned `GetObject` request. This can either be `inline` or `attachment`. The default is `inline`:
+
+```sh
+curl -H "Authorization: Bearer $TOKEN" "https://file.dev.umccr.org/api/v1/s3/presign?responseContentDisposition=attachment" | jq
+```
+
 ## Some missing features
 
 There are some missing features in the query API which are planned, namely:

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -14,10 +14,11 @@ This serves Swagger OpenAPI docs at `http://localhost:8000/swagger-ui` when usin
 
 The API has some environment variables that can be used to configure behaviour (for the presigned url route):
 
-| Option                           | Description                                                                | Type                | Default      |
-|----------------------------------|----------------------------------------------------------------------------|---------------------|--------------|
-| `FILEMANAGER_API_PRESIGN_LIMIT`  | The maximum file size in bytes which presigned URLs will be generated for. | Integer             | `"20971520"` | 
-| `FILEMANAGER_API_PRESIGN_EXPIRY` | The expiry time for presigned urls.                                        | Duration in seconds | `"300"`      |
+| Option                           | Description                                                                                                 | Type                | Default       |
+|----------------------------------|-------------------------------------------------------------------------------------------------------------|---------------------|---------------|
+| `FILEMANAGER_API_TLS_LINKS`      | This controls whether the links component creates `https://` links. By default, `http:// links are created. | Boolean             | `"false"`     |
+| `FILEMANAGER_API_PRESIGN_LIMIT`  | The maximum file size in bytes which presigned URLs will be generated for.                                  | Integer             | `"20971520"`  | 
+| `FILEMANAGER_API_PRESIGN_EXPIRY` | The expiry time for presigned urls.                                                                         | Duration in seconds | `"300"`       |
 
 The deployed instance of the filemanager API can be reached using the desired stage at `https://file.<stage>.umccr.org`
 using the orcabus API token. To retrieve the token, run:

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -14,11 +14,11 @@ This serves Swagger OpenAPI docs at `http://localhost:8000/swagger-ui` when usin
 
 The API has some environment variables that can be used to configure behaviour (for the presigned url route):
 
-| Option                           | Description                                                                                                 | Type                | Default       |
-|----------------------------------|-------------------------------------------------------------------------------------------------------------|---------------------|---------------|
-| `FILEMANAGER_API_TLS_LINKS`      | This controls whether the links component creates `https://` links. By default, `http:// links are created. | Boolean             | `"false"`     |
-| `FILEMANAGER_API_PRESIGN_LIMIT`  | The maximum file size in bytes which presigned URLs will be generated for.                                  | Integer             | `"20971520"`  | 
-| `FILEMANAGER_API_PRESIGN_EXPIRY` | The expiry time for presigned urls.                                                                         | Duration in seconds | `"300"`       |
+| Option                           | Description                                                                                                                    | Type                | Default      |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------|---------------------|--------------|
+| `FILEMANAGER_API_LINKS_URL`      | Override the URL which is used to generate pagination links. By default the `HOST` header is used to created pagination links. | URL                 | Not set      |
+| `FILEMANAGER_API_PRESIGN_LIMIT`  | The maximum file size in bytes which presigned URLs will be generated for.                                                     | Integer             | `"20971520"` | 
+| `FILEMANAGER_API_PRESIGN_EXPIRY` | The expiry time for presigned urls.                                                                                            | Duration in seconds | `"300"`      |
 
 The deployed instance of the filemanager API can be reached using the desired stage at `https://file.<stage>.umccr.org`
 using the orcabus API token. To retrieve the token, run:

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -10,6 +10,15 @@ make start
 
 This serves Swagger OpenAPI docs at `http://localhost:8000/swagger-ui` when using default settings.
 
+## API configuration
+
+The API has some environment variables that can be used to configure behaviour (for the presigned url route):
+
+| Option                           | Description                                                                | Type                | Default      |
+|----------------------------------|----------------------------------------------------------------------------|---------------------|--------------|
+| `FILEMANAGER_API_PRESIGN_LIMIT`  | The maximum file size in bytes which presigned URLs will be generated for. | Integer             | `"20971520"` | 
+| `FILEMANAGER_API_PRESIGN_EXPIRY` | The expiry time for presigned urls.                                        | Duration in seconds | `"300"`      |
+
 The deployed instance of the filemanager API can be reached using the desired stage at `https://file.<stage>.umccr.org`
 using the orcabus API token. To retrieve the token, run:
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/src/main.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/src/main.rs
@@ -5,6 +5,7 @@ use filemanager::env::Config;
 use lambda_http::Error;
 use std::sync::Arc;
 
+use filemanager::clients::aws::s3;
 use filemanager::database::Client;
 use filemanager::handlers::aws::{create_database_pool, update_credentials};
 use filemanager::handlers::init_tracing;
@@ -21,7 +22,11 @@ async fn main() -> Result<(), Error> {
     debug!(?config, "running with config");
 
     let client = Client::new(create_database_pool(&config).await?);
-    let state = AppState::new(client, Arc::new(config));
+    let state = AppState::new(
+        client,
+        Arc::new(config),
+        Arc::new(s3::Client::with_defaults().await),
+    );
 
     let app =
         router(state.clone()).route_layer(from_fn_with_state(state, update_credentials_middleware));
@@ -35,7 +40,7 @@ async fn update_credentials_middleware(
     request: Request,
     next: Next,
 ) -> Response {
-    let result = update_credentials(state.client().connection_ref(), state.config()).await;
+    let result = update_credentials(state.database_client().connection_ref(), state.config()).await;
 
     if let Err(err) = result {
         return ErrorStatusCode::InternalServerError(ErrorResponse::new(format!(

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/src/main.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/src/main.rs
@@ -26,6 +26,8 @@ async fn main() -> Result<(), Error> {
         client,
         Arc::new(config),
         Arc::new(s3::Client::with_defaults().await),
+        // API Gateway is always TLS.
+        true,
     );
 
     let app =

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-server/src/main.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-server/src/main.rs
@@ -78,6 +78,8 @@ async fn main() -> Result<()> {
         client.clone(),
         config.clone(),
         Arc::new(s3::Client::with_defaults().await),
+        // For now, the local server is always non-TLS.
+        false,
     );
 
     if let Some(load) = args.load_sql_file {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -15,7 +15,7 @@ migrate = ["sqlx/migrate"]
 # Serde
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_with = "3"
+serde_with = { version = "3", features = ["chrono"] }
 
 # Async
 async-trait = "0.1"

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/clients/aws/s3.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/clients/aws/s3.rs
@@ -73,10 +73,12 @@ impl Client {
         &self,
         key: &str,
         bucket: &str,
+        response_content_disposition: &str,
         expires_in: Duration,
     ) -> Result<PresignedRequest, GetObjectError> {
         self.inner
             .get_object()
+            .response_content_disposition(response_content_disposition)
             .checksum_mode(Enabled)
             .key(key)
             .bucket(bucket)

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/clients/aws/s3.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/clients/aws/s3.rs
@@ -1,17 +1,17 @@
 //! A mockable wrapper around the S3 client.
 //!
 
-use std::result;
-
+use crate::clients::aws::config::Config;
 use aws_sdk_s3 as s3;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::get_object::{GetObjectError, GetObjectOutput};
 use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
 use aws_sdk_s3::operation::list_buckets::{ListBucketsError, ListBucketsOutput};
+use aws_sdk_s3::presigning::{PresignedRequest, PresigningConfig};
 use aws_sdk_s3::types::ChecksumMode::Enabled;
+use chrono::Duration;
 use mockall::automock;
-
-use crate::clients::aws::config::Config;
+use std::result;
 
 pub type Result<T, E> = result::Result<T, SdkError<E>>;
 
@@ -65,6 +65,29 @@ impl Client {
             .key(key)
             .bucket(bucket)
             .send()
+            .await
+    }
+
+    /// Execute the `GetObject` operation and generate a presigned url for the object.
+    pub async fn presign_url(
+        &self,
+        key: &str,
+        bucket: &str,
+        expires_in: Duration,
+    ) -> Result<PresignedRequest, GetObjectError> {
+        self.inner
+            .get_object()
+            .checksum_mode(Enabled)
+            .key(key)
+            .bucket(bucket)
+            .presigned(
+                PresigningConfig::expires_in(
+                    expires_in
+                        .to_std()
+                        .map_err(SdkError::construction_failure)?,
+                )
+                .map_err(SdkError::construction_failure)?,
+            )
             .await
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/credentials.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/credentials.rs
@@ -204,13 +204,10 @@ mod tests {
     #[tokio::test]
     async fn generate_iam_token_env() {
         let env_config = EnvConfig {
-            database_url: None,
-            pgpassword: None,
             pghost: Some("127.0.0.1".to_string()),
             pgport: Some(5432),
             pguser: Some("filemanager".to_string()),
-            sqs_url: None,
-            paired_ingest_mode: false,
+            ..Default::default()
         };
 
         test_generate_iam_token(|config| async {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
@@ -3,10 +3,14 @@
 
 use crate::error::Error::ConfigError;
 use crate::error::Result;
+use chrono::Duration;
 use envy::from_env;
 use serde::Deserialize;
+use serde_with::serde_as;
+use serde_with::DurationSeconds;
 
 /// Configuration environment variables for filemanager.
+#[serde_as]
 #[derive(Debug, Clone, Deserialize, Default, Eq, PartialEq)]
 pub struct Config {
     pub(crate) database_url: Option<String>,
@@ -18,6 +22,11 @@ pub struct Config {
     pub(crate) sqs_url: Option<String>,
     #[serde(default, rename = "filemanager_paired_ingest_mode")]
     pub(crate) paired_ingest_mode: bool,
+    #[serde(rename = "filemanager_api_presign_limit")]
+    pub(crate) api_presign_limit: Option<u64>,
+    #[serde_as(as = "Option<DurationSeconds<i64>>")]
+    #[serde(rename = "filemanager_api_presign_expiry")]
+    pub(crate) api_presign_expiry: Option<Duration>,
 }
 
 impl Config {
@@ -72,6 +81,16 @@ impl Config {
         self.paired_ingest_mode
     }
 
+    /// Get the presigned size limit.
+    pub fn api_presign_limit(&self) -> Option<u64> {
+        self.api_presign_limit
+    }
+
+    /// Get the presigned expiry time.
+    pub fn api_presign_expiry(&self) -> Option<Duration> {
+        self.api_presign_expiry
+    }
+
     /// Get the value from an optional, or else try and get a different value, unwrapping into a Result.
     pub fn value_or_else<T>(value: Option<T>, or_else: Option<T>) -> Result<T> {
         value
@@ -101,7 +120,8 @@ mod tests {
             ("PGUSER", "user"),
             ("FILEMANAGER_SQS_URL", "url"),
             ("FILEMANAGER_PAIRED_INGEST_MODE", "true"),
-            ("FILEMANAGER_API_SERVER_ADDR", "127.0.0.1:8080"),
+            ("FILEMANAGER_API_PRESIGN_LIMIT", "123"),
+            ("FILEMANAGER_API_PRESIGN_EXPIRY", "60"),
         ]
         .into_iter()
         .map(|(key, value)| (key.to_string(), value.to_string()));
@@ -118,6 +138,8 @@ mod tests {
                 pguser: Some("user".to_string()),
                 sqs_url: Some("url".to_string()),
                 paired_ingest_mode: true,
+                api_presign_limit: Some(123),
+                api_presign_expiry: Some(Duration::seconds(60))
             }
         )
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
@@ -22,6 +22,8 @@ pub struct Config {
     pub(crate) sqs_url: Option<String>,
     #[serde(default, rename = "filemanager_paired_ingest_mode")]
     pub(crate) paired_ingest_mode: bool,
+    #[serde(default, rename = "filemanager_api_tls_links")]
+    pub(crate) api_tls_links: bool,
     #[serde(rename = "filemanager_api_presign_limit")]
     pub(crate) api_presign_limit: Option<u64>,
     #[serde_as(as = "Option<DurationSeconds<i64>>")]
@@ -82,6 +84,11 @@ impl Config {
     }
 
     /// Get the presigned size limit.
+    pub fn api_tls_links(&self) -> bool {
+        self.api_tls_links
+    }
+
+    /// Get the presigned size limit.
     pub fn api_presign_limit(&self) -> Option<u64> {
         self.api_presign_limit
     }
@@ -120,6 +127,7 @@ mod tests {
             ("PGUSER", "user"),
             ("FILEMANAGER_SQS_URL", "url"),
             ("FILEMANAGER_PAIRED_INGEST_MODE", "true"),
+            ("FILEMANAGER_API_TLS_LINKS", "true"),
             ("FILEMANAGER_API_PRESIGN_LIMIT", "123"),
             ("FILEMANAGER_API_PRESIGN_EXPIRY", "60"),
         ]
@@ -138,6 +146,7 @@ mod tests {
                 pguser: Some("user".to_string()),
                 sqs_url: Some("url".to_string()),
                 paired_ingest_mode: true,
+                api_tls_links: true,
                 api_presign_limit: Some(123),
                 api_presign_expiry: Some(Duration::seconds(60))
             }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
@@ -8,6 +8,7 @@ use envy::from_env;
 use serde::Deserialize;
 use serde_with::serde_as;
 use serde_with::DurationSeconds;
+use url::Url;
 
 /// Configuration environment variables for filemanager.
 #[serde_as]
@@ -22,8 +23,8 @@ pub struct Config {
     pub(crate) sqs_url: Option<String>,
     #[serde(default, rename = "filemanager_paired_ingest_mode")]
     pub(crate) paired_ingest_mode: bool,
-    #[serde(default, rename = "filemanager_api_tls_links")]
-    pub(crate) api_tls_links: bool,
+    #[serde(default, rename = "filemanager_api_links_url")]
+    pub(crate) api_links_url: Option<Url>,
     #[serde(rename = "filemanager_api_presign_limit")]
     pub(crate) api_presign_limit: Option<u64>,
     #[serde_as(as = "Option<DurationSeconds<i64>>")]
@@ -84,8 +85,8 @@ impl Config {
     }
 
     /// Get the presigned size limit.
-    pub fn api_tls_links(&self) -> bool {
-        self.api_tls_links
+    pub fn api_links_url(&self) -> Option<&Url> {
+        self.api_links_url.as_ref()
     }
 
     /// Get the presigned size limit.
@@ -127,7 +128,7 @@ mod tests {
             ("PGUSER", "user"),
             ("FILEMANAGER_SQS_URL", "url"),
             ("FILEMANAGER_PAIRED_INGEST_MODE", "true"),
-            ("FILEMANAGER_API_TLS_LINKS", "true"),
+            ("FILEMANAGER_API_LINKS_URL", "https://localhost:8000"),
             ("FILEMANAGER_API_PRESIGN_LIMIT", "123"),
             ("FILEMANAGER_API_PRESIGN_EXPIRY", "60"),
         ]
@@ -146,7 +147,7 @@ mod tests {
                 pguser: Some("user".to_string()),
                 sqs_url: Some("url".to_string()),
                 paired_ingest_mode: true,
-                api_tls_links: true,
+                api_links_url: Some("https://localhost:8000".parse().unwrap()),
                 api_presign_limit: Some(123),
                 api_presign_expiry: Some(Duration::seconds(60))
             }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -44,6 +44,8 @@ pub enum Error {
     ParseError(String),
     #[error("missing host header")]
     MissingHostHeader,
+    #[error("creating presigned url: `{0}`")]
+    PresignedUrlError(String),
 }
 
 impl From<sqlx::Error> for Error {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -702,7 +702,7 @@ pub(crate) mod tests {
         let result = builder
             .paginate_to_list_response(
                 Pagination::new(0, 2),
-                "https://example.com/s3?rowsPerPage=2&page=0"
+                "http://example.com/s3?rowsPerPage=2&page=0"
                     .parse()
                     .unwrap(),
             )
@@ -714,7 +714,7 @@ pub(crate) mod tests {
             &Links::new(
                 None,
                 Some(
-                    "https://example.com/s3?rowsPerPage=2&page=1"
+                    "http://example.com/s3?rowsPerPage=2&page=1"
                         .parse()
                         .unwrap()
                 )

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
@@ -145,7 +145,7 @@ where
     ///     (<uuid>, <current_attributes>),
     ///     ...
     /// ) AS values)
-    /// update <object|s3_object> set attributes = (
+    /// update <s3_object> set attributes = (
     ///     select attributes from update_with where object_id = id
     /// ) where object_id in (select id from update_with)
     /// returning <updated_objects>

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/error.rs
@@ -82,7 +82,7 @@ impl From<Error> for ErrorStatusCode {
             Error::InvalidQuery(_) | Error::ParseError(_) | Error::MissingHostHeader => {
                 Self::BadRequest(err.to_string().into())
             }
-            Error::QueryError(_) | Error::SerdeError(_) => {
+            Error::QueryError(_) | Error::SerdeError(_) | Error::PresignedUrlError(_) => {
                 Self::InternalServerError(err.to_string().into())
             }
             Error::ExpectedSomeValue(_) => Self::NotFound(err.to_string().into()),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
@@ -7,12 +7,12 @@ use crate::database::entities::sea_orm_active_enums::{EventType, StorageClass};
 use crate::routes::filter::wildcard::{Wildcard, WildcardEither};
 use sea_orm::prelude::{DateTimeWithTimeZone, Json};
 use serde::{Deserialize, Serialize};
-use utoipa::{IntoParams, ToSchema};
+use utoipa::IntoParams;
 
 /// The available fields to filter `s3_object` queries by. Each query parameter represents
 /// an `and` clause in the SQL statement. Nested query string style syntax is supported on
 /// JSON attributes. Wildcards are supported on some of the fields.
-#[derive(Serialize, Deserialize, Debug, Default, IntoParams, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Default, IntoParams)]
 #[serde(default, rename_all = "camelCase")]
 #[into_params(parameter_in = Query)]
 pub struct S3ObjectsFilter {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
@@ -25,7 +25,7 @@ use crate::routes::AppState;
     tag = "get",
 )]
 pub async fn get_s3_by_id(state: State<AppState>, Path(id): Path<Uuid>) -> Result<Json<S3>> {
-    let query = GetQueryBuilder::new(&state.client);
+    let query = GetQueryBuilder::new(&state.database_client);
 
     Ok(Json(
         query
@@ -57,9 +57,9 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn get_s3_api(pool: PgPool) {
-        let state = AppState::from_pool(pool);
+        let state = AppState::from_pool(pool).await;
         let entries = EntriesBuilder::default()
-            .build(state.client())
+            .build(state.database_client())
             .await
             .s3_objects;
 
@@ -70,7 +70,7 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn get_non_existent(pool: PgPool) {
-        let state = AppState::from_pool(pool);
+        let state = AppState::from_pool(pool).await;
 
         let (status_code, _) = response_from::<Value>(
             state,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
@@ -4,6 +4,7 @@
 use axum::extract::{Path, State};
 use axum::routing::get;
 use axum::{Json, Router};
+use url::Url;
 use uuid::Uuid;
 
 use crate::database::entities::s3_object::Model as S3;
@@ -11,6 +12,7 @@ use crate::error::Error::ExpectedSomeValue;
 use crate::error::Result;
 use crate::queries::get::GetQueryBuilder;
 use crate::routes::error::ErrorStatusCode;
+use crate::routes::presign::PresignedUrlBuilder;
 use crate::routes::AppState;
 
 /// Get an s3_object given it's id.
@@ -35,25 +37,51 @@ pub async fn get_s3_by_id(state: State<AppState>, Path(id): Path<Uuid>) -> Resul
     ))
 }
 
+/// Generate AWS presigned URLs for a single S3 object using its `s3_object_id`.
+/// This route will not return an object if it has been deleted from the database, or its size
+/// is greater than `FILEMANAGER_API_PRESIGN_LIMIT`.
+#[utoipa::path(
+    get,
+    path = "/s3/presign/{id}",
+    responses(
+        (status = OK, description = "The presigned url for the object with the id", body = Option<Url>),
+        ErrorStatusCode,
+    ),
+    context_path = "/api/v1",
+    tag = "get",
+)]
+pub async fn presign_s3_by_id(state: State<AppState>, id: Path<Uuid>) -> Result<Json<Option<Url>>> {
+    let Json(response) = get_s3_by_id(state.clone(), id).await?;
+
+    Ok(Json(
+        PresignedUrlBuilder::presign_from_model(&state, response).await?,
+    ))
+}
+
 /// The router for getting object records.
 pub fn get_router() -> Router<AppState> {
-    Router::new().route("/s3/:id", get(get_s3_by_id))
+    Router::new()
+        .route("/s3/:id", get(get_s3_by_id))
+        .route("/s3/presign/:id", get(presign_s3_by_id))
 }
 
 #[cfg(test)]
 mod tests {
+    use aws_smithy_mocks_experimental::{mock_client, RuleMode};
     use axum::body::Body;
     use axum::http::{Method, StatusCode};
     use sqlx::PgPool;
 
+    use super::*;
+    use crate::clients::aws::s3;
     use crate::database::aws::migration::tests::MIGRATOR;
+    use crate::env::Config;
     use crate::queries::EntriesBuilder;
+    use crate::routes::list::tests::mock_get_object;
     use crate::routes::list::tests::{response_from, response_from_get};
     use crate::routes::AppState;
     use crate::uuid::UuidGenerator;
     use serde_json::Value;
-
-    use super::*;
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn get_s3_api(pool: PgPool) {
@@ -80,5 +108,61 @@ mod tests {
         )
         .await;
         assert_eq!(status_code, StatusCode::NOT_FOUND);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn get_presign(pool: PgPool) {
+        let client = mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&mock_get_object("0", "0", b""),]
+        );
+
+        let state = AppState::from_pool(pool)
+            .await
+            .with_s3_client(s3::Client::new(client));
+
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(state.database_client())
+            .await;
+
+        let result: Option<Url> = response_from_get(
+            state,
+            &format!("/s3/presign/{}", entries.s3_objects[0].s3_object_id),
+        )
+        .await;
+        assert_eq!(result.unwrap().path(), "/0/0");
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn get_presign_different_count(pool: PgPool) {
+        let client = mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&mock_get_object("2", "2", b""),]
+        );
+
+        let config = Config {
+            api_presign_limit: Some(1),
+            ..Default::default()
+        };
+        let state = AppState::from_pool(pool)
+            .await
+            .with_config(config)
+            .with_s3_client(s3::Client::new(client));
+
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(state.database_client())
+            .await;
+
+        let result: Option<Url> = response_from_get(
+            state,
+            &format!("/s3/presign/{}", entries.s3_objects[2].s3_object_id),
+        )
+        .await;
+        println!("{:#?}", result);
+        assert!(result.is_none());
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/mod.rs
@@ -32,6 +32,7 @@ pub struct AppState {
     database_client: database::Client,
     config: Arc<Config>,
     s3_client: Arc<s3::Client>,
+    use_tls_links: bool,
 }
 
 impl AppState {
@@ -40,11 +41,13 @@ impl AppState {
         database_client: database::Client,
         config: Arc<Config>,
         s3_client: Arc<s3::Client>,
+        use_tls_links: bool,
     ) -> Self {
         Self {
             database_client,
             config,
             s3_client,
+            use_tls_links,
         }
     }
 
@@ -54,6 +57,7 @@ impl AppState {
             database::Client::from_pool(pool),
             Default::default(),
             Arc::new(s3::Client::with_defaults().await),
+            false,
         )
     }
 
@@ -75,6 +79,12 @@ impl AppState {
         self
     }
 
+    /// Set the TLS links option.
+    pub fn with_use_tls_links(mut self, use_tls_links: bool) -> Self {
+        self.use_tls_links = use_tls_links;
+        self
+    }
+
     /// Get the database client.
     pub fn database_client(&self) -> &database::Client {
         &self.database_client
@@ -88,6 +98,11 @@ impl AppState {
     /// Get the database client.
     pub fn s3_client(&self) -> &s3::Client {
         &self.s3_client
+    }
+
+    /// Get the links TLS setting.
+    pub fn use_tls_links(&self) -> bool {
+        self.use_tls_links
     }
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -97,7 +97,7 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn get_swagger_ui(pool: PgPool) {
-        let app = router(AppState::from_pool(pool));
+        let app = router(AppState::from_pool(pool).await);
         let response = app
             .oneshot(
                 Request::builder()

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -33,7 +33,9 @@ pub struct Json(pub Value);
 #[openapi(
     paths(
         list_s3,
+        presign_s3,
         get_s3_by_id,
+        presign_s3_by_id,
         count_s3,
         ingest_from_sqs,
         update_s3_attributes,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -16,6 +16,7 @@ use crate::routes::get::*;
 use crate::routes::ingest::*;
 use crate::routes::list::*;
 use crate::routes::pagination::*;
+use crate::routes::presign::ContentDisposition;
 use crate::routes::update::*;
 
 /// A newtype equivalent to a `DateTime` with a time zone.
@@ -53,6 +54,7 @@ pub struct Json(pub Value);
             Wildcard,
             Json,
             ListResponseS3,
+            ContentDisposition,
             PaginatedResponse,
             Pagination,
             Links,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
@@ -15,11 +15,11 @@ use utoipa::{IntoParams, ToSchema};
 #[aliases(ListResponseS3 = ListResponse<S3>)]
 pub struct ListResponse<M> {
     /// Links to next and previous page.
-    links: Links,
+    pub(crate) links: Links,
     /// The pagination response component.
-    pagination: PaginatedResponse,
+    pub(crate) pagination: PaginatedResponse,
     /// The results of the list operation.
-    results: Vec<M>,
+    pub(crate) results: Vec<M>,
 }
 
 /// The paginated links to the next and previous page.
@@ -125,9 +125,9 @@ impl<M> ListResponse<M> {
 pub struct PaginatedResponse {
     /// The total number of results in this paginated response.
     #[schema(default = 0)]
-    count: u64,
+    pub(crate) count: u64,
     #[serde(flatten)]
-    pagination: Pagination,
+    pub(crate) pagination: Pagination,
 }
 
 impl PaginatedResponse {
@@ -213,10 +213,10 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_api_paginate(pool: PgPool) {
-        let state = AppState::from_pool(pool);
+        let state = AppState::from_pool(pool).await;
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
-            .build(state.client())
+            .build(state.database_client())
             .await
             .s3_objects;
 
@@ -275,11 +275,11 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_api_paginate_existing_no_page_size(pool: PgPool) {
-        let state = AppState::from_pool(pool);
+        let state = AppState::from_pool(pool).await;
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
             .with_n(1001)
-            .build(state.client())
+            .build(state.database_client())
             .await
             .s3_objects;
 
@@ -294,10 +294,10 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_api_paginate_existing_qs(pool: PgPool) {
-        let state = AppState::from_pool(pool);
+        let state = AppState::from_pool(pool).await;
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
-            .build(state.client())
+            .build(state.database_client())
             .await
             .s3_objects;
 
@@ -324,10 +324,10 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_api_paginate_large(pool: PgPool) {
-        let state = AppState::from_pool(pool);
+        let state = AppState::from_pool(pool).await;
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
-            .build(state.client())
+            .build(state.database_client())
             .await
             .s3_objects;
 
@@ -356,11 +356,11 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn list_s3_api_zero_page_size(pool: PgPool) {
-        let state = AppState::from_pool(pool);
+        let state = AppState::from_pool(pool).await;
 
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
-            .build(state.client())
+            .build(state.database_client())
             .await
             .s3_objects;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
@@ -226,12 +226,12 @@ mod tests {
             result.links(),
             &Links::new(
                 Some(
-                    "https://example.com/s3?rowsPerPage=2&page=0"
+                    "http://example.com/s3?rowsPerPage=2&page=0"
                         .parse()
                         .unwrap()
                 ),
                 Some(
-                    "https://example.com/s3?rowsPerPage=2&page=2"
+                    "http://example.com/s3?rowsPerPage=2&page=2"
                         .parse()
                         .unwrap()
                 )
@@ -247,7 +247,7 @@ mod tests {
             &Links::new(
                 None,
                 Some(
-                    "https://example.com/s3?rowsPerPage=2&page=1"
+                    "http://example.com/s3?rowsPerPage=2&page=1"
                         .parse()
                         .unwrap()
                 )
@@ -262,7 +262,7 @@ mod tests {
             result.links(),
             &Links::new(
                 Some(
-                    "https://example.com/s3?rowsPerPage=2&page=3"
+                    "http://example.com/s3?rowsPerPage=2&page=3"
                         .parse()
                         .unwrap()
                 ),
@@ -286,7 +286,7 @@ mod tests {
         let result: ListResponse<S3Object> = response_from_get(state.clone(), "/s3?page=0").await;
         assert_eq!(
             result.links(),
-            &Links::new(None, Some("https://example.com/s3?page=1".parse().unwrap()))
+            &Links::new(None, Some("http://example.com/s3?page=1".parse().unwrap()))
         );
         assert_eq!(result.pagination().count, 1000);
         assert_eq!(result.results(), &entries[0..1000]);
@@ -307,12 +307,12 @@ mod tests {
             result.links(),
             &Links::new(
                 Some(
-                    "https://example.com/s3?some_parameter=123&rowsPerPage=2&page=0"
+                    "http://example.com/s3?some_parameter=123&rowsPerPage=2&page=0"
                         .parse()
                         .unwrap()
                 ),
                 Some(
-                    "https://example.com/s3?some_parameter=123&rowsPerPage=2&page=2"
+                    "http://example.com/s3?some_parameter=123&rowsPerPage=2&page=2"
                         .parse()
                         .unwrap()
                 )
@@ -343,7 +343,7 @@ mod tests {
             result.links(),
             &Links::new(
                 Some(
-                    "https://example.com/s3?rowsPerPage=1&page=19"
+                    "http://example.com/s3?rowsPerPage=1&page=19"
                         .parse()
                         .unwrap()
                 ),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
@@ -8,7 +8,46 @@ use crate::error::Error::PresignedUrlError;
 use crate::error::Result;
 use crate::routes::AppState;
 use chrono::Duration;
+use serde::{Deserialize, Serialize};
 use url::Url;
+use utoipa::{IntoParams, ToSchema};
+
+/// Parameters for presigned URL routes.
+#[derive(Serialize, Deserialize, Debug, Default, IntoParams)]
+#[serde(default, rename_all = "camelCase")]
+#[into_params(parameter_in = Query)]
+pub struct PresignedParams {
+    /// Specify the content-disposition for the presigned URLs themselves.
+    /// This sets the `response-content-disposition` for the presigned `GetObject` request.
+    response_content_disposition: ContentDisposition,
+}
+
+impl PresignedParams {
+    /// Create new presigned params.
+    pub fn new(response_content_disposition: ContentDisposition) -> Self {
+        Self {
+            response_content_disposition,
+        }
+    }
+
+    /// Get the response content disposition.
+    pub fn response_content_disposition(&self) -> ContentDisposition {
+        self.response_content_disposition
+    }
+}
+
+/// Specify the content-disposition, either `inline` or `attachment`.
+#[derive(Copy, Clone, Serialize, Deserialize, Debug, Default, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum ContentDisposition {
+    /// Specify the content-disposition as inline.
+    #[default]
+    #[serde(alias = "inline")]
+    Inline,
+    /// Specify the content-disposition as attachment.
+    #[serde(alias = "attachment")]
+    Attachment,
+}
 
 /// Maximum default presigned URL size limit, 20MB.
 pub const DEFAULT_PRESIGN_LIMIT: u64 = 20971520;
@@ -41,7 +80,12 @@ impl<'a> PresignedUrlBuilder<'a> {
 
     /// Create a presigned url using the key and bucket. This will not create a URL if the size
     /// is over the limit, and will instead return `None`.
-    pub async fn presign_url(&self, key: &str, bucket: &str) -> Result<Option<Url>> {
+    pub async fn presign_url(
+        &self,
+        key: &str,
+        bucket: &str,
+        response_content_disposition: ContentDisposition,
+    ) -> Result<Option<Url>> {
         let limit = if let Some(size) = self.object_size {
             u64::try_from(size).unwrap_or_default()
                 <= self
@@ -53,11 +97,17 @@ impl<'a> PresignedUrlBuilder<'a> {
         };
 
         if limit {
+            let content_disposition = match response_content_disposition {
+                ContentDisposition::Inline => "inline",
+                ContentDisposition::Attachment => &format!("attachment; filename=\"{key}\""),
+            };
+
             let presign = self
                 .s3_client
                 .presign_url(
                     key,
                     bucket,
+                    content_disposition,
                     self.config
                         .api_presign_expiry()
                         .unwrap_or(DEFAULT_PRESIGN_EXPIRY),
@@ -75,10 +125,14 @@ impl<'a> PresignedUrlBuilder<'a> {
     pub async fn presign_from_model(
         state: &'a AppState,
         model: s3_object::Model,
+        response_content_disposition: ContentDisposition,
     ) -> Result<Option<Url>> {
         let builder = Self::new(state.s3_client(), state.config()).set_object_size(model.size);
 
-        if let Some(presigned) = builder.presign_url(&model.key, &model.bucket).await? {
+        if let Some(presigned) = builder
+            .presign_url(&model.key, &model.bucket, response_content_disposition)
+            .await?
+        {
             Ok(Some(presigned))
         } else {
             Ok(None)
@@ -105,15 +159,49 @@ pub(crate) mod tests {
         let config = Default::default();
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(None);
-        let url = builder.presign_url("0", "1").await.unwrap().unwrap();
+        let url = builder
+            .presign_url("0", "1", ContentDisposition::Inline)
+            .await
+            .unwrap()
+            .unwrap();
 
-        assert!(url.query().unwrap().contains("X-Amz-Expires=300"));
+        let query = url.query().unwrap();
+        assert!(query.contains("X-Amz-Expires=300"));
+        assert!(query.contains("response-content-disposition=inline"));
         assert_eq!(url.path(), "/1/0");
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
-        let url = builder.presign_url("0", "1").await.unwrap().unwrap();
+        let url = builder
+            .presign_url("0", "1", ContentDisposition::Inline)
+            .await
+            .unwrap()
+            .unwrap();
 
-        assert!(url.query().unwrap().contains("X-Amz-Expires=300"));
+        let query = url.query().unwrap();
+        assert!(query.contains("X-Amz-Expires=300"));
+        assert!(query.contains("response-content-disposition=inline"));
+        assert_eq!(url.path(), "/1/0");
+    }
+
+    #[tokio::test]
+    async fn presign_attachment() {
+        let client = s3::Client::new(mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&mock_get_object("0", "1", b""),]
+        ));
+        let config = Default::default();
+
+        let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(None);
+        let url = builder
+            .presign_url("0", "1", ContentDisposition::Attachment)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let query = url.query().unwrap();
+        assert!(query.contains("X-Amz-Expires=300"));
+        assert!(query.contains("response-content-disposition=attachment%3B%20filename%3D%220%22"));
         assert_eq!(url.path(), "/1/0");
     }
 
@@ -130,7 +218,10 @@ pub(crate) mod tests {
         };
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
-        let url = builder.presign_url("0", "1").await.unwrap();
+        let url = builder
+            .presign_url("0", "1", ContentDisposition::Inline)
+            .await
+            .unwrap();
 
         assert!(url.is_none());
     }
@@ -148,9 +239,15 @@ pub(crate) mod tests {
         };
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
-        let url = builder.presign_url("0", "1").await.unwrap().unwrap();
+        let url = builder
+            .presign_url("0", "1", ContentDisposition::Inline)
+            .await
+            .unwrap()
+            .unwrap();
 
-        assert!(url.query().unwrap().contains("X-Amz-Expires=500"));
+        let query = url.query().unwrap();
+        assert!(query.contains("X-Amz-Expires=500"));
+        assert!(query.contains("response-content-disposition=inline"));
         assert_eq!(url.path(), "/1/0");
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
@@ -99,7 +99,7 @@ pub(crate) mod tests {
     async fn presign() {
         let client = s3::Client::new(mock_client!(
             aws_sdk_s3,
-            RuleMode::Sequential,
+            RuleMode::MatchAny,
             &[&mock_get_object("0", "1", b""),]
         ));
         let config = Default::default();

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
@@ -1,2 +1,156 @@
 //! Logic for the presigned url route.
 //!
+
+use crate::clients::aws::s3;
+use crate::database::entities::s3_object;
+use crate::env::Config;
+use crate::error::Error::PresignedUrlError;
+use crate::error::Result;
+use crate::routes::AppState;
+use chrono::Duration;
+use url::Url;
+
+/// Maximum default presigned URL size limit, 20MB.
+pub const DEFAULT_PRESIGN_LIMIT: u64 = 20971520;
+
+/// Default presigned URL expiry time, 5 minutes.
+pub const DEFAULT_PRESIGN_EXPIRY: Duration = Duration::minutes(5);
+
+/// A builder for presigned urls.
+pub struct PresignedUrlBuilder<'a> {
+    s3_client: &'a s3::Client,
+    config: &'a Config,
+    object_size: Option<i64>,
+}
+
+impl<'a> PresignedUrlBuilder<'a> {
+    /// Create a builder.
+    pub fn new(s3_client: &'a s3::Client, config: &'a Config) -> Self {
+        Self {
+            s3_client,
+            config,
+            object_size: None,
+        }
+    }
+
+    /// Construct with the current object size.
+    pub fn set_object_size(mut self, size: Option<i64>) -> Self {
+        self.object_size = size;
+        self
+    }
+
+    /// Create a presigned url using the key and bucket. This will not create a URL if the size
+    /// is over the limit, and will instead return `None`.
+    pub async fn presign_url(&self, key: &str, bucket: &str) -> Result<Option<Url>> {
+        let limit = if let Some(size) = self.object_size {
+            u64::try_from(size).unwrap_or_default()
+                <= self
+                    .config
+                    .api_presign_limit()
+                    .unwrap_or(DEFAULT_PRESIGN_LIMIT)
+        } else {
+            true
+        };
+
+        if limit {
+            let presign = self
+                .s3_client
+                .presign_url(
+                    key,
+                    bucket,
+                    self.config
+                        .api_presign_expiry()
+                        .unwrap_or(DEFAULT_PRESIGN_EXPIRY),
+                )
+                .await
+                .map_err(|err| PresignedUrlError(err.into_service_error().to_string()))?;
+
+            Ok(Some(presign.uri().parse()?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Generate a presigned url from a database model.
+    pub async fn presign_from_model(
+        state: &'a AppState,
+        model: s3_object::Model,
+    ) -> Result<Option<Url>> {
+        let builder = Self::new(state.s3_client(), state.config()).set_object_size(model.size);
+
+        if let Some(presigned) = builder.presign_url(&model.key, &model.bucket).await? {
+            Ok(Some(presigned))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use aws_smithy_mocks_experimental::{mock_client, RuleMode};
+
+    use super::*;
+    use crate::clients::aws::s3;
+    use crate::env::Config;
+    use crate::routes::list::tests::mock_get_object;
+
+    #[tokio::test]
+    async fn presign() {
+        let client = s3::Client::new(mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&mock_get_object("0", "1", b""),]
+        ));
+        let config = Default::default();
+
+        let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(None);
+        let url = builder.presign_url("0", "1").await.unwrap().unwrap();
+
+        assert!(url.query().unwrap().contains("X-Amz-Expires=300"));
+        assert_eq!(url.path(), "/1/0");
+
+        let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
+        let url = builder.presign_url("0", "1").await.unwrap().unwrap();
+
+        assert!(url.query().unwrap().contains("X-Amz-Expires=300"));
+        assert_eq!(url.path(), "/1/0");
+    }
+
+    #[tokio::test]
+    async fn presign_limit() {
+        let client = s3::Client::new(mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&mock_get_object("0", "1", b""),]
+        ));
+        let config = Config {
+            api_presign_limit: Some(1),
+            ..Default::default()
+        };
+
+        let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
+        let url = builder.presign_url("0", "1").await.unwrap();
+
+        assert!(url.is_none());
+    }
+
+    #[tokio::test]
+    async fn presign_expiry() {
+        let client = s3::Client::new(mock_client!(
+            aws_sdk_s3,
+            RuleMode::Sequential,
+            &[&mock_get_object("0", "1", b""),]
+        ));
+        let config = Config {
+            api_presign_expiry: Some(Duration::seconds(500)),
+            ..Default::default()
+        };
+
+        let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
+        let url = builder.presign_url("0", "1").await.unwrap().unwrap();
+
+        assert!(url.query().unwrap().contains("X-Amz-Expires=500"));
+        assert_eq!(url.path(), "/1/0");
+    }
+}

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
@@ -19,6 +19,7 @@ use utoipa::{IntoParams, ToSchema};
 pub struct PresignedParams {
     /// Specify the content-disposition for the presigned URLs themselves.
     /// This sets the `response-content-disposition` for the presigned `GetObject` request.
+    #[param(nullable, default = "inline")]
     response_content_disposition: ContentDisposition,
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
@@ -1,0 +1,2 @@
+//! Logic for the presigned url route.
+//!


### PR DESCRIPTION
Closes #459

### Changes
* Adds routes under `/s3/presign` and `/s3/presign/{:id}` to fetch presigned URLs for current objects only.
* `responseContentDisposition` can be used to set the content-disposition of the presigned `GetObject` request. The default value is `inline`, as this matches the HTTP `content-disposition` header.