### PR TITLE
refactor(filemanager): match AWS behaviour for delete markers

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/filemanager-build/src/gen_openapi.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-build/src/gen_openapi.rs
@@ -37,6 +37,11 @@ pub async fn generate_openapi(out_dir: &Path) -> Result<()> {
     let model_ident: Ident = parse_quote! { Model };
     for path in read_dir(out_dir)? {
         let path = path?.path();
+
+        if path.extension() != Some("rs".as_ref()) {
+            continue;
+        }
+
         let content = read_to_string(&path)?;
 
         let mut tokens = parse_file(&content).map_err(|err| OpenAPIGeneration(err.to_string()))?;

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -72,7 +72,7 @@ impl From<EventTypeData> for EventTypeDeleteMarker {
                     .is_some_and(|d| d.contains("Delete Marker Created")))
                 || e.contains("ObjectRemoved:DeleteMarkerCreated") =>
             {
-                Self::new(EventType::Created, true)
+                Self::new(EventType::Deleted, true)
             }
             // Regular deleted event.
             e if e.contains("Object Deleted") || e.contains("ObjectRemoved") => {
@@ -347,7 +347,7 @@ mod tests {
 
         assert_flat_s3_event(
             first_message,
-            &Created,
+            &Deleted,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
             EXPECTED_VERSION_ID.to_string(),
@@ -369,7 +369,7 @@ mod tests {
 
         assert_flat_s3_event(
             first_message,
-            &Created,
+            &Deleted,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
             EXPECTED_VERSION_ID.to_string(),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -178,7 +178,7 @@ where
     ///     select distinct on (bucket, key, version_id) * from s3_object
     ///     order by bucket, key, version_id, sequencer desc
     /// ) as s3_object
-    /// where event_type = 'Created';
+    /// where event_type = 'Created' and is_delete_marker = false;
     /// ```
     ///
     /// This finds all distinct objects within a (bucket, key, version_id) grouping such that they
@@ -205,7 +205,8 @@ where
         QuerySelect::query(&mut self.select)
             .from_clear()
             .from_subquery(subquery, Alias::new("s3_object"))
-            .and_where(s3_object::Column::EventType.eq("Created"));
+            .and_where(s3_object::Column::EventType.eq("Created"))
+            .and_where(s3_object::Column::IsDeleteMarker.eq(false));
 
         self.trace_query("current_state");
 


### PR DESCRIPTION
Closes #563

### Changes
* Delete markers are ingested as `Deleted` events, rather than `Created` events, which matches what AWS does.
* Fix `filemanager-build` issue which was attempting to parse non Rust files.
* Update delete marker tests.

The justification behind this is that filemanager should try to match what AWS does so that there are no surprises. It is also helpful in ensuring that `current_state` queries don't return `delete_marker` objects which don't represent the current state.