### PR TITLE
refactor(filemanager): misc simpler and clearer API

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0005_rename_date.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0005_rename_date.sql
@@ -1,0 +1,2 @@
+-- Rename `date` to `event_time` as it is clearer what the meaning is compared to `last_modified_date`.
+alter table s3_object rename column date to event_time;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
@@ -23,7 +23,7 @@ select
     s3_object_id,
     s3_object.bucket,
     s3_object.key,
-    date as event_time,
+    event_time,
     last_modified_date,
     e_tag,
     sha256,

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/select_object_ids.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/select_object_ids.sql
@@ -1,3 +1,0 @@
--- Select all objects that meet regexp criteria
--- FIXME: Should not trust user input, should be a bit more robust than like/similar to
-select from s3_object where key like $1;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_created_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_created_objects.sql
@@ -3,7 +3,7 @@ insert into s3_object (
     s3_object_id,
     bucket,
     key,
-    date,
+    event_time,
     size,
     sha256,
     last_modified_date,

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
@@ -3,7 +3,7 @@ insert into s3_object (
     s3_object_id,
     bucket,
     key,
-    date,
+    event_time,
     size,
     sha256,
     last_modified_date,

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
@@ -92,7 +92,7 @@ objects_to_update as (
 update as (
     update s3_object
     set sequencer = objects_to_update.input_created_sequencer,
-        date = objects_to_update.input_created_date,
+        event_time = objects_to_update.input_created_date,
         size = objects_to_update.input_size,
         sha256 = objects_to_update.input_sha256,
         last_modified_date = objects_to_update.input_last_modified_date,
@@ -116,7 +116,7 @@ select
     input_id as "s3_object_id!",
     bucket,
     key,
-    date as event_time,
+    event_time,
     last_modified_date,
     e_tag,
     sha256,

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -136,7 +136,7 @@ For example, update attributes on a single record:
 
 ```sh
 curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
---data '{ "attributes": [ { "op": "add", "path": "/portalRunId", "value": "portalRunIdValue" } ] }' \
+--data '[ { "op": "add", "path": "/portalRunId", "value": "portalRunIdValue" } ]' \
 "https://file.dev.umccr.org/api/v1/s3/0190465f-68fa-76e4-9c36-12bdf1a1571d" | jq
 ```
 
@@ -144,7 +144,7 @@ Or, update attributes for multiple records with the same key prefix:
 
 ```sh
 curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
---data '{ "attributes": [ { "op": "add", "path": "/portalRunId", "value": "portalRunIdValue" } ] }' \
+--data '[ { "op": "add", "path": "/portalRunId", "value": "portalRunIdValue" } ]' \
 "https://file.dev.umccr.org/api/v1/s3?key=%25202405212aecb782%25" | jq
 ```
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
@@ -1017,7 +1017,7 @@ pub(crate) mod tests {
         s3_object_results: &PgRow,
         message: FlatS3EventMessage,
         sequencer: Option<String>,
-        date: Option<DateTime<Utc>>,
+        event_time: Option<DateTime<Utc>>,
     ) {
         assert_eq!(message.bucket, s3_object_results.get::<String, _>("bucket"));
         assert_eq!(message.key, s3_object_results.get::<String, _>("key"));
@@ -1046,8 +1046,8 @@ pub(crate) mod tests {
             s3_object_results.get::<Option<DateTime<Utc>>, _>("last_modified_date")
         );
         assert_eq!(
-            date,
-            s3_object_results.get::<Option<DateTime<Utc>>, _>("date")
+            event_time,
+            s3_object_results.get::<Option<DateTime<Utc>>, _>("event_time")
         );
         assert_eq!(
             message.is_delete_marker,
@@ -1082,12 +1082,12 @@ pub(crate) mod tests {
         size: Option<i64>,
         sequencer: Option<String>,
         version_id: String,
-        date: Option<DateTime<Utc>>,
+        event_time: Option<DateTime<Utc>>,
         event_type: EventType,
     ) {
         let message = expected_message(size, version_id, false, event_type);
 
-        assert_row(s3_object_results, message, sequencer, date);
+        assert_row(s3_object_results, message, sequencer, event_time);
     }
 
     fn update_test_events(mut events: TransposedS3EventMessages) -> TransposedS3EventMessages {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
@@ -1582,7 +1582,7 @@ pub(crate) mod tests {
         );
         assert_eq!(
             created_date,
-            s3_object_results.get::<Option<DateTime<Utc>>, _>("date")
+            s3_object_results.get::<Option<DateTime<Utc>>, _>("event_time")
         );
         assert_eq!(
             deleted_date,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/query.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/query.rs
@@ -1,4 +1,4 @@
-use sqlx::{query_file, query_file_as, Acquire, Postgres, Row, Transaction};
+use sqlx::{query_file_as, Acquire, Postgres, Transaction};
 
 use crate::database::Client;
 use crate::error::Result;
@@ -19,25 +19,6 @@ impl Query {
     /// Creates a new filemanager query client.
     pub fn new(client: Client) -> Self {
         Self { client }
-    }
-
-    /// Creates a new filemanager query client with default connection settings.
-    /// -- FIXME: Should not trust user input, should be a bit more robust than like/similar to
-    pub async fn query_objects(&self, query: String) -> Result<QueryResults> {
-        let mut tx = self.client.pool().begin().await?;
-
-        let query_results: Vec<String> =
-            query_file!("../database/queries/api/select_object_ids.sql", &query)
-                .fetch_all(&mut *tx)
-                .await?
-                .into_iter()
-                .map(|row| row.get(0))
-                .collect();
-
-        tx.commit().await?;
-
-        let query_results = QueryResults::new(query_results); // Convert PgQueryResult to QueryResults
-        Ok(query_results)
     }
 
     /// Selects existing objects by the bucket and key for update. This does not start a transaction.

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
@@ -193,7 +193,7 @@ pub(crate) mod tests {
             "select s3_object_id as \"s3_object_id!\",
                 bucket,
                 key,
-                date,
+                event_time,
                 last_modified_date,
                 e_tag,
                 storage_class as \"storage_class: StorageClass\",
@@ -210,7 +210,7 @@ pub(crate) mod tests {
             inserted[0].sequencer,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string())
         );
-        assert_eq!(inserted[0].date, Some(DateTime::default()));
+        assert_eq!(inserted[0].event_time, Some(DateTime::default()));
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -243,7 +243,7 @@ pub(crate) mod tests {
             "select s3_object_id as \"s3_object_id!\",
                 bucket,
                 key,
-                date,
+                event_time,
                 last_modified_date,
                 e_tag,
                 storage_class as \"storage_class: StorageClass\",
@@ -260,6 +260,6 @@ pub(crate) mod tests {
             inserted[0].sequencer,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string())
         );
-        assert_eq!(inserted[0].date, Some(DateTime::default()));
+        assert_eq!(inserted[0].event_time, Some(DateTime::default()));
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -98,8 +98,8 @@ where
                     case_sensitive,
                 )
             }))
-            .add_option(filter.date.map(|v| {
-                Self::filter_operation(Expr::col(s3_object::Column::Date), v, case_sensitive)
+            .add_option(filter.event_time.map(|v| {
+                Self::filter_operation(Expr::col(s3_object::Column::EventTime), v, case_sensitive)
             }))
             .add_option(filter.size.map(|v| s3_object::Column::Size.eq(v)))
             .add_option(filter.sha256.map(|v| s3_object::Column::Sha256.eq(v)))
@@ -784,7 +784,7 @@ pub(crate) mod tests {
         let result = filter_all_s3_from(
             &client,
             S3ObjectsFilter {
-                date: Some(WildcardEither::Wildcard(Wildcard::new(
+                event_time: Some(WildcardEither::Wildcard(Wildcard::new(
                     "1970-01-0%".to_string(),
                 ))),
                 ..Default::default()
@@ -797,7 +797,11 @@ pub(crate) mod tests {
             s3_entries
                 .clone()
                 .into_iter()
-                .filter(|entry| entry.date.unwrap().to_string().starts_with("1970-01-0"))
+                .filter(|entry| entry
+                    .event_time
+                    .unwrap()
+                    .to_string()
+                    .starts_with("1970-01-0"))
                 .collect::<Vec<_>>()
         );
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -16,9 +16,8 @@ use sea_orm::sea_query::{
 };
 use sea_orm::Order::{Asc, Desc};
 use sea_orm::{
-    ActiveEnum, ColumnTrait, Condition, ConnectionTrait, EntityTrait, FromQueryResult,
-    IntoSimpleExpr, JsonValue, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait,
-    Select, Value,
+    ColumnTrait, Condition, ConnectionTrait, EntityTrait, FromQueryResult, IntoSimpleExpr,
+    JsonValue, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait, Select, Value,
 };
 use tracing::trace;
 use url::Url;
@@ -73,13 +72,11 @@ where
     /// Create a condition to filter a query.
     pub fn filter_condition(filter: S3ObjectsFilter, case_sensitive: bool) -> Condition {
         let mut condition = Condition::all()
-            .add_option(filter.event_type.map(|v| {
-                Self::filter_operation(
-                    Expr::col(s3_object::Column::EventType),
-                    v.map(|or| or.as_enum()),
-                    case_sensitive,
-                )
-            }))
+            .add_option(
+                filter
+                    .event_type
+                    .map(|v| s3_object::Column::EventType.eq(v)),
+            )
             .add_option(filter.bucket.map(|v| {
                 Self::filter_operation(
                     Expr::col(s3_object::Column::Bucket),
@@ -114,13 +111,11 @@ where
                 )
             }))
             .add_option(filter.e_tag.map(|v| s3_object::Column::ETag.eq(v)))
-            .add_option(filter.storage_class.map(|v| {
-                Self::filter_operation(
-                    Expr::col(s3_object::Column::StorageClass),
-                    v.map(|or| or.as_enum()),
-                    case_sensitive,
-                )
-            }))
+            .add_option(
+                filter
+                    .storage_class
+                    .map(|v| s3_object::Column::StorageClass.eq(v)),
+            )
             .add_option(
                 filter
                     .is_delete_marker
@@ -572,7 +567,7 @@ pub(crate) mod tests {
         let result = filter_all_s3_from(
             &client,
             S3ObjectsFilter {
-                event_type: Some(WildcardEither::Or(EventType::Created)),
+                event_type: Some(EventType::Created),
                 ..Default::default()
             },
             true,
@@ -789,8 +784,8 @@ pub(crate) mod tests {
         let result = filter_all_s3_from(
             &client,
             S3ObjectsFilter {
-                event_type: Some(WildcardEither::Wildcard(Wildcard::new(
-                    "Cr___ed".to_string(),
+                date: Some(WildcardEither::Wildcard(Wildcard::new(
+                    "1970-01-0%".to_string(),
                 ))),
                 ..Default::default()
             },
@@ -799,23 +794,11 @@ pub(crate) mod tests {
         .await;
         assert_eq!(
             result,
-            filter_event_type(s3_entries.clone(), EventType::Created)
-        );
-
-        let result = filter_all_s3_from(
-            &client,
-            S3ObjectsFilter {
-                event_type: Some(WildcardEither::Wildcard(Wildcard::new(
-                    "cr___ed".to_string(),
-                ))),
-                ..Default::default()
-            },
-            false,
-        )
-        .await;
-        assert_eq!(
-            result,
-            filter_event_type(s3_entries.clone(), EventType::Created)
+            s3_entries
+                .clone()
+                .into_iter()
+                .filter(|entry| entry.date.unwrap().to_string().starts_with("1970-01-0"))
+                .collect::<Vec<_>>()
         );
 
         let result = filter_all_s3_from(

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
@@ -86,7 +86,7 @@ impl Entries {
             bucket: Set((index / bucket_divisor).to_string()),
             key: Set((index / key_divisor).to_string()),
             version_id: Set((index / key_divisor).to_string()),
-            date: date(),
+            event_time: date(),
             size: Set(Some(index as i64)),
             sha256: Set(Some(index.to_string())),
             last_modified_date: date(),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
@@ -491,7 +491,7 @@ pub(crate) mod tests {
             .current_state()
             .filter_all(
                 S3ObjectsFilter {
-                    date: Some(WildcardEither::Wildcard(Wildcard::new(
+                    event_time: Some(WildcardEither::Wildcard(Wildcard::new(
                         "1970-01-0%".to_string(),
                     ))),
                     ..Default::default()

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
@@ -29,8 +29,8 @@ pub struct S3ObjectsFilter {
     /// Query by version_id. Supports wildcards.
     pub(crate) version_id: Option<Wildcard>,
     #[param(required = false, value_type = Wildcard)]
-    /// Query by date. Supports wildcards.
-    pub(crate) date: Option<WildcardEither<DateTimeWithTimeZone>>,
+    /// Query by event_time. Supports wildcards.
+    pub(crate) event_time: Option<WildcardEither<DateTimeWithTimeZone>>,
     #[param(required = false)]
     /// Query by size.
     pub(crate) size: Option<i64>,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
@@ -16,9 +16,9 @@ use utoipa::IntoParams;
 #[serde(default, rename_all = "camelCase")]
 #[into_params(parameter_in = Query)]
 pub struct S3ObjectsFilter {
-    #[param(required = false, value_type = Wildcard)]
-    /// Query by event type. Supports wildcards.
-    pub(crate) event_type: Option<WildcardEither<EventType>>,
+    #[param(required = false)]
+    /// Query by event type.
+    pub(crate) event_type: Option<EventType>,
     #[param(required = false)]
     /// Query by bucket. Supports wildcards.
     pub(crate) bucket: Option<Wildcard>,
@@ -43,9 +43,9 @@ pub struct S3ObjectsFilter {
     #[param(required = false)]
     /// Query by the e_tag.
     pub(crate) e_tag: Option<String>,
-    #[param(required = false, value_type = Wildcard)]
+    #[param(required = false)]
     /// Query by the storage class. Supports wildcards.
-    pub(crate) storage_class: Option<WildcardEither<StorageClass>>,
+    pub(crate) storage_class: Option<StorageClass>,
     #[param(required = false)]
     /// Query by the object delete marker.
     pub(crate) is_delete_marker: Option<bool>,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/update.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/update.rs
@@ -527,7 +527,7 @@ mod tests {
 
         let (_, s3_objects) = response_from::<Vec<S3>>(
             state.clone(),
-            "/s3?eventType=C__%",
+            "/s3?currentState=true&eventTime=1970-01-0%",
             Method::PATCH,
             Body::new(patch.to_string()),
         )
@@ -559,7 +559,7 @@ mod tests {
         let (_, s3_objects) = response_from::<Vec<S3>>(
             state.clone(),
             // Percent-encoding should work too.
-            "/s3?caseSensitive=false&eventType=c%25_%25d",
+            "/s3?caseSensitive=false&currentState=true&eventTime=1970-01-_%25",
             Method::PATCH,
             Body::new(patch.to_string()),
         )


### PR DESCRIPTION
Some more misc changed, related to #462

### Changes
* JSON patch now supports append only, so "add", "test", or "copy" only if an existing key is not being overwritten.
* The outer "attributes" on patch requests is not required.
* `date` has been renamed to `eventTime` for more clarity. /cc @williamputraintan 

I'm holding off on implementing the shortened attributes query string feature, e.g. `portal_run_id=...` rather than `attributes[portal_run_id]=...` as described in #462. This is slightly more complex as it involves capturing unknown parameters in the API. I'm not sure if this is the best idea, because it has the potential to conflict with existing parameters.