### PR TITLE
Payloads use Rgid not RgId

### DIFF
--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/mod-podge/part_1/initialise-wts-library-dbs/step_functions_templates/initialise_wts_library_db_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/mod-podge/part_1/initialise-wts-library-dbs/step_functions_templates/initialise_wts_library_db_sfn_template.asl.json
@@ -85,7 +85,7 @@
             "Type": "Pass",
             "Next": "Initialise Fastq List Row and Update Library",
             "Parameters": {
-              "fastq_list_row_id.$": "States.ArrayGetItem($.fastq_list_row_objs[*].fastqListRowRgId, $.index)"
+              "fastq_list_row_id.$": "States.ArrayGetItem($.fastq_list_row_objs[*].fastqListRowRgid, $.index)"
             },
             "ResultPath": "$.get_fastq_list_row_id_step"
           },

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/pva/part_2/initialise-umccrise-library-dbs/step_functions_templates/initialise_umccrise_library_db_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/pva/part_2/initialise-umccrise-library-dbs/step_functions_templates/initialise_umccrise_library_db_sfn_template.asl.json
@@ -126,7 +126,7 @@
             "Type": "Pass",
             "Next": "Initialise Fastq List Row and Update Library",
             "Parameters": {
-              "fastq_list_row_id.$": "States.ArrayGetItem($.fastq_list_row_objs[*].fastqListRowRgId, $.index)"
+              "fastq_list_row_id.$": "States.ArrayGetItem($.fastq_list_row_objs[*].fastqListRowRgid, $.index)"
             },
             "ResultPath": "$.get_fastq_list_row_id_step"
           },


### PR DESCRIPTION
Resolves errors for mod-podge and umccrise that failed to initialise fastq list row attributes on samplesheet showers