### PR TITLE
fix: filemanager migration

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/Cargo.lock
+++ b/lib/workload/stateless/stacks/filemanager/Cargo.lock
@@ -549,6 +549,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-sdk-cloudformation"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ace4f1ef88afc41ef46a3343ce9ac49f78e0d03dbf749ed27e9f032004f1581"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "once_cell",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
 name = "aws-sdk-s3"
 version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2284,7 @@ dependencies = [
 name = "filemanager-migrate-lambda"
 version = "0.1.0"
 dependencies = [
+ "aws-sdk-cloudformation",
  "aws_lambda_events",
  "filemanager",
  "lambda_runtime",

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
@@ -6,7 +6,7 @@ import { BucketProps } from './ingest';
 /**
  * Props for the API function.
  */
-export type ApiFunctionProps = fn.FunctionPropsNoPackage & DatabaseProps & BucketProps;
+export type ApiFunctionProps = fn.FunctionPropsConfigurable & DatabaseProps & BucketProps;
 
 /**
  * A construct for the Lambda API function.

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
@@ -31,9 +31,9 @@ export type DatabaseProps = {
 };
 
 /**
- * Props for a Rust function without the package.
+ * Props for a Rust function which can be configured from the top-level orcabus context.
  */
-export type FunctionPropsNoPackage = {
+export type FunctionPropsConfigurable = {
   /**
    * Additional build environment variables when building the Lambda function.
    */
@@ -57,9 +57,9 @@ export type FunctionPropsNoPackage = {
 };
 
 /**
- * Props for the Rust function.
+ * Props for the Rust function which can be configured from the top-level orcabus context.
  */
-export type FunctionProps = FunctionPropsNoPackage &
+export type FunctionProps = FunctionPropsConfigurable &
   DatabaseProps & {
     /**
      * The package to build for this function.
@@ -69,6 +69,10 @@ export type FunctionProps = FunctionPropsNoPackage &
      * Name of the Lambda function resource.
      */
     readonly functionName?: string;
+    /**
+     * The timeout for the Lambda function, defaults to 28 seconds.
+     */
+    readonly timeout?: Duration;
   };
 
 /**
@@ -121,7 +125,7 @@ export class Function extends Construct {
         },
       },
       memorySize: 128,
-      timeout: Duration.seconds(28),
+      timeout: props.timeout ?? Duration.seconds(28),
       environment: {
         // No password here, using RDS IAM to generate credentials.
         PGHOST: props.host,

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
@@ -28,7 +28,7 @@ export type EventSourceProps = {
 /**
  * Props for the ingest function.
  */
-export type IngestFunctionProps = fn.FunctionPropsNoPackage & DatabaseProps & EventSourceProps;
+export type IngestFunctionProps = fn.FunctionPropsConfigurable & DatabaseProps & EventSourceProps;
 
 /**
  * A construct for the Lambda ingest function.

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/inventory.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/inventory.ts
@@ -19,7 +19,7 @@ export type InventoryFunctionConfig = {
 /**
  * Props for the inventory function.
  */
-export type InventoryFunctionProps = fn.FunctionPropsNoPackage &
+export type InventoryFunctionProps = fn.FunctionPropsConfigurable &
   DatabaseProps &
   InventoryFunctionConfig;
 

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/migrate.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/migrate.ts
@@ -1,17 +1,22 @@
 import { Construct } from 'constructs';
 import * as fn from './function';
 import { DatabaseProps } from './function';
+import { Duration } from 'aws-cdk-lib';
 
 /**
  * Props for the migrate function.
  */
-export type MigrateFunctionProps = fn.FunctionPropsNoPackage & DatabaseProps;
+export type MigrateFunctionProps = fn.FunctionPropsConfigurable & DatabaseProps;
 
 /**
  * A construct for the Lambda migrate function.
  */
 export class MigrateFunction extends fn.Function {
   constructor(scope: Construct, id: string, props: MigrateFunctionProps) {
-    super(scope, id, { package: 'filemanager-migrate-lambda', ...props });
+    super(scope, id, {
+      package: 'filemanager-migrate-lambda',
+      timeout: Duration.minutes(2),
+      ...props,
+    });
   }
 }

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/migrate.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/migrate.ts
@@ -1,7 +1,8 @@
 import { Construct } from 'constructs';
 import * as fn from './function';
 import { DatabaseProps } from './function';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, Stack } from 'aws-cdk-lib';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 
 /**
  * Props for the migrate function.
@@ -18,5 +19,13 @@ export class MigrateFunction extends fn.Function {
       timeout: Duration.minutes(2),
       ...props,
     });
+
+    // Need to be able to determine if the stack is in rollback state.
+    this.addToPolicy(
+      new PolicyStatement({
+        actions: ['cloudformation:DescribeStacks'],
+        resources: [Stack.of(this).stackId],
+      })
+    );
   }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager-migrate-lambda/Cargo.toml
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-migrate-lambda/Cargo.toml
@@ -8,10 +8,13 @@ rust-version.workspace = true
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
 tokio = { version = "1", features = ["macros"] }
 tracing = { version = "0.1" }
 
 aws_lambda_events = "0.15"
+aws-sdk-cloudformation = "1"
 lambda_runtime = "0.13"
 
 filemanager = { path = "../filemanager", features = ["migrate"] }


### PR DESCRIPTION
Related to #460 and #514

### Issue
The migration Lambda function timed out because the migration involved index creation which can take a while.

### Changes
* Update migration function timeout to 2 minutes.
* Fix migration Lambda function which was getting stuck in `UPDATE_ROLLBACK_FAILED`.
    * The fix involves checking the status of the CloudFormation stack.
    * The migration function now uses the built in `CloudFormationCustomResourceRequest` from the `lambda-runtime`.
    
The migration from #514 doesn't take that long (only about 30 seconds), so for now the simplest solution is to increase the Lambda timeout. Later, it might be an issue if there are any long-running index creation steps.

A better solution could involve:
* Creating an asynchronous migration using the [`isComplete` handler](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.custom_resources-readme.html#asynchronous-providers-iscomplete) from the provider framework.
* Running the migration script using CodeBuild.