### PR TITLE
Add support for linked libraries to WRSC event schema

### DIFF
--- a/docs/schemas/events/executionservice/WorkflowRunStateChange.schema.json
+++ b/docs/schemas/events/executionservice/WorkflowRunStateChange.schema.json
@@ -77,8 +77,29 @@
         "workflowRunName": {
           "type": "string"
         },
+        "linkedLibraries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LibraryRecord"
+          }
+        },
         "payload": {
           "$ref": "#/definitions/Payload"
+        }
+      }
+    },
+    "LibraryRecord": {
+      "type": "object",
+      "required": [
+        "libraryId",
+        "orcabusId"
+      ],
+      "properties": {
+        "libraryId": {
+          "type": "string"
+        },
+        "orcabusId": {
+          "type": "string"
         }
       }
     },

--- a/docs/schemas/events/executionservice/example/WRSC__example1.json
+++ b/docs/schemas/events/executionservice/example/WRSC__example1.json
@@ -15,6 +15,16 @@
     "workflowName": "BclConvert",
     "workflowVersion": "4.2.7",
     "workflowRunName": "540424_A01001_0193_BBBBMMDRX5",
+    "linkedLibraries": [
+      {
+        "libraryId": "L000001",
+        "orcabusId": "lib.01J5M2J44HFJ9424G7074NKTGN"
+      },
+      {
+        "libraryId": "L000002",
+        "orcabusId": "lib.01J5M2JFE1JPYV62RYQEG99CP5"
+      }
+    ],
     "payload": {
       "version": "0.1.0",
       "data": {

--- a/docs/schemas/events/workflowmanager/WorkflowRunStateChange.schema.json
+++ b/docs/schemas/events/workflowmanager/WorkflowRunStateChange.schema.json
@@ -73,8 +73,29 @@
         "workflowRunName": {
           "type": "string"
         },
+        "linkedLibraries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LibraryRecord"
+          }
+        },
         "payload": {
           "$ref": "#/definitions/Payload"
+        }
+      }
+    },
+    "LibraryRecord": {
+      "type": "object",
+      "required": [
+        "libraryId",
+        "orcabusId"
+      ],
+      "properties": {
+        "libraryId": {
+          "type": "string"
+        },
+        "orcabusId": {
+          "type": "string"
         }
       }
     },

--- a/docs/schemas/events/workflowmanager/example/WRSC__example1.json
+++ b/docs/schemas/events/workflowmanager/example/WRSC__example1.json
@@ -14,6 +14,16 @@
     "workflowName": "<fill-by-workflow-manager> e.g. bssh_icav2_fastq_copy",
     "workflowVersion": "<fill-by-workflow-manager> e.g. 1.2.3",
     "workflowRunName": "<fill-by-workflow-manager> e.g. 540424_A01001_0193_BBBBMMDRX5 FASTQ Copy",
+    "linkedLibraries": [
+      {
+        "libraryId": "L000001",
+        "orcabusId": "lib.01J5M2J44HFJ9424G7074NKTGN"
+      },
+      {
+        "libraryId": "L000002",
+        "orcabusId": "lib.01J5M2JFE1JPYV62RYQEG99CP5"
+      }
+    ],
     "payload": {
       "refId": "<fill-by-workflow-manager> e.g. <uuid>",
       "version": "0.1.0",


### PR DESCRIPTION
This is a new convention to support the linking of workflow runs to libraries.

The association currently has to be supported by the execution services / stacky glues that have that information, as the workflow manager does not have access to it atm.
Also, the workflow manager currently relies on the WRSC event to establish the library association, including the `libraryId` (from the lab metadata) and the corresponding `orcabusId` (from the metadata manager). This is expected to be relaxed once we have a different mechanism of updating the workflow manager (e.g. `LibraryStateChange` events).

@raylrui @williamputraintan 

For now this addition is optional as to not break any existing implementations. However, it would be great if we could adopt this wherever possible. 