### PR TITLE
Add lane to bclconvert samplesheet if it doesn't exist

### DIFF
--- a/lib/workload/stateless/stacks/bclconvert-manager/deps/requirements.txt
+++ b/lib/workload/stateless/stacks/bclconvert-manager/deps/requirements.txt
@@ -4,3 +4,4 @@ wrapica==2.27.1.post20240830140737
 xmltodict==0.13.0
 mypy_boto3_ssm>=1.16.0
 mypy_boto3_secretsmanager>=1.16.0
+more-itertools>=10.3.0

--- a/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/icav2_analysis/analysis_helper.py
+++ b/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/icav2_analysis/analysis_helper.py
@@ -197,7 +197,8 @@ def collect_analysis_objects(project_id: str, analysis_id: str) -> Dict:
     logger.info("Reading in the samplesheet")
     samplesheet_dict = read_v2_samplesheet(
         project_id=project_id,
-        data_id=samplesheet_file_id
+        samplesheet_data_id=samplesheet_file_id,
+        runinfo_data_id=run_info_file_id
     )
 
     return {

--- a/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/runinfo/__init__.py
+++ b/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/runinfo/__init__.py
@@ -1,5 +1,6 @@
-from .runinfo_helper import get_run_id_from_run_info
+from .runinfo_helper import get_run_id_from_run_info, get_num_lanes_from_run_info
 
 __all__ = [
+    'get_num_lanes_from_run_info',
     'get_run_id_from_run_info'
 ]

--- a/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/runinfo/runinfo_helper.py
+++ b/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/runinfo/runinfo_helper.py
@@ -100,3 +100,12 @@ def get_run_id_from_run_info(project_id: str, data_id: str) -> str:
     """
     return read_runinfo_xml(project_id, data_id)['RunInfo']['Run']['@Id']
 
+
+def get_num_lanes_from_run_info(project_id: str, data_id: str) -> int:
+    """
+    Get the number of lanes in a run info object
+    :param project_id:
+    :param data_id:
+    :return:
+    """
+    return int(read_runinfo_xml(project_id, data_id)['RunInfo']['Run']['FlowcellLayout']['@LaneCount'])

--- a/lib/workload/stateless/stacks/bclconvert-manager/translator_service/icav2_event_translator.py
+++ b/lib/workload/stateless/stacks/bclconvert-manager/translator_service/icav2_event_translator.py
@@ -499,3 +499,5 @@ def parse_event_code(event_code):
 #     #   "statusCode": 200,
 #     #   "body": "\"Internal event sent to the event bus and both msg stored in the DynamoDB table.\""
 #     # }
+
+


### PR DESCRIPTION
If there is no lane attribute in the samplesheet bclconvert_data section, collect the runinfo xml and duplicate every row in the samplesheet for every lane in the instrument run