### PR TITLE
Fix issue with WRSC generation when a libary record exists

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/create_workflow_run_state.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/services/create_workflow_run_state.py
@@ -92,12 +92,13 @@ def handler(event, context):
         input_libraries: list[srv.LibraryRecord] = srv_wrsc.linkedLibraries
         if input_libraries:
             for input_rec in input_libraries:
-                # check if the library has already a DB record
-                db_lib: Library = Library.objects.get_by_keyword(orcabus_id=input_rec.orcabusId)
-                # create it if not
-                if not db_lib:
-                    # TODO: the library record should exist in the future - synced with metadata service on
-                    #       LibraryStateChange events
+                # get the DB record of the library
+                try:
+                    db_lib: Library = Library.objects.get(orcabus_id=input_rec.orcabusId)
+                except Library.DoesNotExist:
+                    # The library record should exist - synced with metadata service on LibraryStateChange events
+                    # However, until that sync is in place we may need to create a record on demand
+                    # FIXME: remove this once library records are automatically synced
                     db_lib = Library.objects.create(orcabus_id=input_rec.orcabusId, library_id=input_rec.libraryId)
 
                 # create the library association

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/tests/test_create_workflow_run_state.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager_proc/tests/test_create_workflow_run_state.py
@@ -7,15 +7,15 @@ from django.utils.timezone import make_aware
 from workflow_manager_proc.domain.workflowmanager.workflowrunstatechange import WorkflowRunStateChange
 from workflow_manager_proc.services import create_workflow_run_state
 from workflow_manager_proc.tests.case import WorkflowManagerProcUnitTestCase, logger
-from workflow_manager.models import WorkflowRun, State, WorkflowRunUtil
+from workflow_manager.models import WorkflowRun, State, WorkflowRunUtil, Library
 from workflow_manager.tests.factories import WorkflowRunFactory
 
 
 class WorkflowSrvUnitTests(WorkflowManagerProcUnitTestCase):
 
-    def test_get_workflow_from_db(self):
+    def test_create_wrsc_no_library(self):
         """
-        python manage.py test workflow_manager_proc.tests.test_create_workflow_run_state.WorkflowSrvUnitTests.test_get_workflow_from_db
+        python manage.py test workflow_manager_proc.tests.test_create_workflow_run_state.WorkflowSrvUnitTests.test_create_wrsc_no_library
         """
 
         test_event = {
@@ -58,9 +58,9 @@ class WorkflowSrvUnitTests(WorkflowManagerProcUnitTestCase):
         # We don't expect any library associations here!
         self.assertEqual(0, db_wfr.libraries.count())
 
-    def test_get_workflow_from_db2(self):
+    def test_create_wrsc_library(self):
         """
-        python manage.py test workflow_manager_proc.tests.test_create_workflow_run_state.WorkflowSrvUnitTests.test_get_workflow_from_db2
+        python manage.py test workflow_manager_proc.tests.test_create_workflow_run_state.WorkflowSrvUnitTests.test_create_wrsc_library
         """
         library_ids = ["L000001", "L000002"]
         lib_ids = [
@@ -73,6 +73,74 @@ class WorkflowSrvUnitTests(WorkflowManagerProcUnitTestCase):
                 "orcabusId": "lib.01J5M2JFE1JPYV62RYQEG99CP5"
             }
         ]
+
+        test_event = {
+            "portalRunId": "202405012397gatc",
+            "executionId": "icav2.id.12345",
+            "timestamp": "2025-05-01T09:25:44Z",
+            "status": "DRAFT",
+            "workflowName": "ctTSO500",
+            "workflowVersion": "4.2.7",
+            "workflowRunName": "ctTSO500-L000002",
+            "linkedLibraries": lib_ids,
+            "payload": {
+                "version": "0.1.0",
+                "data": {
+                    "projectId": "bxxxxxxxx-dxxx-4xxxx-adcc-xxxxxxxxx",
+                    "analysisId": "12345678-238c-4200-b632-d5dd8c8db94a",
+                    "userReference": "540424_A01001_0193_BBBBMMDRX5_c754de_bd822f",
+                    "timeCreated": "2024-05-01T10:11:35Z",
+                    "timeModified": "2024-05-01T11:24:29Z",
+                    "pipelineId": "bfffffff-cb27-4dfa-846e-acd6eb081aca",
+                    "pipelineCode": "CTTSO500 v4_2_7",
+                    "pipelineDescription": "This is an ctTSO500 workflow execution",
+                    "pipelineUrn": "urn:ilmn:ica:pipeline:bfffffff-cb27-4dfa-846e-acd6eb081aca#CTTSO500_v4_2_7"
+                }
+            }
+        }
+
+        logger.info("Test the created WRSC event...")
+        result_wrsc: WorkflowRunStateChange = create_workflow_run_state.handler(test_event, None)
+        logger.info(result_wrsc)
+        self.assertIsNotNone(result_wrsc)
+        self.assertEqual("ctTSO500-L000002", result_wrsc.workflowRunName)
+        # We do expect 2 library associations here!
+        self.assertIsNotNone(result_wrsc.linkedLibraries)
+        self.assertEqual(2, len(result_wrsc.linkedLibraries))
+        for lib in result_wrsc.linkedLibraries:
+            self.assertTrue(lib.libraryId in library_ids)
+
+        logger.info("Test the persisted DB record...")
+        wfr_qs: QuerySet = WorkflowRun.objects.all()
+        self.assertEqual(1, wfr_qs.count())
+        db_wfr: WorkflowRun = wfr_qs.first()
+        self.assertEqual("ctTSO500-L000002", db_wfr.workflow_run_name)
+        # We do expect 2 library associations here!
+        self.assertEqual(2, db_wfr.libraries.count())
+        for lib in db_wfr.libraries.all():
+            self.assertTrue(lib.library_id in library_ids)
+
+    def test_create_wrsc_library_exists(self):
+        """
+        python manage.py test workflow_manager_proc.tests.test_create_workflow_run_state.WorkflowSrvUnitTests.test_create_wrsc_library_exists
+        """
+
+        library_ids = ["L000001", "L000002"]
+        lib_ids = [
+            {
+                "libraryId": library_ids[0],
+                "orcabusId": "lib.01J5M2J44HFJ9424G7074NKTGN"
+            },
+            {
+                "libraryId": library_ids[1],
+                "orcabusId": "lib.01J5M2JFE1JPYV62RYQEG99CP5"
+            }
+        ]
+        for lib_id in lib_ids:
+            Library.objects.create(
+                library_id=lib_id["libraryId"],
+                orcabus_id=lib_id["orcabusId"]
+            )
 
         test_event = {
             "portalRunId": "202405012397gatc",


### PR DESCRIPTION
- Update Django query to expect and return a single DB record instead of a QuerySet
- Handle DoesNotExist case
- Add new test case to check for this condition