### PR TITLE
fix(filemanager): presigned URL access

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -73,6 +73,7 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-access_key_id}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-secret_access_key}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-ap-southeast-2}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-session_token}
     ports:
       - '8400:8000'
     build:

--- a/lib/workload/stateless/stacks/filemanager/Makefile
+++ b/lib/workload/stateless/stacks/filemanager/Makefile
@@ -37,7 +37,7 @@ docker-run: docker-build
 	docker compose -p "$(DOCKER_PROJECT_NAME)" run -d --service-ports postgres | xargs -I {} docker port {} 4321
 docker-find:
 	# Find a running filemanager docker container.
-	@docker ps --filter name=$(DOCKER_PROJECT_NAME) --latest --format "{{.ID}}" | xargs -I {} docker port {} 4321
+	@docker ps --filter name=$(DOCKER_PROJECT_NAME)-postgres --latest --format "{{.ID}}" | xargs -I {} docker port {} | tail -n 1 | awk '{print $$NF}'
 docker-api: docker-postgres
 	# Run the local API server in a docker container.
 	@docker compose -p "$(DOCKER_PROJECT_NAME)" up api

--- a/lib/workload/stateless/stacks/filemanager/compose.yml
+++ b/lib/workload/stateless/stacks/filemanager/compose.yml
@@ -22,6 +22,7 @@ services:
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-access_key_id}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-secret_access_key}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-ap-southeast-2}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-session_token}
     ports:
       - "8000:8000"
     depends_on:

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
@@ -1,11 +1,12 @@
 import { Construct } from 'constructs';
 import * as fn from './function';
 import { DatabaseProps } from './function';
+import { BucketProps } from './ingest';
 
 /**
  * Props for the API function.
  */
-export type ApiFunctionProps = fn.FunctionPropsNoPackage & DatabaseProps;
+export type ApiFunctionProps = fn.FunctionPropsNoPackage & DatabaseProps & BucketProps;
 
 /**
  * A construct for the Lambda API function.
@@ -22,5 +23,7 @@ export class ApiFunction extends fn.Function {
       },
       ...props,
     });
+
+    this.addPoliciesForBuckets(props.buckets);
   }
 }

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
@@ -5,6 +5,17 @@ import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { DatabaseProps } from './function';
 
 /**
+ * Props for controlling access to buckets.
+ */
+export type BucketProps = {
+  /**
+   * The buckets that the filemanager is expected to process. This will add policies to access the buckets via
+   * 's3:List*' and 's3:Get*'.
+   */
+  readonly buckets: string[];
+};
+
+/**
  * Props related to the filemanager event source.
  */
 export type EventSourceProps = {
@@ -12,12 +23,7 @@ export type EventSourceProps = {
    * The SQS queue URL to receive events from.
    */
   readonly eventSources: IQueue[];
-  /**
-   * The buckets that the filemanager is expected to process. This will add policies to access the buckets via
-   * 's3:List*' and 's3:Get*'.
-   */
-  readonly buckets: string[];
-};
+} & BucketProps;
 
 /**
  * Props for the ingest function.

--- a/lib/workload/stateless/stacks/filemanager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/stack.ts
@@ -136,6 +136,7 @@ export class Filemanager extends Stack {
       vpc: this.vpc,
       host: this.host,
       securityGroup: this.securityGroup,
+      buckets: [...props.eventSourceBuckets, ...props.inventorySourceBuckets],
       ...props,
     });
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/clients/aws/s3.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/clients/aws/s3.rs
@@ -79,7 +79,6 @@ impl Client {
         self.inner
             .get_object()
             .response_content_disposition(response_content_disposition)
-            .checksum_mode(Enabled)
             .key(key)
             .bucket(bucket)
             .presigned(


### PR DESCRIPTION
Related to #459 

### Changes
* Fix presigned URL route so that URLs can be accessed. The fix is two-fold:
    * The API function needs `GetObject` access to the buckets.
    * Checksum mode should not be used because this creates an additional header `x-amz-checksum-mode` which is supposed to be present when fetching the presigned URL.
* Adjust `Makefile` so that finding a postgres database behaves nicer with the top-level `make start-all-service`.