### PR TITLE
add workflow run status count api

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/serializers.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/serializers.py
@@ -67,3 +67,16 @@ class StateModelSerializer(serializers.ModelSerializer):
     class Meta:
         model = State
         fields = '__all__'
+
+class WorkflowRunCountByStatusSerializer(serializers.Serializer):
+    all = serializers.IntegerField()
+    succeeded = serializers.IntegerField()
+    aborted = serializers.IntegerField()
+    failed = serializers.IntegerField()
+    ongoing = serializers.IntegerField()
+
+    def update(self, instance, validated_data):
+        pass
+
+    def create(self, validated_data):
+        pass


### PR DESCRIPTION
Add new api for orcaui `api/v1/workflowrun/count_by_status/` in Workflow Manager
Returns the count of records for each status: 'SUCCEEDED', 'ABORTED', 'FAILED', and 'Onging' State.

UI by status: 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/8baedd63-ead1-4868-9f5e-23f85e9b6327">
