### PR TITLE
Fix/filemanager api tidy

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -70,6 +70,7 @@ services:
       # Container database address for running server inside a docker container.
       - DATABASE_URL=postgresql://orcabus:orcabus@db:5432/filemanager
       - RUST_LOG=debug
+      - FILEMANAGER_API_CORS_ALLOW_ORIGINS=${FILEMANAGER_API_CORS_ALLOW_ORIGINS:-http://localhost:8400}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-access_key_id}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-secret_access_key}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-ap-southeast-2}

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -154,6 +154,8 @@ export const bclconvertInteropQcDynamoDbTableSSMArn = path.join(
 
 // Stateless
 
+export const corsAllowOrigins = ['*'];
+
 export const bclconvertInteropQcIcav2PipelineWorkflowName = 'bclconvert-interop-qc';
 export const bclconvertInteropQcIcav2PipelineWorkflowTypeVersion = '1.3.1--1.21';
 export const bclconvertInteropQcIcav2ServiceVersion = '2024.07.01';

--- a/config/stacks/fileManager.ts
+++ b/config/stacks/fileManager.ts
@@ -13,6 +13,7 @@ import {
   oncoanalyserBucket,
   icav2PipelineCacheBucket,
   fileManagerIngestRoleName,
+  corsAllowOrigins,
 } from '../constants';
 import { RemovalPolicy } from 'aws-cdk-lib';
 
@@ -36,5 +37,6 @@ export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => 
     inventorySourceBuckets: ['filemanager-inventory-test'],
     eventSourceBuckets: [oncoanalyserBucket[stage], icav2PipelineCacheBucket[stage]],
     fileManagerIngestRoleName: fileManagerIngestRoleName,
+    corsAllowOrigins,
   };
 };

--- a/config/stacks/metadataManager.ts
+++ b/config/stacks/metadataManager.ts
@@ -1,4 +1,10 @@
-import { AppStage, cognitoApiGatewayProps, computeSecurityGroupName, vpcProps } from '../constants';
+import {
+  AppStage,
+  cognitoApiGatewayProps,
+  computeSecurityGroupName,
+  corsAllowOrigins,
+  vpcProps,
+} from '../constants';
 import { MetadataManagerStackProps } from '../../lib/workload/stateless/stacks/metadata-manager/deploy/stack';
 import { RemovalPolicy } from 'aws-cdk-lib';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -16,5 +22,6 @@ export const getMetadataManagerStackProps = (stage: AppStage): MetadataManagerSt
     isDailySync: isDailySync,
     lambdaSecurityGroupName: computeSecurityGroupName,
     apiGatewayCognitoProps: { ...cognitoApiGatewayProps, apiGwLogsConfig: logsConfig },
+    corsAllowOrigins,
   };
 };

--- a/config/stacks/sequenceRunManager.ts
+++ b/config/stacks/sequenceRunManager.ts
@@ -4,6 +4,7 @@ import {
   cognitoStatusPageAppClientIdParameterName,
   cognitoUserPoolIdParameterName,
   computeSecurityGroupName,
+  corsAllowOrigins,
   eventBusName,
   vpcProps,
 } from '../constants';
@@ -25,5 +26,6 @@ export const getSequenceRunManagerStackProps = (stage: AppStage): SequenceRunMan
     cognitoPortalAppClientIdParameterName: cognitoPortalAppClientIdParameterName,
     cognitoStatusPageAppClientIdParameterName: cognitoStatusPageAppClientIdParameterName,
     apiGwLogsConfig: logsConfig,
+    corsAllowOrigins,
   };
 };

--- a/config/stacks/workflowRunManager.ts
+++ b/config/stacks/workflowRunManager.ts
@@ -8,6 +8,7 @@ import {
   cognitoPortalAppClientIdParameterName,
   cognitoStatusPageAppClientIdParameterName,
   AppStage,
+  corsAllowOrigins,
 } from '../constants';
 import { RemovalPolicy } from 'aws-cdk-lib';
 
@@ -25,5 +26,6 @@ export const getWorkflowManagerStackProps = (stage: AppStage): WorkflowManagerSt
     cognitoPortalAppClientIdParameterName: cognitoPortalAppClientIdParameterName,
     cognitoStatusPageAppClientIdParameterName: cognitoStatusPageAppClientIdParameterName,
     apiGwLogsConfig: logsConfig,
+    corsAllowOrigins,
   };
 };

--- a/lib/workload/components/api-gateway/index.ts
+++ b/lib/workload/components/api-gateway/index.ts
@@ -1,7 +1,7 @@
 import { Construct } from 'constructs';
 import { aws_ssm, Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { HttpJwtAuthorizer } from 'aws-cdk-lib/aws-apigatewayv2-authorizers';
-import { CorsHttpMethod, HttpApi, CfnStage, DomainName } from 'aws-cdk-lib/aws-apigatewayv2';
+import { CfnStage, CorsHttpMethod, DomainName, HttpApi } from 'aws-cdk-lib/aws-apigatewayv2';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { IStringParameter, StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
@@ -34,6 +34,10 @@ export interface ApiGatewayConstructProps {
    * The configuration for aws cloudwatch logs
    */
   apiGwLogsConfig: ApiGwLogsConfig;
+  /**
+   * Allowed CORS origins.
+   */
+  corsAllowOrigins?: string[];
 }
 
 export class ApiGatewayConstruct extends Construct {
@@ -65,8 +69,9 @@ export class ApiGatewayConstruct extends Construct {
           CorsHttpMethod.HEAD,
           CorsHttpMethod.OPTIONS,
           CorsHttpMethod.POST,
+          CorsHttpMethod.PATCH,
         ],
-        allowOrigins: ['*'], // FIXME allowed origins from config constant
+        allowOrigins: props.corsAllowOrigins,
         maxAge: Duration.days(10),
       },
       defaultAuthorizer: this.getAuthorizer(props),

--- a/lib/workload/stateless/stacks/filemanager/.env.example
+++ b/lib/workload/stateless/stacks/filemanager/.env.example
@@ -5,3 +5,4 @@ FILEMANAGER_DATABASE_PORT=4321
 DATABASE_URL=postgresql://filemanager:filemanager@${FILEMANAGER_DATABASE_HOST}:${FILEMANAGER_DATABASE_PORT}/filemanager #pragma: allowlist secret
 
 FILEMANAGER_LINKS_URL=localhost:8000
+FILEMANAGER_API_CORS_ALLOW_ORIGINS=http://localhost:8000

--- a/lib/workload/stateless/stacks/filemanager/Cargo.lock
+++ b/lib/workload/stateless/stacks/filemanager/Cargo.lock
@@ -984,6 +984,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2148,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws_lambda_events",
  "axum",
+ "axum-extra",
  "bytes",
  "chrono",
  "csv",

--- a/lib/workload/stateless/stacks/filemanager/compose.yml
+++ b/lib/workload/stateless/stacks/filemanager/compose.yml
@@ -19,6 +19,7 @@ services:
       # Container database address for running server inside a docker container.
       - DATABASE_URL=postgresql://filemanager:filemanager@postgres:4321/filemanager
       - RUST_LOG=debug
+      - FILEMANAGER_API_CORS_ALLOW_ORIGINS=${FILEMANAGER_API_CORS_ALLOW_ORIGINS:-http://localhost:8000}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-access_key_id}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-secret_access_key}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-ap-southeast-2}

--- a/lib/workload/stateless/stacks/filemanager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/stack.ts
@@ -32,6 +32,7 @@ export type FilemanagerConfig = Omit<DatabaseProps, 'host' | 'securityGroup'> & 
   cognitoStatusPageAppClientIdParameterName: string;
   apiGwLogsConfig: ApiGwLogsConfig;
   fileManagerIngestRoleName: string;
+  corsAllowOrigins?: string[];
 };
 
 /**
@@ -151,7 +152,6 @@ export class Filemanager extends Stack {
     const apiIntegration = new HttpLambdaIntegration('ApiIntegration', apiLambda.function);
 
     new HttpRoute(this, 'HttpRoute', {
-      // FIXME: Should not be just proxy but objects/{:id}
       httpApi: httpApi,
       integration: apiIntegration,
       routeKey: HttpRouteKey.with('/{proxy+}', HttpMethod.ANY),

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -14,11 +14,12 @@ This serves Swagger OpenAPI docs at `http://localhost:8000/swagger-ui` when usin
 
 The API has some environment variables that can be used to configure behaviour (for the presigned url route):
 
-| Option                           | Description                                                                                                                    | Type                | Default      |
-|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------|---------------------|--------------|
-| `FILEMANAGER_API_LINKS_URL`      | Override the URL which is used to generate pagination links. By default the `HOST` header is used to created pagination links. | URL                 | Not set      |
-| `FILEMANAGER_API_PRESIGN_LIMIT`  | The maximum file size in bytes which presigned URLs will be generated for.                                                     | Integer             | `"20971520"` | 
-| `FILEMANAGER_API_PRESIGN_EXPIRY` | The expiry time for presigned urls.                                                                                            | Duration in seconds | `"300"`      |
+| Option                               | Description                                                                                                                    | Type                | Default                     |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|---------------------|-----------------------------|
+| `FILEMANAGER_API_LINKS_URL`          | Override the URL which is used to generate pagination links. By default the `HOST` header is used to created pagination links. | URL                 | Not set                     |
+| `FILEMANAGER_API_PRESIGN_LIMIT`      | The maximum file size in bytes which presigned URLs will be generated for.                                                     | Integer             | `"20971520"`                | 
+| `FILEMANAGER_API_PRESIGN_EXPIRY`     | The expiry time for presigned urls.                                                                                            | Duration in seconds | `"300"`                     |
+| `FILEMANAGER_API_CORS_ALLOW_ORIGINS` | The origins to allow for CORS.                                                                                                 | List of origins     | Not set, no origins allowed |
 
 The deployed instance of the filemanager API can be reached using the desired stage at `https://file.<stage>.umccr.org`
 using the orcabus API token. To retrieve the token, run:

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/src/main.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-lambda/src/main.rs
@@ -30,8 +30,8 @@ async fn main() -> Result<(), Error> {
         true,
     );
 
-    let app =
-        router(state.clone()).route_layer(from_fn_with_state(state, update_credentials_middleware));
+    let app = router(state.clone())?
+        .route_layer(from_fn_with_state(state, update_credentials_middleware));
 
     run(app).await
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-server/src/main.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-server/src/main.rs
@@ -120,7 +120,7 @@ async fn main() -> Result<()> {
         Migration::new(client).migrate().await?;
     }
 
-    let app = router(state);
+    let app = router(state)?;
     let listener = TcpListener::bind(args.api_server_addr).await?;
 
     let local_addr = listener.local_addr()?;

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -35,7 +35,7 @@ axum-extra = "0.9"
 utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid", "url"] }
 utoipa-swagger-ui = { version = "7", features = ["axum", "debug-embed", "url"] }
 tower = "0.4"
-tower-http = { version = "0.5", features = ["trace"] }
+tower-http = { version = "0.5", features = ["trace", "cors"] }
 serde_qs = { version = "0.13", features = ["axum"] }
 json-patch = "2"
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -31,6 +31,7 @@ strum = { version = "0.26", features = ["derive"] }
 
 # Query server
 axum = "0.7"
+axum-extra = "0.9"
 utoipa = { version = "4", features = ["axum_extras", "chrono", "uuid", "url"] }
 utoipa-swagger-ui = { version = "7", features = ["axum", "debug-embed", "url"] }
 tower = "0.4"

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
@@ -30,6 +30,8 @@ pub struct Config {
     #[serde_as(as = "Option<DurationSeconds<i64>>")]
     #[serde(rename = "filemanager_api_presign_expiry")]
     pub(crate) api_presign_expiry: Option<Duration>,
+    #[serde(rename = "filemanager_api_cors_allow_origins")]
+    pub(crate) api_cors_allow_origins: Option<Vec<String>>,
 }
 
 impl Config {
@@ -99,6 +101,11 @@ impl Config {
         self.api_presign_expiry
     }
 
+    /// Get the allowed origins
+    pub fn api_cors_allow_origins(&self) -> Option<&[String]> {
+        self.api_cors_allow_origins.as_deref()
+    }
+
     /// Get the value from an optional, or else try and get a different value, unwrapping into a Result.
     pub fn value_or_else<T>(value: Option<T>, or_else: Option<T>) -> Result<T> {
         value
@@ -131,6 +138,10 @@ mod tests {
             ("FILEMANAGER_API_LINKS_URL", "https://localhost:8000"),
             ("FILEMANAGER_API_PRESIGN_LIMIT", "123"),
             ("FILEMANAGER_API_PRESIGN_EXPIRY", "60"),
+            (
+                "FILEMANAGER_API_CORS_ALLOW_ORIGINS",
+                "localhost:8000,127.0.0.1",
+            ),
         ]
         .into_iter()
         .map(|(key, value)| (key.to_string(), value.to_string()));
@@ -149,7 +160,11 @@ mod tests {
                 paired_ingest_mode: true,
                 api_links_url: Some("https://localhost:8000".parse().unwrap()),
                 api_presign_limit: Some(123),
-                api_presign_expiry: Some(Duration::seconds(60))
+                api_presign_expiry: Some(Duration::seconds(60)),
+                api_cors_allow_origins: Some(vec![
+                    "localhost:8000".to_string(),
+                    "127.0.0.1".to_string()
+                ])
             }
         )
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -46,6 +46,8 @@ pub enum Error {
     MissingHostHeader,
     #[error("creating presigned url: `{0}`")]
     PresignedUrlError(String),
+    #[error("configuring API: `{0}`")]
+    ApiConfigurationError(String),
 }
 
 impl From<sqlx::Error> for Error {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -239,8 +239,8 @@ where
     ///     limit page_size
     ///     offset page * page_size;
     /// ```
-    pub async fn paginate(mut self, page: u64, page_size: u64) -> Result<Self> {
-        let offset = page.checked_mul(page_size).ok_or_else(|| OverflowError)?;
+    pub async fn paginate(mut self, offset: u64, page_size: u64) -> Result<Self> {
+        let offset = offset.checked_mul(page_size).ok_or_else(|| OverflowError)?;
         self.select = self.select.offset(offset).limit(page_size);
 
         self.trace_query("paginate");
@@ -254,9 +254,9 @@ where
         pagination: Pagination,
         page_link: Url,
     ) -> Result<ListResponse<M>> {
-        let page = pagination.page();
+        let offset = pagination.offset()?;
         let page_size = pagination.rows_per_page();
-        let mut query = self.paginate(page, page_size).await?;
+        let mut query = self.paginate(offset, page_size).await?;
 
         // Always add one to the limit to see if there is additional pages that can be fetched.
         QuerySelect::query(&mut query.select).reset_limit();
@@ -274,7 +274,12 @@ where
         } else {
             // Remove the last element because we fetched one additional result.
             results.pop();
-            Some(page.checked_add(1).ok_or_else(|| OverflowError)?)
+            Some(
+                pagination
+                    .page()
+                    .checked_add(1)
+                    .ok_or_else(|| OverflowError)?,
+            )
         };
 
         ListResponse::from_next_page(pagination, results, next_page, page_link)
@@ -696,8 +701,8 @@ pub(crate) mod tests {
 
         let result = builder
             .paginate_to_list_response(
-                Pagination::new(0, 2),
-                "http://example.com/s3?rowsPerPage=2&page=0"
+                Pagination::from_u64(1, 2).unwrap(),
+                "http://example.com/s3?rowsPerPage=2&page=1"
                     .parse()
                     .unwrap(),
             )
@@ -709,7 +714,7 @@ pub(crate) mod tests {
             &Links::new(
                 None,
                 Some(
-                    "http://example.com/s3?rowsPerPage=2&page=1"
+                    "http://example.com/s3?rowsPerPage=2&page=2"
                         .parse()
                         .unwrap()
                 )
@@ -981,7 +986,7 @@ pub(crate) mod tests {
 
     async fn paginate_all<C, T, M>(
         builder: ListQueryBuilder<'_, C, T>,
-        page: u64,
+        offset: u64,
         page_size: u64,
     ) -> Vec<M>
     where
@@ -990,7 +995,7 @@ pub(crate) mod tests {
         M: FromQueryResult + Send + Sync,
     {
         builder
-            .paginate(page, page_size)
+            .paginate(offset, page_size)
             .await
             .unwrap()
             .all()

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -253,6 +253,7 @@ where
         self,
         pagination: Pagination,
         page_link: Url,
+        count: u64,
     ) -> Result<ListResponse<M>> {
         let offset = pagination.offset()?;
         let page_size = pagination.rows_per_page();
@@ -282,7 +283,7 @@ where
             )
         };
 
-        ListResponse::from_next_page(pagination, results, next_page, page_link)
+        ListResponse::from_next_page(pagination, results, next_page, page_link, count)
     }
 
     /// Create a list count from a query builder.
@@ -705,6 +706,7 @@ pub(crate) mod tests {
                 "http://example.com/s3?rowsPerPage=2&page=1"
                     .parse()
                     .unwrap(),
+                10,
             )
             .await
             .unwrap();

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/error.rs
@@ -3,37 +3,67 @@
 
 use crate::error::Error;
 use aws_lambda_events::http::StatusCode;
+use axum::extract;
+use axum::extract::rejection::{JsonRejection, PathRejection, QueryRejection};
 use axum::response::{IntoResponse, Response};
-use axum::Json;
+use axum_extra::extract::WithRejection;
 use sea_orm::DbErr;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use serde_qs::axum::QsQueryRejection;
+use std::fmt;
+use std::fmt::{Debug, Display, Formatter};
+use thiserror::Error;
 use utoipa::{IntoResponses, ToSchema};
+
+/// Type alias for a Query with a custom rejection.
+pub type Query<T> = WithRejection<extract::Query<T>, ErrorStatusCode>;
+
+/// Type alias for a QsQuery with a custom rejection.
+pub type QsQuery<T> = WithRejection<serde_qs::axum::QsQuery<T>, ErrorStatusCode>;
+
+/// Type alias for a Path with a custom rejection.
+pub type Path<T> = WithRejection<extract::Path<T>, ErrorStatusCode>;
+
+/// Type alias for a Json with a custom rejection.
+pub type Json<T> = WithRejection<extract::Json<T>, ErrorStatusCode>;
 
 /// The fallback route, returns `NOT_FOUND`.
 pub async fn fallback() -> impl IntoResponse {
     (
         StatusCode::NOT_FOUND,
-        Json(ErrorResponse::new("not found".to_string())),
+        extract::Json(ErrorResponse::new("not found".to_string())),
     )
         .into_response()
 }
 
 /// The error response format returned in the API.
-#[derive(Debug, Serialize, ToSchema)]
+#[derive(Debug, Serialize, ToSchema, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorResponse {
     message: String,
 }
 
+impl Display for ErrorResponse {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
 /// An enum representing http status code errors returned by the API.
-#[derive(Debug, IntoResponses)]
+#[derive(Debug, IntoResponses, Error)]
 pub enum ErrorStatusCode {
-    #[response(
-        status = BAD_REQUEST,
-        description = "the request could not be parsed or the request triggered a constraint error in the database",
-        example = json!({"message": "JSON Error: parsing json"}),
-    )]
-    BadRequest(ErrorResponse),
+    #[response(status = BAD_REQUEST)]
+    #[error(transparent)]
+    QueryRejection(#[from] QueryRejection),
+    #[response(status = BAD_REQUEST)]
+    #[error(transparent)]
+    QsQueryRejection(#[from] QsQueryRejection),
+    #[response(status = BAD_REQUEST)]
+    #[error(transparent)]
+    PathRejection(#[from] PathRejection),
+    #[response(status = BAD_REQUEST)]
+    #[error(transparent)]
+    JsonRejection(#[from] JsonRejection),
     #[response(
         status = NOT_FOUND,
         description = "the resource or route could not be found",
@@ -46,19 +76,57 @@ pub enum ErrorStatusCode {
         example = json!({"message": "Failed to acquire connection from pool: Connection pool timed out"}),
     )]
     InternalServerError(ErrorResponse),
+    #[response(
+        status = BAD_REQUEST,
+        description = "the request could not be parsed or the request triggered a constraint error in the database",
+        example = json!({"message": "JSON Error: parsing json"}),
+    )]
+    BadRequest(ErrorResponse),
+}
+
+impl Display for ErrorStatusCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ErrorStatusCode::BadRequest(err) => Display::fmt(err, f),
+            ErrorStatusCode::NotFound(err) => Display::fmt(err, f),
+            ErrorStatusCode::InternalServerError(err) => Display::fmt(err, f),
+            ErrorStatusCode::QueryRejection(rejection) => Display::fmt(rejection, f),
+            ErrorStatusCode::QsQueryRejection(rejection) => Display::fmt(rejection, f),
+            ErrorStatusCode::PathRejection(rejection) => Display::fmt(rejection, f),
+            ErrorStatusCode::JsonRejection(rejection) => Display::fmt(rejection, f),
+        }
+    }
 }
 
 impl IntoResponse for ErrorStatusCode {
     fn into_response(self) -> Response {
-        match self {
-            ErrorStatusCode::BadRequest(err) => {
-                (StatusCode::BAD_REQUEST, Json(err)).into_response()
-            }
+        let response = match self {
+            ErrorStatusCode::BadRequest(err) => (StatusCode::BAD_REQUEST, extract::Json(err)),
             ErrorStatusCode::InternalServerError(err) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, Json(err)).into_response()
+                (StatusCode::INTERNAL_SERVER_ERROR, extract::Json(err))
             }
-            ErrorStatusCode::NotFound(err) => (StatusCode::NOT_FOUND, Json(err)).into_response(),
-        }
+            ErrorStatusCode::NotFound(err) => (StatusCode::NOT_FOUND, extract::Json(err)),
+            ErrorStatusCode::QueryRejection(rejection) => (
+                rejection.status(),
+                extract::Json(ErrorResponse::new(rejection.body_text())),
+            ),
+            ErrorStatusCode::QsQueryRejection(rejection) => {
+                let message = rejection.to_string();
+                let status = rejection.into_response().status();
+
+                (status, extract::Json(ErrorResponse::new(message)))
+            }
+            ErrorStatusCode::PathRejection(rejection) => (
+                rejection.status(),
+                extract::Json(ErrorResponse::new(rejection.body_text())),
+            ),
+            ErrorStatusCode::JsonRejection(rejection) => (
+                rejection.status(),
+                extract::Json(ErrorResponse::new(rejection.body_text())),
+            ),
+        };
+
+        response.into_response()
     }
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
@@ -12,7 +12,7 @@ use utoipa::IntoParams;
 /// The available fields to filter `s3_object` queries by. Each query parameter represents
 /// an `and` clause in the SQL statement. Nested query string style syntax is supported on
 /// JSON attributes. Wildcards are supported on some of the fields.
-#[derive(Serialize, Deserialize, Debug, Default, IntoParams)]
+#[derive(Serialize, Deserialize, Debug, Default, IntoParams, Clone)]
 #[serde(default, rename_all = "camelCase")]
 #[into_params(parameter_in = Query)]
 pub struct S3ObjectsFilter {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/wildcard.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/wildcard.rs
@@ -6,7 +6,7 @@ use utoipa::ToSchema;
 
 /// An enum which deserializes into a concrete type or a wildcard. This is used for better
 /// type support when non-string filter parameters such as `StorageClass` or `EventType`.
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(untagged)]
 pub enum WildcardEither<T> {
     Or(T),
@@ -39,7 +39,7 @@ impl<T> WildcardEither<T> {
 /// A wildcard type represents a filter to match arbitrary characters. Use '%' for multiple characters
 /// and '_' for a single character. Use '\\' to escape these characters. Wildcards are converted to
 /// postgres `like` or `ilike` queries.
-#[derive(Serialize, Deserialize, Debug, Default, ToSchema, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, ToSchema, Eq, PartialEq, Clone)]
 #[serde(default, rename_all = "camelCase")]
 pub struct Wildcard(pub(crate) String);
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/ingest.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/ingest.rs
@@ -81,7 +81,7 @@ mod tests {
             let s3_ctx = S3Client::with_defaults_context();
             s3_ctx.expect().return_once(|| s3_client);
 
-            let app = api_router(state.clone());
+            let app = api_router(state.clone()).unwrap();
             app.oneshot(
                 Request::builder()
                     .method(Method::POST)

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -3,7 +3,7 @@
 
 use crate::database::entities::s3_object;
 use crate::database::entities::s3_object::Model as S3;
-use crate::error::Error::{ConversionError, MissingHostHeader, ParseError};
+use crate::error::Error::{MissingHostHeader, ParseError};
 use crate::error::Result;
 use crate::queries::list::ListQueryBuilder;
 use crate::routes::error::{ErrorStatusCode, QsQuery, Query};
@@ -16,6 +16,7 @@ use axum::http::header::HOST;
 use axum::routing::get;
 use axum::{extract, Json, Router};
 use axum_extra::extract::WithRejection;
+use sea_orm::TransactionTrait;
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use url::Url;
@@ -120,9 +121,10 @@ pub async fn list_s3(
     WithRejection(serde_qs::axum::QsQuery(filter_all), _): QsQuery<S3ObjectsFilter>,
     request: Request,
 ) -> Result<Json<ListResponse<S3>>> {
-    let mut response =
-        ListQueryBuilder::<_, s3_object::Entity>::new(state.database_client.connection_ref())
-            .filter_all(filter_all, wildcard.case_sensitive());
+    let txn = state.database_client().connection_ref().begin().await?;
+
+    let mut response = ListQueryBuilder::<_, s3_object::Entity>::new(&txn)
+        .filter_all(filter_all.clone(), wildcard.case_sensitive());
 
     if list.current_state {
         response = response.current_state();
@@ -153,9 +155,20 @@ pub async fn list_s3(
 
     let url = url.join(&request.uri().to_string())?;
 
-    Ok(Json(
-        response.paginate_to_list_response(pagination, url).await?,
-    ))
+    let Json(count) = count_s3(
+        state,
+        WithRejection(extract::Query(wildcard), PhantomData),
+        WithRejection(extract::Query(list), PhantomData),
+        WithRejection(serde_qs::axum::QsQuery(filter_all), PhantomData),
+    )
+    .await?;
+    let response = response
+        .paginate_to_list_response(pagination, url, count.n_records)
+        .await?;
+
+    txn.commit().await?;
+
+    Ok(Json(response))
 }
 
 /// Count all s3_objects according to the parameters.
@@ -212,7 +225,7 @@ pub async fn presign_s3(
 ) -> Result<Json<ListResponse<Url>>> {
     let Json(ListResponse {
         links,
-        mut pagination,
+        pagination,
         results,
     }) = list_s3(
         state.clone(),
@@ -236,8 +249,6 @@ pub async fn presign_s3(
             urls.push(presigned);
         }
     }
-
-    pagination.count = u64::try_from(urls.len()).map_err(|err| ConversionError(err.to_string()))?;
 
     let response = ListResponse::new(links, pagination, urls);
     Ok(Json(response))
@@ -289,6 +300,7 @@ pub(crate) mod tests {
         let result: ListResponse<S3> = response_from_get(state, "/s3").await;
         assert_eq!(result.links(), &Links::new(None, None));
         assert_eq!(result.results(), entries);
+        assert_eq!(result.pagination().count, 10);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -316,6 +328,7 @@ pub(crate) mod tests {
             )
         );
         assert_eq!(result.results(), vec![entries[2].clone()]);
+        assert_eq!(result.pagination().count, 2);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -343,6 +356,7 @@ pub(crate) mod tests {
             )
         );
         assert_eq!(result.results(), vec![entries[2].clone()]);
+        assert_eq!(result.pagination().count, 2);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -373,6 +387,7 @@ pub(crate) mod tests {
             )
         );
         assert_eq!(result.results(), vec![entries[2].clone()]);
+        assert_eq!(result.pagination().count, 2);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -476,7 +491,7 @@ pub(crate) mod tests {
 
         let result: ListResponse<Url> = response_from_get(state, "/s3/presign").await;
         assert_eq!(result.links(), &Links::new(None, None));
-        assert_eq!(1, result.pagination().count);
+        assert_eq!(2, result.pagination().count);
 
         let query = result.results()[0].query().unwrap();
         assert!(query.contains("X-Amz-Expires=300"));
@@ -499,6 +514,7 @@ pub(crate) mod tests {
             response_from_get(state, "/s3?currentState=true&size=4&rowsPerPage=1&page=1").await;
         assert_eq!(result.links(), &Links::new(None, None));
         assert_eq!(result.results(), vec![entries[24].clone()]);
+        assert_eq!(result.pagination().count, 1);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -516,6 +532,7 @@ pub(crate) mod tests {
             result.results(),
             filter_event_type(entries, EventType::Deleted)
         );
+        assert_eq!(result.pagination().count, 5);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -529,6 +546,7 @@ pub(crate) mod tests {
 
         let result: ListResponse<S3> = response_from_get(state, "/s3?bucket=1&key=2").await;
         assert_eq!(result.results(), vec![entries[2].clone()]);
+        assert_eq!(result.pagination().count, 1);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -543,22 +561,27 @@ pub(crate) mod tests {
         let result: ListResponse<S3> =
             response_from_get(state.clone(), "/s3?attributes[attributeId]=1").await;
         assert_eq!(result.results(), vec![entries[1].clone()]);
+        assert_eq!(result.pagination().count, 1);
 
         let result: ListResponse<S3> =
             response_from_get(state.clone(), "/s3?attributes[nestedId][attributeId]=4").await;
         assert_eq!(result.results(), vec![entries[4].clone()]);
+        assert_eq!(result.pagination().count, 1);
 
         let result: ListResponse<S3> =
             response_from_get(state.clone(), "/s3?attributes[nonExistentId]=1").await;
         assert!(result.results().is_empty());
+        assert_eq!(result.pagination().count, 0);
 
         let result: ListResponse<S3> =
             response_from_get(state.clone(), "/s3?attributes[attributeId]=1&key=2").await;
         assert!(result.results().is_empty());
+        assert_eq!(result.pagination().count, 0);
 
         let result: ListResponse<S3> =
             response_from_get(state, "/s3?attributes[attributeId]=1&key=1").await;
         assert_eq!(result.results(), vec![entries[1].clone()]);
+        assert_eq!(result.pagination().count, 1);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -581,10 +604,12 @@ pub(crate) mod tests {
         let s3_objects: ListResponse<S3> =
             response_from_get(state.clone(), "/s3?attributes[attributeId]=%a%").await;
         assert_contains(s3_objects.results(), &entries, 0..2);
+        assert_eq!(s3_objects.pagination().count, 2);
 
         let s3_objects: ListResponse<S3> =
             response_from_get(state.clone(), "/s3?attributes[attributeId]=%A%").await;
         assert!(s3_objects.results().is_empty());
+        assert_eq!(s3_objects.pagination().count, 0);
 
         let s3_objects: ListResponse<S3> = response_from_get(
             state.clone(),
@@ -592,6 +617,7 @@ pub(crate) mod tests {
         )
         .await;
         assert_contains(s3_objects.results(), &entries, 0..2);
+        assert_eq!(s3_objects.pagination().count, 2);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -678,7 +678,7 @@ pub(crate) mod tests {
         method: Method,
         body: Body,
     ) -> (StatusCode, T) {
-        let app = api_router(state);
+        let app = api_router(state).unwrap();
         let response = app
             .oneshot(
                 Request::builder()

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -21,7 +21,7 @@ use crate::routes::update::*;
 
 /// A newtype equivalent to a `DateTime` with a time zone.
 #[derive(ToSchema)]
-#[schema(value_type = DateTime)]
+#[schema(value_type = DateTime, format = DateTime)]
 pub struct DateTimeWithTimeZone(pub DateTime<FixedOffset>);
 
 /// A newtype equivalent to an arbitrary JSON `Value`.

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -102,7 +102,7 @@ mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn get_swagger_ui(pool: PgPool) {
-        let app = router(AppState::from_pool(pool).await);
+        let app = router(AppState::from_pool(pool).await).unwrap();
         let response = app
             .oneshot(
                 Request::builder()

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/openapi.rs
@@ -54,6 +54,7 @@ pub struct Json(pub Value);
             Wildcard,
             Json,
             ListResponseS3,
+            ListResponseUrl,
             ContentDisposition,
             PaginatedResponse,
             Pagination,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
@@ -146,11 +146,12 @@ pub struct Pagination {
     /// The one-indexed page to fetch from the list of objects.
     /// Increments by 1 starting from 1.
     /// Defaults to the beginning of the collection.
-    #[param(nullable, default = 1)]
+    #[param(required = false, default = 1, minimum = 1, value_type = u64)]
+    #[schema(required = false, default = 1, minimum = 1, value_type = u64)]
     page: NonZeroU64,
     /// The number of rows per page, i.e. the page size.
     /// If this is zero then the default is used.
-    #[param(nullable, default = 1000)]
+    #[param(required = false, default = 1000)]
     #[serde(deserialize_with = "deserialize_zero_page_as_default")]
     rows_per_page: u64,
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
@@ -19,7 +19,7 @@ use utoipa::{IntoParams, ToSchema};
 pub struct PresignedParams {
     /// Specify the content-disposition for the presigned URLs themselves.
     /// This sets the `response-content-disposition` for the presigned `GetObject` request.
-    #[param(nullable, default = "inline")]
+    #[param(required = false, default = "inline")]
     response_content_disposition: ContentDisposition,
 }
 

--- a/lib/workload/stateless/stacks/metadata-manager/deploy/construct/lambda-api/index.ts
+++ b/lib/workload/stateless/stacks/metadata-manager/deploy/construct/lambda-api/index.ts
@@ -1,6 +1,6 @@
 import { Construct } from 'constructs';
 import { Duration } from 'aws-cdk-lib';
-import { HttpMethod, HttpRoute, HttpRouteKey, IHttpApi } from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpMethod, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv2';
 import { PythonFunction, PythonFunctionProps } from '@aws-cdk/aws-lambda-python-alpha';
 import { ISecret } from 'aws-cdk-lib/aws-secretsmanager';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
@@ -22,6 +22,10 @@ type LambdaProps = {
    * The props for api-gateway
    */
   apiGatewayConstructProps: ApiGatewayConstructProps;
+  /**
+   * Allowed CORS origins.
+   */
+  corsAllowOrigins?: string[];
 };
 
 export class LambdaAPIConstruct extends Construct {

--- a/lib/workload/stateless/stacks/metadata-manager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/metadata-manager/deploy/stack.ts
@@ -3,7 +3,6 @@ import { Construct } from 'constructs';
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Vpc, VpcLookupOptions, SecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import { Secret } from 'aws-cdk-lib/aws-secretsmanager';
-import { Schedule } from 'aws-cdk-lib/aws-events';
 import { Code, Runtime, Architecture, LayerVersion } from 'aws-cdk-lib/aws-lambda';
 
 // import custom constructs
@@ -26,6 +25,10 @@ export type MetadataManagerStackProps = {
    * A boolean to tell whether the sync lambda should run daily
    */
   isDailySync: boolean;
+  /**
+   * Allowed CORS origins.
+   */
+  corsAllowOrigins?: string[];
   /**
    * API Gateway props
    */
@@ -100,6 +103,7 @@ export class MetadataManagerStack extends Stack {
         customDomainNamePrefix: 'metadata',
         ...props.apiGatewayCognitoProps,
       },
+      corsAllowOrigins: props.corsAllowOrigins,
     });
 
     // (2)

--- a/lib/workload/stateless/stacks/sequence-run-manager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/sequence-run-manager/deploy/stack.ts
@@ -20,6 +20,7 @@ export interface SequenceRunManagerStackProps {
   cognitoPortalAppClientIdParameterName: string;
   cognitoStatusPageAppClientIdParameterName: string;
   apiGwLogsConfig: ApiGwLogsConfig;
+  corsAllowOrigins?: string[];
 }
 
 export class SequenceRunManagerStack extends Stack {

--- a/lib/workload/stateless/stacks/workflow-manager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/workflow-manager/deploy/stack.ts
@@ -26,6 +26,7 @@ export interface WorkflowManagerStackProps extends StackProps {
   cognitoPortalAppClientIdParameterName: string;
   cognitoStatusPageAppClientIdParameterName: string;
   apiGwLogsConfig: ApiGwLogsConfig;
+  corsAllowOrigins?: string[];
 }
 
 export class WorkflowManagerStack extends Stack {

--- a/skel/django-api/deploy/stack.ts
+++ b/skel/django-api/deploy/stack.ts
@@ -2,13 +2,13 @@
 
 import path from 'path';
 import { Construct } from 'constructs';
-import { Architecture, ILayerVersion } from 'aws-cdk-lib/aws-lambda';
+import { Architecture } from 'aws-cdk-lib/aws-lambda';
 import { ISecurityGroup, IVpc, SecurityGroup, Vpc, VpcLookupOptions } from 'aws-cdk-lib/aws-ec2';
 import { EventBus, IEventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { aws_events_targets, aws_lambda, aws_secretsmanager, Duration, Stack, StackProps } from 'aws-cdk-lib';
 import { PythonFunction, PythonLayerVersion } from '@aws-cdk/aws-lambda-python-alpha';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
-import { CorsHttpMethod, HttpApi, HttpMethod, HttpRoute, HttpRouteKey, HttpStage } from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpMethod, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv2';
 import { PostgresManagerStack } from '../../../lib/workload/stateful/stacks/postgres-manager/deploy/stack';
 import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { ApiGatewayConstruct, ApiGwLogsConfig } from '../../../lib/workload/components/api-gateway';
@@ -21,6 +21,7 @@ export interface ProjectNameStackProps { // FIXME change prop interface name
   cognitoPortalAppClientIdParameterName: string;
   cognitoStatusPageAppClientIdParameterName: string;
   apiGwLogsConfig: ApiGwLogsConfig;
+  corsAllowOrigins?: string[];
 }
 
 export class ProjectNameStack extends Stack {  // FIXME change construct name


### PR DESCRIPTION
Closes #491 

### Changes
* Pagination starts at 1 now, and the count field contains the real count of records for a collection.
* The API server has proper JSON-formatted error responses now, and the OpenAPI presign route is fixed.
* CORS support has been added, which can be adjusted with `FILEMANAGER_API_CORS_ALLOW_ORIGINS`.
    * I've also moved the `corsAllowOrigins` to the top-level config for all microservices.