### PR TITLE
Change(WorkflowRunManager): add more query and search terms

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/viewsets/workflow_run.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/viewsets/workflow_run.py
@@ -1,4 +1,4 @@
-from django.db.models import Q, Max
+from django.db.models import Q, Max, F
 from rest_framework import filters
 from rest_framework.decorators import action
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -19,9 +19,15 @@ class WorkflowRunViewSet(ReadOnlyModelViewSet):
     def get_queryset(self):
         
         """
-        custom queryset to filter by:
+        custom queryset:
+        add filter by:
         start_time, end_time : range of latest state timestamp
         is_ongoing : filter by ongoing workflow runs
+        status : filter by latest state status
+        
+        add search terms: 
+        library_id: filter by library_id
+        orcabus_id: filter by orcabus_id
         """
         # default time is 0
         start_time = self.request.query_params.get('start_time', 0)
@@ -29,6 +35,12 @@ class WorkflowRunViewSet(ReadOnlyModelViewSet):
         
         # get is ongoing flag
         is_ongoing = self.request.query_params.get('is_ongoing', 'false')
+        
+        # get status
+        status = self.request.query_params.get('status', '')
+        
+        # get search query params
+        search_params = self.request.query_params.get('search', '')
         
         # exclude the custom query params from the rest of the query params
         def exclude_params(params):
@@ -38,8 +50,14 @@ class WorkflowRunViewSet(ReadOnlyModelViewSet):
         exclude_params([
             'start_time',
             'end_time',
-            'is_ongoing'
+            'is_ongoing',
+            'status',
         ])
+        
+        if search_params.startswith('L') or search_params.startswith('lib'):
+            exclude_params([
+                'search'
+            ])
                 
         # get all workflow runs with rest of the query params
         result_set = WorkflowRun.objects.get_by_keyword(**self.request.query_params).prefetch_related('states').prefetch_related('libraries').select_related('workflow') # add prefetch_related & select_related to reduce the number of queries
@@ -55,6 +73,18 @@ class WorkflowRunViewSet(ReadOnlyModelViewSet):
                 ~Q(states__status="ABORTED") &
                 ~Q(states__status="SUCCEEDED")
             )
+        
+        if status:
+            result_set = result_set.annotate(latest_state_time=Max('states__timestamp')).filter(
+                states__timestamp=F('latest_state_time'),
+                states__status=status
+            )
+        
+        # search by library_id or orcabus_id
+        if search_params.startswith('L'):
+            result_set = result_set.filter(libraries__library_id__icontains=search_params)
+        if search_params.startswith('lib'):
+            result_set = result_set.filter(libraries__orcabus_id__icontains=search_params)
         
         return result_set
 


### PR DESCRIPTION
1. add status query params for filter by the latest status
2. add libraryId and orcabusId in the search terms for group workflow runs

example: 
`http://localhost:8000/api/v1/workflowrun/?search=lib.01J5S9CFX5P69S4KZRQGDFKV1N&status=GENERATING_OUTPUTS`
`http://localhost:8000/api/v1/workflowrun/?search=L2400255&status=READY`
