### PR TITLE
Initialise library set to prevent sfn failing

### DIFF
--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/part_1/initialise-cttsov2-instrument-dbs/step_functions_templates/initialise_cttsov2_instrument_run_db_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/part_1/initialise-cttsov2-instrument-dbs/step_functions_templates/initialise_cttsov2_instrument_run_db_sfn_template.asl.json
@@ -21,6 +21,9 @@
           },
           "id_type": {
             "S": "${__instrument_run_partition_name__}"
+          },
+          "library_set": {
+            "SS": []
           }
         }
       },

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_1/initialise-wgts-instrument-run-db/step_functions_templates/initialise_wgts_instrument_run_db_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_1/initialise-wgts-instrument-run-db/step_functions_templates/initialise_wgts_instrument_run_db_sfn_template.asl.json
@@ -21,6 +21,9 @@
           },
           "id_type": {
             "S": "${__instrument_run_partition_name__}"
+          },
+          "library_set": {
+            "SS": []
           }
         }
       },


### PR DESCRIPTION
sfn event-to-ready will fail when no library has been initialised for this sample type on this run

Resolves #544 