### PR TITLE
refactor: filemanager indexes

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/Cargo.lock
+++ b/lib/workload/stateless/stacks/filemanager/Cargo.lock
@@ -2168,6 +2168,7 @@ dependencies = [
  "mockall_double",
  "orc-rust",
  "parquet",
+ "percent-encoding",
  "rand",
  "sea-orm",
  "serde",

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0006_index.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0006_index.sql
@@ -1,0 +1,2 @@
+-- A gin index on attributes supported the `@?` operator and jsonpath queries.
+create index attributes_index on s3_object using gin (attributes jsonb_path_ops);

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0006_index.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0006_index.sql
@@ -1,2 +1,4 @@
 -- A gin index on attributes supported the `@?` operator and jsonpath queries.
 create index attributes_index on s3_object using gin (attributes jsonb_path_ops);
+-- An index on keys helps querying by prefix.
+create index key_index on s3_object (key text_pattern_ops);

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -104,26 +104,28 @@ curl --get -H "Authorization: Bearer $TOKEN" --data-urlencode "attributes[portal
 
 ### Wilcard matching
 
-The API supports using wildcards to match multiple characters in a value for most field. Use `%` to match multiple characters
-and `_` to match one character. These queries get converted to postgres `like` queries under the hood. For example, query
-on a key prefix:
+The API supports using wildcards to match multiple characters in a value for most field. Use `*` to match multiple characters
+and `?` to match one character. Use a backslash character to match a literal `*` or `?` in the query. Another backslash can be used
+to escape itself. No other escape characters are supported.
+
+These get converted to postgres `like` queries under the hood. For example, query on a key prefix:
 
 ```sh
-curl --get -H "Authorization: Bearer $TOKEN" --data-urlencode "key=temp\_data%" \
+curl --get -H "Authorization: Bearer $TOKEN" --data-urlencode "key=temp_data*" \
 "https://file.dev.umccr.org/api/v1/s3" | jq
 ```
 
 Case-insensitive wildcard matching, which gets converted to a postgres `ilike` statement, is supported by using `caseSensitive`:
 
 ```sh
-curl --get -H "Authorization: Bearer $TOKEN" --data-urlencode "key=temp\_data%" \
+curl --get -H "Authorization: Bearer $TOKEN" --data-urlencode "key=temp_data*" \
 "https://file.dev.umccr.org/api/v1/s3?caseSensitive=false" | jq
 ```
 
-Wildcard matching is also supported on attributes:
+Wildcard matching is also supported on attributes, which get converted to jsonpath `like_regex` queries:
 
 ```sh
-curl --get -H "Authorization: Bearer $TOKEN" --data-urlencode "attributes[portalRunId]=20240521%" \
+curl --get -H "Authorization: Bearer $TOKEN" --data-urlencode "attributes[portalRunId]=20240521*" \
 "https://file.dev.umccr.org/api/v1/s3" | jq
 ```
 
@@ -147,7 +149,7 @@ Or, update attributes for multiple records with the same key prefix:
 ```sh
 curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
 --data '[ { "op": "add", "path": "/portalRunId", "value": "portalRunIdValue" } ]' \
-"https://file.dev.umccr.org/api/v1/s3?key=%25202405212aecb782%25" | jq
+"https://file.dev.umccr.org/api/v1/s3?key=*202405212aecb782*" | jq
 ```
 
 ## Count objects

--- a/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/Cargo.toml
@@ -72,6 +72,7 @@ aws_lambda_events = "0.15"
 
 [dev-dependencies]
 lazy_static = "1"
+percent-encoding = "2"
 
 aws-smithy-runtime-api = "1"
 aws-smithy-mocks-experimental = "0.2"

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/wildcard.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/wildcard.rs
@@ -1,6 +1,8 @@
 //! Wildcard filtering logic.
 //!
 
+use crate::error::Error::ParseError;
+use crate::error::Result;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -54,34 +56,125 @@ impl Wildcard {
         self.0
     }
 
-    /// Check whether there are wildcard matches contained in this wildcard. This is useful to
-    /// convert the wildcard to a postgres `like` statement, because wildcards without any
-    /// `%` or `_` don't need to be run through `like` and can instead be used in an equality
-    /// comparison
-    pub fn contains_wildcard(&self) -> bool {
-        let mut chars = self.0.chars().peekable();
+    fn wildcard_positions(&self) -> (Vec<usize>, Vec<usize>) {
+        let mut chars = self.0.chars().enumerate().peekable();
 
-        while let Some(char) = chars.next() {
-            // If there is a backslash, then the next character can be either '%' or '_' and not
-            // pass this check.
+        let mut wildcard_positions = vec![];
+        let mut escaped_positions = vec![];
+        while let Some((pos, char)) = chars.next() {
+            // If there is a backslash, then the next character can be '*' and not be a wildcard.
             if char == '\\' {
                 let peek = chars.peek();
-                if let Some(next_char) = peek {
-                    if *next_char == '%' || *next_char == '_' {
+                if let Some((_, next_char)) = peek {
+                    if *next_char == '*' || *next_char == '?' || *next_char == '\\' {
                         // Skip the next character as we have just processed it.
                         chars.next();
+                        escaped_positions.push(pos);
                         continue;
                     }
                 }
+
+                escaped_positions.push(pos);
             }
 
             // This will result in a wildcard match as it is not escaped.
-            if char == '%' || char == '_' {
-                return true;
+            if char == '*' || char == '?' {
+                wildcard_positions.push(pos);
             }
         }
 
-        false
+        (wildcard_positions, escaped_positions)
+    }
+
+    fn to_postgres_wildcard(
+        &self,
+        escape_characters: &str,
+        escape_replacement: &str,
+        single_wildcard: &str,
+        multi_wildcard: &str,
+    ) -> Result<String> {
+        let (mut wildcard_positions, mut escaped_positions) = self.wildcard_positions();
+        let mut out = String::with_capacity(self.0.len());
+
+        let mut chars = self.0.chars().enumerate().peekable();
+        while let Some((pos, char)) = chars.next() {
+            // A wildcard should be converted to a regex.
+            if Some(&pos) == wildcard_positions.first() {
+                // This is a wildcard.
+                wildcard_positions.remove(0);
+                if char == '?' {
+                    out.push_str(single_wildcard);
+                } else {
+                    out.push_str(multi_wildcard);
+                }
+
+                continue;
+            }
+
+            // An escaped wildcard needs to be converted to an escaped regex character.
+            if Some(&pos) == escaped_positions.first() {
+                escaped_positions.remove(0);
+
+                // The next character must be a valid escape.
+                match chars.peek() {
+                    Some((_, next_char))
+                        if *next_char != '*' && *next_char != '?' && *next_char != '\\' =>
+                    {
+                        return Err(ParseError(format!(
+                            "invalid escape character: `\\{}`",
+                            next_char
+                        )));
+                    }
+                    None => return Err(ParseError("invalid escape character".to_string())),
+                    _ => {}
+                }
+
+                // Skip the escape, process on next iteration.
+                continue;
+            }
+
+            if escape_characters.contains(char) {
+                out.push_str(escape_replacement);
+            }
+            out.push(char);
+        }
+
+        Ok(out)
+    }
+
+    /// Find all wildcard positions contained in the underlying string and return true if there is a wildcard.
+    /// This is useful to convert the wildcard to a postgres `like_regex` statement, because wildcards
+    /// without any `*` don't need to be run through `like` and can instead be used in an equality
+    /// comparison.
+    pub fn contains_wildcard(&self) -> bool {
+        !self.wildcard_positions().0.is_empty()
+    }
+    
+    /// Convert this wildcard to a postgres jsonbpath `like_regex` string, escaping relevant characters.
+    pub fn to_like_regex(&self) -> Result<String> {
+        // Valid postgres regex characters need to be escaped.
+        let escape_characters = r"!$()*+.:<=>?[\]^{|}-";
+        // Two backslashes needed as this is part of a jsonbpath escape:
+        // https://www.postgresql.org/docs/current/functions-json.html#JSONPATH-REGULAR-EXPRESSIONS
+        let escape_replacement = r"\\";
+        self.to_postgres_wildcard(escape_characters, escape_replacement, ".", ".*")
+    }
+
+    /// Convert this wildcard to a postgres `like` expression, escaping relevant characters.
+    pub fn to_like_expression(&self) -> Result<String> {
+        // Valid postgres regex characters need to be escaped.
+        let escape_characters = r"\%_";
+        // Only a single backslash is needed to escape the above characters.
+        let escape_replacement = r"\";
+        self.to_postgres_wildcard(escape_characters, escape_replacement, "_", "%")
+    }
+
+    /// Convert this wildcard to a postgres equality expression.
+    pub fn to_eq_expression(&self) -> Result<String> {
+        // Nothing to escape for equality except the escape character
+        let escape_characters = r"\";
+        let escape_replacement = r"\";
+        self.to_postgres_wildcard(escape_characters, escape_replacement, "", "")
     }
 }
 
@@ -106,43 +199,214 @@ mod tests {
             serde_json::from_value(json!("Standard")).unwrap();
         assert_eq!(wildcard, WildcardEither::Or(StorageClass::Standard));
 
-        let wildcard: WildcardEither<EventType> = serde_json::from_value(json!("Create%")).unwrap();
+        let wildcard: WildcardEither<EventType> = serde_json::from_value(json!("Create*")).unwrap();
         assert_eq!(
             wildcard,
-            WildcardEither::Wildcard(Wildcard::new("Create%".to_string()))
+            WildcardEither::Wildcard(Wildcard::new("Create*".to_string()))
         );
         let wildcard: WildcardEither<DateTimeWithTimeZone> =
-            serde_json::from_value(json!("1970-01-01%")).unwrap();
+            serde_json::from_value(json!("1970-01-01*")).unwrap();
         assert_eq!(
             wildcard,
-            WildcardEither::Wildcard(Wildcard::new("1970-01-01%".to_string()))
+            WildcardEither::Wildcard(Wildcard::new("1970-01-01*".to_string()))
         );
         let wildcard: WildcardEither<StorageClass> =
-            serde_json::from_value(json!("Standar%")).unwrap();
+            serde_json::from_value(json!("Standar*")).unwrap();
         assert_eq!(
             wildcard,
-            WildcardEither::Wildcard(Wildcard::new("Standar%".to_string()))
+            WildcardEither::Wildcard(Wildcard::new("Standar*".to_string()))
         );
     }
 
     #[test]
-    fn wildcard_deserialize() {
+    fn contains_wildcard() {
         assert!(!Wildcard::new(r#"test"#.to_string()).contains_wildcard());
         assert!(!Wildcard::new(r#"tes\n"#.to_string()).contains_wildcard());
 
-        assert!(Wildcard::new(r#"t%st"#.to_string()).contains_wildcard());
-        assert!(Wildcard::new(r#"t_st"#.to_string()).contains_wildcard());
+        assert!(Wildcard::new(r#"t*st"#.to_string()).contains_wildcard());
+        assert!(Wildcard::new(r#"t?st"#.to_string()).contains_wildcard());
 
-        assert!(!Wildcard::new(r#"t\%st"#.to_string()).contains_wildcard());
-        assert!(!Wildcard::new(r#"t\_st"#.to_string()).contains_wildcard());
+        assert!(!Wildcard::new(r#"t\*st"#.to_string()).contains_wildcard());
+        assert!(!Wildcard::new(r#"t\?st"#.to_string()).contains_wildcard());
         assert!(!Wildcard::new(r#"t\\st"#.to_string()).contains_wildcard());
 
-        assert!(Wildcard::new(r#"te%%"#.to_string()).contains_wildcard());
-        assert!(Wildcard::new(r#"te__"#.to_string()).contains_wildcard());
+        assert!(Wildcard::new(r#"te**"#.to_string()).contains_wildcard());
+        assert!(Wildcard::new(r#"te??"#.to_string()).contains_wildcard());
         assert!(!Wildcard::new(r#"te\\\\"#.to_string()).contains_wildcard());
 
-        assert!(Wildcard::new(r#"te\%%"#.to_string()).contains_wildcard());
-        assert!(Wildcard::new(r#"te\__"#.to_string()).contains_wildcard());
+        assert!(Wildcard::new(r#"te\**"#.to_string()).contains_wildcard());
+        assert!(Wildcard::new(r#"te\??"#.to_string()).contains_wildcard());
         assert!(!Wildcard::new(r#"tes\\"#.to_string()).contains_wildcard());
+    }
+
+    #[test]
+    fn to_like_expression() {
+        assert_eq!(
+            Wildcard::new(r#"test"#.to_string())
+                .to_like_expression()
+                .unwrap(),
+            "test"
+        );
+        assert_eq!(
+            Wildcard::new("tes\n".to_string())
+                .to_like_expression()
+                .unwrap(),
+            "tes\n"
+        );
+
+        assert_eq!(
+            Wildcard::new("t*st".to_string())
+                .to_like_expression()
+                .unwrap(),
+            "t%st"
+        );
+        assert_eq!(
+            Wildcard::new("t?st".to_string())
+                .to_like_expression()
+                .unwrap(),
+            "t_st"
+        );
+
+        assert_eq!(
+            Wildcard::new(r"t\*st".to_string())
+                .to_like_expression()
+                .unwrap(),
+            r"t*st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t\?st".to_string())
+                .to_like_expression()
+                .unwrap(),
+            r"t?st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t\\st".to_string())
+                .to_like_expression()
+                .unwrap(),
+            r"t\\st"
+        );
+
+        assert_eq!(
+            Wildcard::new(r"t%st".to_string())
+                .to_like_expression()
+                .unwrap(),
+            r"t\%st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t_st".to_string())
+                .to_like_expression()
+                .unwrap(),
+            r"t\_st"
+        );
+
+        assert!(Wildcard::new(r"t\st".to_string())
+            .to_like_expression()
+            .is_err());
+        assert!(Wildcard::new(r"tes\".to_string())
+            .to_like_expression()
+            .is_err());
+    }
+
+    #[test]
+    fn to_like_regex() {
+        assert_eq!(
+            Wildcard::new(r#"test"#.to_string())
+                .to_like_regex()
+                .unwrap(),
+            "test"
+        );
+        assert_eq!(
+            Wildcard::new("tes\n".to_string()).to_like_regex().unwrap(),
+            "tes\n"
+        );
+
+        assert_eq!(
+            Wildcard::new("t*st".to_string()).to_like_regex().unwrap(),
+            "t.*st"
+        );
+        assert_eq!(
+            Wildcard::new("t?st".to_string()).to_like_regex().unwrap(),
+            "t.st"
+        );
+
+        assert_eq!(
+            Wildcard::new(r"t\*st".to_string()).to_like_regex().unwrap(),
+            r"t\\*st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t\?st".to_string()).to_like_regex().unwrap(),
+            r"t\\?st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t\\st".to_string()).to_like_regex().unwrap(),
+            r"t\\\st"
+        );
+
+        assert_eq!(
+            Wildcard::new(r"t.st".to_string()).to_like_regex().unwrap(),
+            r"t\\.st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t-st".to_string()).to_like_regex().unwrap(),
+            r"t\\-st"
+        );
+
+        assert!(Wildcard::new(r"t\st".to_string()).to_like_regex().is_err());
+        assert!(Wildcard::new(r"tes\".to_string()).to_like_regex().is_err());
+    }
+
+    #[test]
+    fn to_eq_expression() {
+        assert_eq!(
+            Wildcard::new(r#"test"#.to_string())
+                .to_eq_expression()
+                .unwrap(),
+            "test"
+        );
+        assert_eq!(
+            Wildcard::new("tes\n".to_string())
+                .to_eq_expression()
+                .unwrap(),
+            "tes\n"
+        );
+
+        assert_eq!(
+            Wildcard::new(r"t\*st".to_string())
+                .to_eq_expression()
+                .unwrap(),
+            "t*st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t\?st".to_string())
+                .to_eq_expression()
+                .unwrap(),
+            "t?st"
+        );
+
+        assert_eq!(
+            Wildcard::new(r"t.st".to_string())
+                .to_eq_expression()
+                .unwrap(),
+            r"t.st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t%st".to_string())
+                .to_eq_expression()
+                .unwrap(),
+            r"t%st"
+        );
+        assert_eq!(
+            Wildcard::new(r"t\\st".to_string())
+                .to_eq_expression()
+                .unwrap(),
+            r"t\\st"
+        );
+
+        assert!(Wildcard::new(r"t\st".to_string())
+            .to_eq_expression()
+            .is_err());
+        assert!(Wildcard::new(r"tes\".to_string())
+            .to_eq_expression()
+            .is_err());
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/wildcard.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/wildcard.rs
@@ -149,7 +149,7 @@ impl Wildcard {
     pub fn contains_wildcard(&self) -> bool {
         !self.wildcard_positions().0.is_empty()
     }
-    
+
     /// Convert this wildcard to a postgres jsonbpath `like_regex` string, escaping relevant characters.
     pub fn to_like_regex(&self) -> Result<String> {
         // Valid postgres regex characters need to be escaped.

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
@@ -92,7 +92,7 @@ pub async fn presign_s3_by_id(
                 ..Default::default()
             },
             true,
-        )
+        )?
         .all()
         .await?;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/update.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/update.rs
@@ -132,7 +132,7 @@ pub async fn update_s3_collection_attributes(
     let txn = state.database_client().connection_ref().begin().await?;
 
     let mut results = UpdateQueryBuilder::<_, s3_object::Entity>::new(&txn)
-        .filter_all(filter_all, wildcard.case_sensitive());
+        .filter_all(filter_all, wildcard.case_sensitive())?;
 
     if list.current_state() {
         results = results.current_state();
@@ -450,7 +450,7 @@ mod tests {
 
         let (_, s3_objects) = response_from::<Vec<S3>>(
             state.clone(),
-            "/s3?attributes[attributeId]=%a%",
+            "/s3?attributes[attributeId]=*a*",
             Method::PATCH,
             Body::new(patch.to_string()),
         )
@@ -487,7 +487,7 @@ mod tests {
 
         let (_, s3_objects) = response_from::<Vec<S3>>(
             state.clone(),
-            "/s3?attributes[attributeId]=%A%",
+            "/s3?attributes[attributeId]=*A*",
             Method::PATCH,
             Body::new(patch.to_string()),
         )
@@ -496,7 +496,7 @@ mod tests {
 
         let (_, s3_objects) = response_from::<Vec<S3>>(
             state.clone(),
-            "/s3?attributes[attributeId]=%A%&caseSensitive=false",
+            "/s3?attributes[attributeId]=*A*&caseSensitive=false",
             Method::PATCH,
             Body::new(patch.to_string()),
         )
@@ -527,7 +527,7 @@ mod tests {
 
         let (_, s3_objects) = response_from::<Vec<S3>>(
             state.clone(),
-            "/s3?currentState=true&eventTime=1970-01-0%",
+            "/s3?currentState=true&eventTime=1970-01-0*",
             Method::PATCH,
             Body::new(patch.to_string()),
         )
@@ -559,7 +559,7 @@ mod tests {
         let (_, s3_objects) = response_from::<Vec<S3>>(
             state.clone(),
             // Percent-encoding should work too.
-            "/s3?caseSensitive=false&currentState=true&eventTime=1970-01-_%25",
+            "/s3?caseSensitive=false&currentState=true&eventTime=1970-01-?%2A",
             Method::PATCH,
             Body::new(patch.to_string()),
         )


### PR DESCRIPTION
Closes #460

### Changes
* Rework JSON queries to use jsonpath operators and a gin index.
    * The wildcard operators have changed to `*` for multiple characters and `?` for single characters. \cc @williamputraintan 
* Add index for prefix searching on keys.

### To do
* Partition records into `current` objects, and `historical` records.