### PR TITLE
feat(filemanager): ingest_id tagging and object move tracking

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0002_s3_ingest_id.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0002_s3_ingest_id.sql
@@ -1,0 +1,2 @@
+alter table s3_object add column ingest_id uuid;
+create index ingest_id_index on s3_object (ingest_id);

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0002_s3_move_id.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0002_s3_move_id.sql
@@ -1,1 +1,0 @@
-alter table s3_object add column move_id uuid;

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0002_s3_move_id.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0002_s3_move_id.sql
@@ -1,0 +1,1 @@
+alter table s3_object add column move_id uuid;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
@@ -35,6 +35,7 @@ select
     is_delete_marker,
     event_type,
     move_id,
+    attributes,
     0::bigint as "number_reordered"
 from input
 -- Grab the most recent object in each input group.

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
@@ -34,6 +34,7 @@ select
     size,
     is_delete_marker,
     event_type,
+    move_id,
     0::bigint as "number_reordered"
 from input
 -- Grab the most recent object in each input group.

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
@@ -34,7 +34,7 @@ select
     size,
     is_delete_marker,
     event_type,
-    move_id,
+    ingest_id,
     attributes,
     0::bigint as "number_reordered"
 from input

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_created_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_created_objects.sql
@@ -13,7 +13,7 @@ insert into s3_object (
     sequencer,
     is_delete_marker,
     event_type,
-    move_id,
+    ingest_id,
     attributes
 )
 values (

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_created_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_created_objects.sql
@@ -12,7 +12,8 @@ insert into s3_object (
     version_id,
     sequencer,
     is_delete_marker,
-    event_type
+    event_type,
+    move_id
 )
 values (
     unnest($1::uuid[]),
@@ -27,7 +28,8 @@ values (
     unnest($10::text[]),
     unnest($11::text[]),
     unnest($12::boolean[]),
-    unnest($13::event_type[])
+    unnest($13::event_type[]),
+    unnest($14::uuid[])
 ) on conflict on constraint sequencer_unique do update
     set number_duplicate_events = s3_object.number_duplicate_events + 1
     returning s3_object_id, number_duplicate_events;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_created_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_created_objects.sql
@@ -13,7 +13,8 @@ insert into s3_object (
     sequencer,
     is_delete_marker,
     event_type,
-    move_id
+    move_id,
+    attributes
 )
 values (
     unnest($1::uuid[]),
@@ -29,7 +30,8 @@ values (
     unnest($11::text[]),
     unnest($12::boolean[]),
     unnest($13::event_type[]),
-    unnest($14::uuid[])
+    unnest($14::uuid[]),
+    unnest($15::jsonb[])
 ) on conflict on constraint sequencer_unique do update
     set number_duplicate_events = s3_object.number_duplicate_events + 1
     returning s3_object_id, number_duplicate_events;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
@@ -13,7 +13,7 @@ insert into s3_object (
     sequencer,
     is_delete_marker,
     event_type,
-    move_id,
+    ingest_id,
     attributes
 )
 values (

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
@@ -12,7 +12,8 @@ insert into s3_object (
     version_id,
     sequencer,
     is_delete_marker,
-    event_type
+    event_type,
+    move_id
 )
 values (
     unnest($1::uuid[]),
@@ -27,7 +28,8 @@ values (
     unnest($10::text[]),
     unnest($11::text[]),
     unnest($12::boolean[]),
-    unnest($13::event_type[])
+    unnest($13::event_type[]),
+    unnest($14::uuid[])
 ) on conflict on constraint sequencer_unique do update
     set number_duplicate_events = s3_object.number_duplicate_events + 1
     returning s3_object_id, number_duplicate_events;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
@@ -13,7 +13,8 @@ insert into s3_object (
     sequencer,
     is_delete_marker,
     event_type,
-    move_id
+    move_id,
+    attributes
 )
 values (
     unnest($1::uuid[]),
@@ -29,7 +30,8 @@ values (
     unnest($11::text[]),
     unnest($12::boolean[]),
     unnest($13::event_type[]),
-    unnest($14::uuid[])
+    unnest($14::uuid[]),
+    unnest($15::jsonb[])
 ) on conflict on constraint sequencer_unique do update
     set number_duplicate_events = s3_object.number_duplicate_events + 1
     returning s3_object_id, number_duplicate_events;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
@@ -19,7 +19,8 @@ with input as (
         $11::text[],
         $12::boolean[],
         $13::event_type[],
-        $14::uuid[]
+        $14::uuid[],
+        $15::jsonb[]
     ) as input (
         s3_object_id,
         bucket,
@@ -34,7 +35,8 @@ with input as (
         created_sequencer,
         is_delete_marker,
         event_type,
-        move_id
+        move_id,
+        attributes
     )
 ),
 -- Then, select the objects that need to be updated.

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
@@ -35,7 +35,7 @@ with input as (
         created_sequencer,
         is_delete_marker,
         event_type,
-        move_id,
+        ingest_id,
         attributes
     )
 ),
@@ -56,7 +56,7 @@ current_objects as (
         input.storage_class as input_storage_class,
         input.is_delete_marker as input_is_delete_marker,
         input.event_type as input_event_type,
-        input.move_id as input_move_id
+        input.ingest_id as input_ingest_id
     from s3_object
     -- Grab the relevant values to update with.
     join input on
@@ -105,7 +105,7 @@ update as (
         is_delete_marker = objects_to_update.input_is_delete_marker,
         storage_class = objects_to_update.input_storage_class,
         event_type = objects_to_update.input_event_type,
-        move_id = objects_to_update.input_move_id,
+        ingest_id = objects_to_update.input_ingest_id,
         number_reordered = s3_object.number_reordered +
             -- Note the asymmetry between this and the reorder for deleted query.
             case when objects_to_update.deleted_sequencer is not null or objects_to_update.sequencer is not null then
@@ -133,7 +133,7 @@ select
     number_duplicate_events,
     size,
     is_delete_marker,
-    move_id,
+    ingest_id,
     attributes,
     -- This is used to simplify re-constructing the FlatS3EventMessages in the Lambda. I.e. this update detected an
     -- out of order created event, so return a created event back.

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
@@ -18,7 +18,8 @@ with input as (
         $10::text[],
         $11::text[],
         $12::boolean[],
-        $13::event_type[]
+        $13::event_type[],
+        $14::uuid[]
     ) as input (
         s3_object_id,
         bucket,
@@ -32,7 +33,8 @@ with input as (
         version_id,
         created_sequencer,
         is_delete_marker,
-        event_type
+        event_type,
+        move_id
     )
 ),
 -- Then, select the objects that need to be updated.
@@ -51,7 +53,8 @@ current_objects as (
         input.e_tag as input_e_tag,
         input.storage_class as input_storage_class,
         input.is_delete_marker as input_is_delete_marker,
-        input.event_type as input_event_type
+        input.event_type as input_event_type,
+        input.move_id as input_move_id
     from s3_object
     -- Grab the relevant values to update with.
     join input on
@@ -100,6 +103,7 @@ update as (
         is_delete_marker = objects_to_update.input_is_delete_marker,
         storage_class = objects_to_update.input_storage_class,
         event_type = objects_to_update.input_event_type,
+        move_id = objects_to_update.input_move_id,
         number_reordered = s3_object.number_reordered +
             -- Note the asymmetry between this and the reorder for deleted query.
             case when objects_to_update.deleted_sequencer is not null or objects_to_update.sequencer is not null then
@@ -127,6 +131,7 @@ select
     number_duplicate_events,
     size,
     is_delete_marker,
+    move_id,
     -- This is used to simplify re-constructing the FlatS3EventMessages in the Lambda. I.e. this update detected an
     -- out of order created event, so return a created event back.
     'Created'::event_type as "event_type"

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
@@ -132,6 +132,7 @@ select
     size,
     is_delete_marker,
     move_id,
+    attributes,
     -- This is used to simplify re-constructing the FlatS3EventMessages in the Lambda. I.e. this update detected an
     -- out of order created event, so return a created event back.
     'Created'::event_type as "event_type"

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
@@ -98,7 +98,7 @@ select
     number_duplicate_events,
     size,
     is_delete_marker,
-    move_id,
+    ingest_id,
     attributes,
     -- This is used to simplify re-constructing the FlatS3EventMessages in the Lambda. I.e. this update detected an
     -- out of order deleted event, so return a deleted event back.

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
@@ -99,6 +99,7 @@ select
     size,
     is_delete_marker,
     move_id,
+    attributes,
     -- This is used to simplify re-constructing the FlatS3EventMessages in the Lambda. I.e. this update detected an
     -- out of order deleted event, so return a deleted event back.
     'Deleted'::event_type as "event_type"

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
@@ -98,6 +98,7 @@ select
     number_duplicate_events,
     size,
     is_delete_marker,
+    move_id,
     -- This is used to simplify re-constructing the FlatS3EventMessages in the Lambda. I.e. this update detected an
     -- out of order deleted event, so return a deleted event back.
     'Deleted'::event_type as "event_type"

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
@@ -20,6 +20,7 @@ export class ApiFunction extends fn.Function {
         // See https://github.com/awslabs/aws-lambda-rust-runtime/tree/main/lambda-http#integration-with-api-gateway-stages
         // for more info.
         AWS_LAMBDA_HTTP_IGNORE_STAGE_IN_PATH: 'true',
+        ...props.environment,
       },
       ...props,
     });

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
@@ -165,11 +165,11 @@ export class Function extends Construct {
   /**
    * Add policies for 's3:List*' and 's3:Get*' on the buckets to this function's role.
    */
-  addPoliciesForBuckets(buckets: string[]) {
+  addPoliciesForBuckets(buckets: string[], additionalActions?: string[]) {
     buckets.map((bucket) => {
       this.addToPolicy(
         new PolicyStatement({
-          actions: ['s3:ListBucket', 's3:GetObject'],
+          actions: [...['s3:ListBucket', 's3:GetObject'], ...(additionalActions ?? [])],
           resources: [`arn:aws:s3:::${bucket}`, `arn:aws:s3:::${bucket}/*`],
         })
       );

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
@@ -3,6 +3,7 @@ import { IQueue } from 'aws-cdk-lib/aws-sqs';
 import * as fn from './function';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { DatabaseProps } from './function';
+import { FILEMANAGER_SERVICE_NAME } from '../../stack';
 
 /**
  * Props for controlling access to buckets.
@@ -35,7 +36,14 @@ export type IngestFunctionProps = fn.FunctionPropsConfigurable & DatabaseProps &
  */
 export class IngestFunction extends fn.Function {
   constructor(scope: Construct, id: string, props: IngestFunctionProps) {
-    super(scope, id, { package: 'filemanager-ingest-lambda', ...props });
+    super(scope, id, {
+      package: 'filemanager-ingest-lambda',
+      environment: {
+        FILEMANAGER_INGESTER_TAG_NAME: 'umccr-org:OrcaBusFileManagerIngestId',
+        ...props.environment,
+      },
+      ...props,
+    });
 
     this.addAwsManagedPolicy('service-role/AWSLambdaSQSQueueExecutionRole');
 
@@ -43,6 +51,11 @@ export class IngestFunction extends fn.Function {
       const eventSource = new SqsEventSource(source);
       this.function.addEventSource(eventSource);
     });
-    this.addPoliciesForBuckets(props.buckets);
+    this.addPoliciesForBuckets(props.buckets, [
+      's3:GetObjectTagging',
+      's3:GetObjectVersionTagging',
+      's3:PutObjectTagging',
+      's3:PutObjectVersionTagging',
+    ]);
   }
 }

--- a/lib/workload/stateless/stacks/filemanager/docs/MOVED_OBJECTS.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/MOVED_OBJECTS.md
@@ -5,9 +5,9 @@ S3 events alone, it's not possible to tell whether an object that has been delet
 the same object that has been moved, or two different objects. This is because S3 only tracks `Created` or `Deleted`
 events.
 
-To track moved objects, the filemanager stores additional information in S3 tags, that gets copied when the object
+To track moved objects, filemanager stores additional information in S3 tags. The tag gets updated when the object
 is moved. This allows the filemanager to track how objects move and also allows it to copy attributes when an object
-is moved/copied.
+is moved/copied. This process is described [below](#tagging-process).
 
 ## Tagging process
 
@@ -26,14 +26,18 @@ API provides a way to query the database for records with a given `ingest_id`.
 
 ## Design considerations
 
-Object tags on S3 are limited to 10 tags per object, and each tag can only store 258 unicode characters. The filemanager
-avoids storing a large amount of data by using a UUID as the value of the tag, which is linked to object records that
-store attributes and data. 
+Object tags on S3 are [limited][s3-tagging] to 10 tags per object, and each tag can only store 258 unicode characters.
+The filemanager avoids storing a large amount of data by using a UUID as the value of the tag, which is linked to object
+records that store attributes and data. 
 
 The object tagging process cannot be atomic, so there is a chance for concurrency errors to occur. Tagging can also
 fail due to database or network errors. The filemanager only tracks `ingest_id`s if it knows that a tag has been
 successfully created on S3, and successfully stored in the database. If tagging fails, or it's not enabled, then the `ingest_id`
 column will be null.
+
+The act of tagging the object allows it to be tracked - ideally this is done as soon as possible. Currently, this happens
+at ingestion, however this could have performance implications. Alternative approaches should consider asynchronous tagging.
+For example, [`s3:ObjectTagging:*`][s3-tagging-event] events could be used for this purpose.
 
 The object tagging mechanism also doesn't differentiate between moved objects and copied objects with the same tags.
 If an object is copied with tags, the `ingest_id` will also be copied and the above logic will apply.
@@ -41,7 +45,14 @@ If an object is copied with tags, the `ingest_id` will also be copied and the ab
 ## Alternative designs
 
 Alternatively, S3 object metadata could also be used to track moves using a similar mechanism. However, metadata can
-only be updated by deleting and recreated the object. This process would be much more costly so tagging was chosen instead.
+[only be updated][s3-metadata] by deleting and recreated the object. This process would be much more costly so tagging 
+was chosen instead.
+
 Another approach is to compare object checksums or etags. However, this would also be limited if the checksum is not present,
-or  if the etag was computed using a different part-size. Both these approaches could be used in addition to object tagging
+or if the etag was computed using a different part-size. It also fails if the checksum is not expected to be the same,
+for example, if tracking set of files that are compressed. Both these approaches could be used in addition to object tagging
 to provide more ways to track moves.
+
+[s3-tagging]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html
+[s3-tagging-event]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html#supported-notification-event-types
+[s3-metadata]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html

--- a/lib/workload/stateless/stacks/filemanager/docs/MOVED_OBJECTS.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/MOVED_OBJECTS.md
@@ -1,0 +1,49 @@
+# Tracking moved objects
+
+The filemanager tracks records from S3 events, which do not describe how objects move from one location to another. Using
+S3 events alone, it's impossible to tell whether an object that has been deleted in one place and created in another is
+the same object that has been moved, or two different objects. This is because S3 only tracks `Created` or `Deleted`
+events.
+
+To track moved objects, the filemanager has to store additional information on objects, that gets copied when the object
+is moved. The design involves using object tagging to store an identifier on all objects that is copied when the 
+object is moved. This id can be used to track how object moves.
+
+When records are ingested, the filemanager first checks if the object contains the tag with the id field. If the tag is
+present, then the object has been moved, and the new record reuses that id. If not, a new id is generated  and the object
+is tagged with it. Later, the database can be queried to find all record matching the id. This represents a sequence of moved
+objects.
+
+## Tagging process
+
+The process of tagging is:
+
+* When an object record is ingested, the filemanager queries `Created` events for tags. 
+* If the tags can be retrieved, the filemanager looks for a tag called `filemanager_id`. The key name can be 
+  configured in the environment variable `FILEMANAGER_INGESTER_TAG_NAME`.
+* The tag is parsed as a UUID, and stored in the `move_id` column of `s3_object` for that record.
+* If the tag does not exist, then a new UUID is generated, and the object is tagged on S3 by calling `PutObjectTagging`. 
+  The new tag is also stored in the `move_id` column.
+* The database is also queried for any records with the same `move_id` so that attributes can be copied to the new record.
+
+This logic is enabled by default, but it can be switched off by setting `FILEMANAGER_INGESTER_TRACK_MOVES`. The filemanager
+API provides a way to query the database for records with a given `move_id`.
+
+## Design considerations
+
+Object tags on S3 are limited to 10 tags per object, where each tag can only store 258 unicode characters. This means that it
+is not possible a large amount of data or attributes in tags. Instead, filemanager stores a single UUID in the tag, which is
+linked to object records that store the attributes and data. 
+
+The object tagging process cannot be atomic, so there is a chance for concurrency errors to occur. Tagging can also
+fail due to database or network errors. The filemanager only tracks `move_id`s if it knows that a tag has been
+successfully created on S3, and successfully stored in the database. If tagging fails, or it's not enabled then the `move_id`
+column will be null.
+
+## Alternative designs
+
+Alternatively, S3 object metadata could also be used to track moves using a similar mechanism. However, metadata can
+only be updated by deleting and recreated the object, so tagging was chosen instead. Another mechanism which could track
+moved objects is to compare object checksums or etags. This works but may also be limited if checksum is not present, or
+if the etag was computed using a different part-size. Both these approaches could be used in addition to object tagging
+to provide the filemanager more ways to track moves.

--- a/lib/workload/stateless/stacks/filemanager/docs/MOVED_OBJECTS.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/MOVED_OBJECTS.md
@@ -1,49 +1,47 @@
 # Tracking moved objects
 
 The filemanager tracks records from S3 events, which do not describe how objects move from one location to another. Using
-S3 events alone, it's impossible to tell whether an object that has been deleted in one place and created in another is
+S3 events alone, it's not possible to tell whether an object that has been deleted in one place and created in another is
 the same object that has been moved, or two different objects. This is because S3 only tracks `Created` or `Deleted`
 events.
 
-To track moved objects, the filemanager has to store additional information on objects, that gets copied when the object
-is moved. The design involves using object tagging to store an identifier on all objects that is copied when the 
-object is moved. This id can be used to track how object moves.
-
-When records are ingested, the filemanager first checks if the object contains the tag with the id field. If the tag is
-present, then the object has been moved, and the new record reuses that id. If not, a new id is generated  and the object
-is tagged with it. Later, the database can be queried to find all record matching the id. This represents a sequence of moved
-objects.
+To track moved objects, the filemanager stores additional information in S3 tags, that gets copied when the object
+is moved. This allows the filemanager to track how objects move and also allows it to copy attributes when an object
+is moved/copied.
 
 ## Tagging process
 
 The process of tagging is:
 
 * When an object record is ingested, the filemanager queries `Created` events for tags. 
-* If the tags can be retrieved, the filemanager looks for a tag called `filemanager_id`. The key name can be 
+* If the tags can be retrieved, the filemanager looks for a key called `ingest_id`. The key name can be 
   configured in the environment variable `FILEMANAGER_INGESTER_TAG_NAME`.
-* The tag is parsed as a UUID, and stored in the `move_id` column of `s3_object` for that record.
+* The tag is parsed as a UUID, and stored in the `ingest_id` column of `s3_object` for that record.
 * If the tag does not exist, then a new UUID is generated, and the object is tagged on S3 by calling `PutObjectTagging`. 
-  The new tag is also stored in the `move_id` column.
-* The database is also queried for any records with the same `move_id` so that attributes can be copied to the new record.
+  The new tag is also stored in the `ingest_id` column.
+* The database is also queried for any records with the same `ingest_id` so that attributes can be copied to the new record.
 
 This logic is enabled by default, but it can be switched off by setting `FILEMANAGER_INGESTER_TRACK_MOVES`. The filemanager
-API provides a way to query the database for records with a given `move_id`.
+API provides a way to query the database for records with a given `ingest_id`.
 
 ## Design considerations
 
-Object tags on S3 are limited to 10 tags per object, where each tag can only store 258 unicode characters. This means that it
-is not possible a large amount of data or attributes in tags. Instead, filemanager stores a single UUID in the tag, which is
-linked to object records that store the attributes and data. 
+Object tags on S3 are limited to 10 tags per object, and each tag can only store 258 unicode characters. The filemanager
+avoids storing a large amount of data by using a UUID as the value of the tag, which is linked to object records that
+store attributes and data. 
 
 The object tagging process cannot be atomic, so there is a chance for concurrency errors to occur. Tagging can also
-fail due to database or network errors. The filemanager only tracks `move_id`s if it knows that a tag has been
-successfully created on S3, and successfully stored in the database. If tagging fails, or it's not enabled then the `move_id`
+fail due to database or network errors. The filemanager only tracks `ingest_id`s if it knows that a tag has been
+successfully created on S3, and successfully stored in the database. If tagging fails, or it's not enabled, then the `ingest_id`
 column will be null.
+
+The object tagging mechanism also doesn't differentiate between moved objects and copied objects with the same tags.
+If an object is copied with tags, the `ingest_id` will also be copied and the above logic will apply.
 
 ## Alternative designs
 
 Alternatively, S3 object metadata could also be used to track moves using a similar mechanism. However, metadata can
-only be updated by deleting and recreated the object, so tagging was chosen instead. Another mechanism which could track
-moved objects is to compare object checksums or etags. This works but may also be limited if checksum is not present, or
-if the etag was computed using a different part-size. Both these approaches could be used in addition to object tagging
-to provide the filemanager more ways to track moves.
+only be updated by deleting and recreated the object. This process would be much more costly so tagging was chosen instead.
+Another approach is to compare object checksums or etags. However, this would also be limited if the checksum is not present,
+or  if the etag was computed using a different part-size. Both these approaches could be used in addition to object tagging
+to provide more ways to track moves.

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/clients/aws/s3.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/clients/aws/s3.rs
@@ -6,10 +6,13 @@ use std::result;
 use aws_sdk_s3 as s3;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::get_object::{GetObjectError, GetObjectOutput};
+use aws_sdk_s3::operation::get_object_tagging::{GetObjectTaggingError, GetObjectTaggingOutput};
 use aws_sdk_s3::operation::head_object::{HeadObjectError, HeadObjectOutput};
 use aws_sdk_s3::operation::list_buckets::{ListBucketsError, ListBucketsOutput};
+use aws_sdk_s3::operation::put_object_tagging::{PutObjectTaggingError, PutObjectTaggingOutput};
 use aws_sdk_s3::presigning::{PresignedRequest, PresigningConfig};
 use aws_sdk_s3::types::ChecksumMode::Enabled;
+use aws_sdk_s3::types::Tagging;
 use chrono::Duration;
 use mockall::automock;
 
@@ -66,6 +69,36 @@ impl Client {
             .checksum_mode(Enabled)
             .key(key)
             .bucket(bucket)
+            .send()
+            .await
+    }
+
+    /// Execute the `GetObjectTagging` operation.
+    pub async fn get_object_tagging(
+        &self,
+        key: &str,
+        bucket: &str,
+    ) -> Result<GetObjectTaggingOutput, GetObjectTaggingError> {
+        self.inner
+            .get_object_tagging()
+            .key(key)
+            .bucket(bucket)
+            .send()
+            .await
+    }
+
+    /// Execute the `PutObjectTagging` operation.
+    pub async fn put_object_tagging(
+        &self,
+        key: &str,
+        bucket: &str,
+        tagging: Tagging,
+    ) -> Result<PutObjectTaggingOutput, PutObjectTaggingError> {
+        self.inner
+            .put_object_tagging()
+            .key(key)
+            .bucket(bucket)
+            .tagging(tagging)
             .send()
             .await
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
@@ -53,7 +53,7 @@ impl Ingester {
         .bind(&events.sequencers)
         .bind(&events.is_delete_markers)
         .bind(&events.event_types)
-        .bind(&events.move_ids)
+        .bind(&events.ingest_ids)
         .bind(&events.attributes)
         .fetch_all(&mut *tx)
         .await?;
@@ -106,7 +106,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 1);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         assert_created(&s3_object_results[0]);
     }
@@ -155,7 +155,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 1);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         assert_with(
             &s3_object_results[0],
@@ -194,7 +194,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 2);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         assert_eq!(
             1,
@@ -301,7 +301,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 2);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         // Order should be different here.
         assert_ingest_events(
@@ -1098,16 +1098,16 @@ pub(crate) mod tests {
                 *sha256 = Some(EXPECTED_SHA256.to_string());
             });
         };
-        let update_move_ids = |move_ids: &mut Vec<Option<Uuid>>| {
-            move_ids.iter_mut().for_each(|move_id| {
-                *move_id = Some(UuidGenerator::generate());
+        let update_ingest_ids = |ingest_ids: &mut Vec<Option<Uuid>>| {
+            ingest_ids.iter_mut().for_each(|ingest_id| {
+                *ingest_id = Some(UuidGenerator::generate());
             });
         };
 
         update_last_modified(&mut events.last_modified_dates);
         update_storage_class(&mut events.storage_classes);
         update_sha256(&mut events.sha256s);
-        update_move_ids(&mut events.move_ids);
+        update_ingest_ids(&mut events.ingest_ids);
 
         events
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
@@ -53,6 +53,7 @@ impl Ingester {
         .bind(&events.sequencers)
         .bind(&events.is_delete_markers)
         .bind(&events.event_types)
+        .bind(&events.move_ids)
         .fetch_all(&mut *tx)
         .await?;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
@@ -54,6 +54,7 @@ impl Ingester {
         .bind(&events.is_delete_markers)
         .bind(&events.event_types)
         .bind(&events.move_ids)
+        .bind(&events.attributes)
         .fetch_all(&mut *tx)
         .await?;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
@@ -105,6 +105,7 @@ impl IngesterPaired {
         .bind(&object_created.is_delete_markers)
         .bind(vec![Other; object_created.s3_object_ids.len()])
         .bind(&object_created.move_ids)
+        .bind(&object_created.attributes)
         .fetch_all(&mut *tx)
         .await?;
 
@@ -126,6 +127,7 @@ impl IngesterPaired {
         .bind(&object_created.is_delete_markers)
         .bind(vec![Other; object_created.s3_object_ids.len()])
         .bind(&object_created.move_ids)
+        .bind(&object_created.attributes)
         .fetch_all(&mut *tx)
         .await?;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
@@ -104,7 +104,7 @@ impl IngesterPaired {
         .bind(&object_created.sequencers)
         .bind(&object_created.is_delete_markers)
         .bind(vec![Other; object_created.s3_object_ids.len()])
-        .bind(&object_created.move_ids)
+        .bind(&object_created.ingest_ids)
         .bind(&object_created.attributes)
         .fetch_all(&mut *tx)
         .await?;
@@ -126,7 +126,7 @@ impl IngesterPaired {
         .bind(&object_created.sequencers)
         .bind(&object_created.is_delete_markers)
         .bind(vec![Other; object_created.s3_object_ids.len()])
-        .bind(&object_created.move_ids)
+        .bind(&object_created.ingest_ids)
         .bind(&object_created.attributes)
         .fetch_all(&mut *tx)
         .await?;
@@ -219,7 +219,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 1);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         assert_created(&s3_object_results[0]);
     }
@@ -273,7 +273,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 1);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         assert_with(
             &s3_object_results[0],
@@ -313,7 +313,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 1);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         assert_ingest_events(&s3_object_results[0], EXPECTED_VERSION_ID);
     }
@@ -334,7 +334,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 1);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         assert_eq!(
             2,
@@ -462,7 +462,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 1);
         assert!(s3_object_results[0]
-            .get::<Option<Uuid>, _>("move_id")
+            .get::<Option<Uuid>, _>("ingest_id")
             .is_some());
         assert_eq!(2, s3_object_results[0].get::<i64, _>("number_reordered"));
         assert_ingest_events(&s3_object_results[0], EXPECTED_VERSION_ID);

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/entities/s3_object.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/entities/s3_object.rs
@@ -37,6 +37,7 @@ pub struct Model {
     #[sea_orm(column_type = "Text", nullable)]
     pub deleted_sequencer: Option<String>,
     pub number_reordered: i64,
+    pub move_id: Option<Uuid>,
 }
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/entities/s3_object.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/entities/s3_object.rs
@@ -37,7 +37,7 @@ pub struct Model {
     #[sea_orm(column_type = "Text", nullable)]
     pub deleted_sequencer: Option<String>,
     pub number_reordered: i64,
-    pub move_id: Option<Uuid>,
+    pub ingest_id: Option<Uuid>,
 }
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
@@ -152,6 +152,7 @@ pub trait Migrate {
 #[cfg(test)]
 pub(crate) mod tests {
     use chrono::{DateTime, Utc};
+    use sea_orm::prelude::Json;
     use sqlx::{query, PgPool, Row};
 
     use crate::database::aws::migration::tests::MIGRATOR;
@@ -241,6 +242,7 @@ pub(crate) mod tests {
         .bind(vec![false])
         .bind(vec![event_type])
         .bind(vec![UuidGenerator::generate()])
+        .bind(vec![None::<Json>])
         .fetch_all(pool)
         .await
         .unwrap();

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
@@ -240,6 +240,7 @@ pub(crate) mod tests {
         .bind(vec![EXPECTED_SEQUENCER_CREATED_ONE.to_string()])
         .bind(vec![false])
         .bind(vec![event_type])
+        .bind(vec![UuidGenerator::generate()])
         .fetch_all(pool)
         .await
         .unwrap();

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
@@ -16,6 +16,7 @@ use crate::error::Result;
 /// Configuration environment variables for filemanager.
 #[serde_as]
 #[derive(Debug, Clone, Deserialize, Eq, PartialEq)]
+#[serde(default)]
 pub struct Config {
     pub(crate) database_url: Option<String>,
     pub(crate) pgpassword: Option<String>,
@@ -24,8 +25,12 @@ pub struct Config {
     pub(crate) pguser: Option<String>,
     #[serde(rename = "filemanager_sqs_url")]
     pub(crate) sqs_url: Option<String>,
-    #[serde(default, rename = "filemanager_paired_ingest_mode")]
+    #[serde(rename = "filemanager_paired_ingest_mode")]
     pub(crate) paired_ingest_mode: bool,
+    #[serde(rename = "filemanager_ingester_track_moves")]
+    pub(crate) ingester_track_moves: bool,
+    #[serde(rename = "filemanager_ingester_tag_name")]
+    pub(crate) ingester_tag_name: String,
     #[serde(default, rename = "filemanager_api_links_url")]
     pub(crate) api_links_url: Option<Url>,
     #[serde(rename = "filemanager_api_presign_limit")]
@@ -35,15 +40,9 @@ pub struct Config {
     pub(crate) api_presign_expiry: Option<Duration>,
     #[serde(rename = "filemanager_api_cors_allow_origins")]
     pub(crate) api_cors_allow_origins: Option<Vec<String>>,
-    #[serde(
-        default = "default_allow_methods",
-        rename = "filemanager_api_cors_allow_methods"
-    )]
+    #[serde(rename = "filemanager_api_cors_allow_methods")]
     pub(crate) api_cors_allow_methods: Vec<String>,
-    #[serde(
-        default = "default_allow_headers",
-        rename = "filemanager_api_cors_allow_headers"
-    )]
+    #[serde(rename = "filemanager_api_cors_allow_headers")]
     pub(crate) api_cors_allow_headers: Vec<String>,
 }
 
@@ -57,28 +56,22 @@ impl Default for Config {
             pguser: None,
             sqs_url: None,
             paired_ingest_mode: false,
+            ingester_track_moves: true,
+            ingester_tag_name: "filemanager_id".to_string(),
             api_links_url: None,
             api_presign_limit: None,
             api_presign_expiry: None,
             api_cors_allow_origins: None,
-            api_cors_allow_methods: default_allow_methods(),
-            api_cors_allow_headers: default_allow_headers(),
+            api_cors_allow_methods: vec![
+                Method::GET.to_string(),
+                Method::HEAD.to_string(),
+                Method::OPTIONS.to_string(),
+                Method::POST.to_string(),
+                Method::PATCH.to_string(),
+            ],
+            api_cors_allow_headers: vec![AUTHORIZATION.to_string()],
         }
     }
-}
-
-fn default_allow_methods() -> Vec<String> {
-    vec![
-        Method::GET.to_string(),
-        Method::HEAD.to_string(),
-        Method::OPTIONS.to_string(),
-        Method::POST.to_string(),
-        Method::PATCH.to_string(),
-    ]
-}
-
-fn default_allow_headers() -> Vec<String> {
-    vec![AUTHORIZATION.to_string()]
 }
 
 impl Config {
@@ -131,6 +124,16 @@ impl Config {
     /// Get the paired ingest mode.
     pub fn paired_ingest_mode(&self) -> bool {
         self.paired_ingest_mode
+    }
+
+    /// Whether the ingester should track moves.
+    pub fn ingester_track_moves(&self) -> bool {
+        self.ingester_track_moves
+    }
+
+    /// Get the ingester tag name.
+    pub fn ingester_tag_name(&self) -> &str {
+        &self.ingester_tag_name
     }
 
     /// Get the presigned size limit.
@@ -192,6 +195,8 @@ mod tests {
             ("PGUSER", "user"),
             ("FILEMANAGER_SQS_URL", "url"),
             ("FILEMANAGER_PAIRED_INGEST_MODE", "true"),
+            ("FILEMANAGER_INGESTER_TRACK_MOVES", "false"),
+            ("FILEMANAGER_INGESTER_TAG_NAME", "tag"),
             ("FILEMANAGER_API_LINKS_URL", "https://localhost:8000"),
             ("FILEMANAGER_API_PRESIGN_LIMIT", "123"),
             ("FILEMANAGER_API_PRESIGN_EXPIRY", "60"),
@@ -217,6 +222,8 @@ mod tests {
                 pguser: Some("user".to_string()),
                 sqs_url: Some("url".to_string()),
                 paired_ingest_mode: true,
+                ingester_track_moves: false,
+                ingester_tag_name: "tag".to_string(),
                 api_links_url: Some("https://localhost:8000".parse().unwrap()),
                 api_presign_limit: Some(123),
                 api_presign_expiry: Some(Duration::seconds(60)),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/env.rs
@@ -57,7 +57,7 @@ impl Default for Config {
             sqs_url: None,
             paired_ingest_mode: false,
             ingester_track_moves: true,
-            ingester_tag_name: "filemanager_id".to_string(),
+            ingester_tag_name: "ingest_id".to_string(),
             api_links_url: None,
             api_presign_limit: None,
             api_presign_expiry: None,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -4,7 +4,6 @@
 use std::{io, result};
 
 use sea_orm::{DbErr, RuntimeErr};
-use sqlx::migrate::MigrateError;
 use thiserror::Error;
 use url::ParseError;
 use uuid::Uuid;
@@ -16,8 +15,6 @@ pub type Result<T> = result::Result<T, Error>;
 pub enum Error {
     #[error("database error: `{0}`")]
     DatabaseError(DbErr),
-    #[error("SQL migrate error: `{0}`")]
-    MigrateError(String),
     #[error("SQS error: `{0}`")]
     SQSError(String),
     #[error("serde error: `{0}`")]
@@ -48,6 +45,9 @@ pub enum Error {
     PresignedUrlError(String),
     #[error("configuring API: `{0}`")]
     ApiConfigurationError(String),
+    #[cfg(feature = "migrate")]
+    #[error("SQL migrate error: `{0}`")]
+    MigrateError(String),
 }
 
 impl From<sqlx::Error> for Error {
@@ -59,12 +59,6 @@ impl From<sqlx::Error> for Error {
 impl From<DbErr> for Error {
     fn from(err: DbErr) -> Self {
         Self::DatabaseError(err)
-    }
-}
-
-impl From<MigrateError> for Error {
-    fn from(err: MigrateError) -> Self {
-        Self::DatabaseError(DbErr::Migration(err.to_string()))
     }
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/error.rs
@@ -26,8 +26,8 @@ pub enum Error {
     ConfigError(String),
     #[error("credential generator error: `{0}`")]
     CredentialGeneratorError(String),
-    #[error("S3 inventory error: `{0}`")]
-    S3InventoryError(String),
+    #[error("S3 error: `{0}`")]
+    S3Error(String),
     #[error("{0}")]
     IoError(#[from] io::Error),
     #[error("numerical operation overflowed")]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
@@ -528,6 +528,7 @@ impl From<Record> for FlatS3EventMessage {
             // Anything in an inventory report is always a created event.
             event_type: Created,
             is_delete_marker: is_delete_marker.unwrap_or_default(),
+            move_id: None,
             number_duplicate_events: 0,
             number_reordered: 0,
         }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
@@ -528,7 +528,7 @@ impl From<Record> for FlatS3EventMessage {
             // Anything in an inventory report is always a created event.
             event_type: Created,
             is_delete_marker: is_delete_marker.unwrap_or_default(),
-            move_id: None,
+            ingest_id: None,
             attributes: None,
             number_duplicate_events: 0,
             number_reordered: 0,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
@@ -529,6 +529,7 @@ impl From<Record> for FlatS3EventMessage {
             event_type: Created,
             is_delete_marker: is_delete_marker.unwrap_or_default(),
             move_id: None,
+            attributes: None,
             number_duplicate_events: 0,
             number_reordered: 0,
         }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
@@ -26,7 +26,7 @@ use std::result;
 
 #[double]
 use crate::clients::aws::s3::Client;
-use crate::error::Error::S3InventoryError;
+use crate::error::Error::S3Error;
 use crate::error::{Error, Result};
 use crate::events::aws::message::{default_version_id, quote_e_tag, EventType::Created};
 use crate::events::aws::{FlatS3EventMessage, FlatS3EventMessages, StorageClass};
@@ -69,7 +69,7 @@ impl Inventory {
         let mut inventory_bytes = vec![];
         MultiGzDecoder::new(BufReader::new(body))
             .read_to_end(&mut inventory_bytes)
-            .map_err(|err| S3InventoryError(format!("decompressing CSV: {}", err)))?;
+            .map_err(|err| S3Error(format!("decompressing CSV: {}", err)))?;
 
         // AWS seems to return extra newlines at the end of the CSV, so we remove these
         let inventory_bytes = Self::trim_whitespace(inventory_bytes.as_slice());
@@ -132,9 +132,8 @@ impl Inventory {
         // https://github.com/Swoorup/arrow-convert
         // This is should be similar to arrow2_convert::TryIntoArrow in the above performance graph,
         // as it is a port of arrow2_convert with arrow-rs as the dependency.
-        from_slice::<Vec<Record>>(buf.as_slice()).map_err(|err| {
-            S3InventoryError(format!("failed to deserialize json from arrow: {}", err))
-        })
+        from_slice::<Vec<Record>>(buf.as_slice())
+            .map_err(|err| S3Error(format!("failed to deserialize json from arrow: {}", err)))
     }
 
     /// Parse a parquet manifest file into records.
@@ -162,11 +161,11 @@ impl Inventory {
             .client
             .get_object(key.as_ref(), bucket.as_ref())
             .await
-            .map_err(|err| S3InventoryError(err.to_string()))?
+            .map_err(|err| S3Error(err.to_string()))?
             .body
             .collect()
             .await
-            .map_err(|err| S3InventoryError(err.to_string()))?
+            .map_err(|err| S3Error(err.to_string()))?
             .to_vec())
     }
 
@@ -174,10 +173,10 @@ impl Inventory {
     fn verify_md5<T: AsRef<[u8]>>(data: T, verify_with: T) -> Result<()> {
         if md5::compute(data).0
             != hex::decode(&verify_with)
-                .map_err(|err| S3InventoryError(format!("decoding hex string: {}", err)))?
+                .map_err(|err| S3Error(format!("decoding hex string: {}", err)))?
                 .as_slice()
         {
-            return Err(S3InventoryError(
+            return Err(S3Error(
                 "mismatched MD5 checksums in inventory manifest".to_string(),
             ));
         }
@@ -232,9 +231,7 @@ impl Inventory {
             InventoryFormat::Csv => self.parse_csv(schema, body.as_slice()).await,
             InventoryFormat::Parquet => self.parse_parquet(body).await,
             InventoryFormat::Orc => self.parse_orc(body).await,
-            _ => Err(S3InventoryError(
-                "unsupported manifest file type".to_string(),
-            )),
+            _ => Err(S3Error("unsupported manifest file type".to_string())),
         }
     }
 
@@ -246,9 +243,7 @@ impl Inventory {
             // Proper arn, parse out the bucket.
             Ok(arn) => {
                 if arn.service != Service::S3.into() {
-                    return Err(S3InventoryError(
-                        "destination bucket ARN is not S3".to_string(),
-                    ));
+                    return Err(S3Error("destination bucket ARN is not S3".to_string()));
                 }
                 arn.resource.to_string()
             }
@@ -286,25 +281,25 @@ impl Inventory {
 
 impl From<csv::Error> for Error {
     fn from(error: csv::Error) -> Self {
-        S3InventoryError(error.to_string())
+        S3Error(error.to_string())
     }
 }
 
 impl From<ParquetError> for Error {
     fn from(error: ParquetError) -> Self {
-        S3InventoryError(error.to_string())
+        S3Error(error.to_string())
     }
 }
 
 impl From<ArrowError> for Error {
     fn from(error: ArrowError) -> Self {
-        S3InventoryError(error.to_string())
+        S3Error(error.to_string())
     }
 }
 
 impl From<OrcError> for Error {
     fn from(error: OrcError) -> Self {
-        S3InventoryError(error.to_string())
+        S3Error(error.to_string())
     }
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -3,25 +3,18 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::{PgHasArrayType, PgTypeInfo};
 
 use crate::events::aws::{FlatS3EventMessage, FlatS3EventMessages};
 use crate::uuid::UuidGenerator;
 
 /// The type of S3 event.
 #[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd, Clone, Hash, sqlx::Type)]
-#[sqlx(type_name = "event_type", no_pg_array)]
+#[sqlx(type_name = "event_type")]
 pub enum EventType {
     #[default]
     Created,
     Deleted,
     Other,
-}
-
-impl PgHasArrayType for EventType {
-    fn array_type_info() -> PgTypeInfo {
-        PgTypeInfo::with_name("_event_type")
-    }
 }
 
 /// Data for converting from S3 events to the internal filemanager event type.

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -191,7 +191,7 @@ impl From<Record> for FlatS3EventMessage {
             sha256: None,
             event_type,
             is_delete_marker,
-            move_id: None,
+            ingest_id: None,
             attributes: None,
             number_duplicate_events: 0,
             number_reordered: 0,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -199,6 +199,7 @@ impl From<Record> for FlatS3EventMessage {
             event_type,
             is_delete_marker,
             move_id: None,
+            attributes: None,
             number_duplicate_events: 0,
             number_reordered: 0,
         }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -198,6 +198,7 @@ impl From<Record> for FlatS3EventMessage {
             sha256: None,
             event_type,
             is_delete_marker,
+            move_id: None,
             number_duplicate_events: 0,
             number_reordered: 0,
         }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
@@ -487,6 +487,14 @@ impl FlatS3EventMessage {
         self
     }
 
+    /// Update the delete marker if not None.
+    pub fn update_delete_marker(mut self, delete_marker: Option<bool>) -> Self {
+        delete_marker
+            .into_iter()
+            .for_each(|is_delete_marker| self.is_delete_marker = is_delete_marker);
+        self
+    }
+
     /// Set the s3 object id.
     pub fn with_s3_object_id(mut self, s3_object_id: Uuid) -> Self {
         self.s3_object_id = s3_object_id;

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
@@ -5,7 +5,6 @@ use aws_sdk_s3::types::StorageClass as AwsStorageClass;
 use chrono::{DateTime, Utc};
 use itertools::{izip, Itertools};
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::{PgHasArrayType, PgTypeInfo};
 use sqlx::FromRow;
 use uuid::Uuid;
 
@@ -23,7 +22,7 @@ pub mod message;
 /// A wrapper around AWS storage types with sqlx support.
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Clone, sqlx::Type, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-#[sqlx(type_name = "storage_class", no_pg_array)]
+#[sqlx(type_name = "storage_class")]
 pub enum StorageClass {
     DeepArchive,
     Glacier,
@@ -35,12 +34,6 @@ pub enum StorageClass {
     Snow,
     Standard,
     StandardIa,
-}
-
-impl PgHasArrayType for StorageClass {
-    fn array_type_info() -> PgTypeInfo {
-        PgTypeInfo::with_name("_storage_class")
-    }
 }
 
 impl StorageClass {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
@@ -79,6 +79,7 @@ pub struct TransposedS3EventMessages {
     pub last_modified_dates: Vec<Option<DateTime<Utc>>>,
     pub event_types: Vec<EventType>,
     pub is_delete_markers: Vec<bool>,
+    pub move_ids: Vec<Option<Uuid>>,
 }
 
 impl TransposedS3EventMessages {
@@ -99,6 +100,7 @@ impl TransposedS3EventMessages {
             last_modified_dates: Vec::with_capacity(capacity),
             event_types: Vec::with_capacity(capacity),
             is_delete_markers: Vec::with_capacity(capacity),
+            move_ids: Vec::with_capacity(capacity),
         }
     }
 
@@ -118,6 +120,7 @@ impl TransposedS3EventMessages {
             last_modified_date,
             event_type,
             is_delete_marker,
+            move_id,
             ..
         } = message;
 
@@ -134,6 +137,7 @@ impl TransposedS3EventMessages {
         self.last_modified_dates.push(last_modified_date);
         self.event_types.push(event_type);
         self.is_delete_markers.push(is_delete_marker);
+        self.move_ids.push(move_id);
     }
 }
 
@@ -171,6 +175,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
             messages.last_modified_dates,
             messages.event_types,
             messages.is_delete_markers,
+            messages.move_ids
         )
         .map(
             |(
@@ -187,6 +192,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
                 last_modified_date,
                 event_type,
                 is_delete_marker,
+                move_id,
             )| {
                 FlatS3EventMessage {
                     s3_object_id,
@@ -202,6 +208,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
                     event_time,
                     event_type,
                     is_delete_marker,
+                    move_id,
                     number_duplicate_events: 0,
                     number_reordered: 0,
                 }
@@ -435,6 +442,7 @@ pub struct FlatS3EventMessage {
     pub event_time: Option<DateTime<Utc>>,
     pub event_type: EventType,
     pub is_delete_marker: bool,
+    pub move_id: Option<Uuid>,
     pub number_duplicate_events: i64,
     pub number_reordered: i64,
 }
@@ -492,6 +500,14 @@ impl FlatS3EventMessage {
         delete_marker
             .into_iter()
             .for_each(|is_delete_marker| self.is_delete_marker = is_delete_marker);
+        self
+    }
+
+    /// Update the delete marker if not None.
+    pub fn update_move_id(mut self, move_id: Option<Uuid>) -> Self {
+        move_id
+            .into_iter()
+            .for_each(|move_id| self.move_id = Some(move_id));
         self
     }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
@@ -73,7 +73,7 @@ pub struct TransposedS3EventMessages {
     pub last_modified_dates: Vec<Option<DateTime<Utc>>>,
     pub event_types: Vec<EventType>,
     pub is_delete_markers: Vec<bool>,
-    pub move_ids: Vec<Option<Uuid>>,
+    pub ingest_ids: Vec<Option<Uuid>>,
     pub attributes: Vec<Option<Json>>,
 }
 
@@ -95,7 +95,7 @@ impl TransposedS3EventMessages {
             last_modified_dates: Vec::with_capacity(capacity),
             event_types: Vec::with_capacity(capacity),
             is_delete_markers: Vec::with_capacity(capacity),
-            move_ids: Vec::with_capacity(capacity),
+            ingest_ids: Vec::with_capacity(capacity),
             attributes: Vec::with_capacity(capacity),
         }
     }
@@ -116,7 +116,7 @@ impl TransposedS3EventMessages {
             last_modified_date,
             event_type,
             is_delete_marker,
-            move_id,
+            ingest_id,
             attributes,
             ..
         } = message;
@@ -134,7 +134,7 @@ impl TransposedS3EventMessages {
         self.last_modified_dates.push(last_modified_date);
         self.event_types.push(event_type);
         self.is_delete_markers.push(is_delete_marker);
-        self.move_ids.push(move_id);
+        self.ingest_ids.push(ingest_id);
         self.attributes.push(attributes);
     }
 }
@@ -173,7 +173,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
             messages.last_modified_dates,
             messages.event_types,
             messages.is_delete_markers,
-            messages.move_ids,
+            messages.ingest_ids,
             messages.attributes,
         )
         .map(
@@ -191,7 +191,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
                 last_modified_date,
                 event_type,
                 is_delete_marker,
-                move_id,
+                ingest_id,
                 attributes,
             )| {
                 FlatS3EventMessage {
@@ -208,7 +208,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
                     event_time,
                     event_type,
                     is_delete_marker,
-                    move_id,
+                    ingest_id,
                     attributes,
                     number_duplicate_events: 0,
                     number_reordered: 0,
@@ -442,7 +442,7 @@ pub struct FlatS3EventMessage {
     pub event_time: Option<DateTime<Utc>>,
     pub event_type: EventType,
     pub is_delete_marker: bool,
-    pub move_id: Option<Uuid>,
+    pub ingest_id: Option<Uuid>,
     pub attributes: Option<Json>,
     pub number_duplicate_events: i64,
     pub number_reordered: i64,
@@ -577,8 +577,8 @@ impl FlatS3EventMessage {
     }
 
     /// Set the move id.
-    pub fn with_move_id(mut self, move_id: Option<Uuid>) -> Self {
-        self.move_id = move_id;
+    pub fn with_ingest_id(mut self, ingest_id: Option<Uuid>) -> Self {
+        self.ingest_id = ingest_id;
         self
     }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/mod.rs
@@ -16,7 +16,7 @@ pub trait Collect {
 }
 
 /// The event source with a type and the number of (potentially duplicate) records contained.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EventSource {
     event_type: EventSourceType,
     n_records: usize,
@@ -39,7 +39,7 @@ impl EventSource {
 
 /// The type of event.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum EventSourceType {
     S3(TransposedS3EventMessages),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
@@ -39,7 +39,7 @@ pub async fn receive_and_ingest<'a>(
         .with_s3_client(s3_client)
         .with_sqs_client(sqs_client)
         .set_sqs_url(sqs_url)
-        .build_receive(env_config)
+        .build_receive(env_config, database_client)
         .await?
         .collect()
         .await?
@@ -74,7 +74,7 @@ pub async fn ingest_event(
 
     let events = CollecterBuilder::default()
         .with_s3_client(s3_client)
-        .build(events, env_config)
+        .build(events, env_config, &database_client)
         .await
         .collect()
         .await?

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
@@ -211,6 +211,7 @@ pub(crate) mod tests {
     use sqlx::postgres::PgRow;
     use sqlx::PgPool;
 
+    use super::*;
     use crate::database::aws::ingester::tests::{
         assert_row, expected_message, fetch_results, remove_version_ids, replace_sequencers,
         test_events, test_ingester,
@@ -233,8 +234,6 @@ pub(crate) mod tests {
     };
     use crate::events::aws::FlatS3EventMessage;
     use crate::events::EventSourceType::S3;
-
-    use super::*;
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_receive_and_ingest(pool: PgPool) {
@@ -528,7 +527,7 @@ pub(crate) mod tests {
         assert_row(row, message, Some("".to_string()), None);
     }
 
-    async fn s3_object_results(pool: &PgPool) -> Vec<PgRow> {
+    pub(crate) async fn s3_object_results(pool: &PgPool) -> Vec<PgRow> {
         sqlx::query("select * from s3_object order by sequencer, key")
             .fetch_all(pool)
             .await

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
@@ -217,7 +217,7 @@ pub(crate) mod tests {
     };
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::events::aws::collecter::tests::{
-        expected_head_object, set_s3_client_expectations, set_sqs_client_expectations,
+        set_s3_client_expectations, set_sqs_client_expectations,
     };
     use crate::events::aws::inventory::tests::{
         csv_manifest_from_key_expectations, EXPECTED_LAST_MODIFIED_ONE,
@@ -252,7 +252,7 @@ pub(crate) mod tests {
     async fn test_ingest_event(pool: PgPool) {
         let mut s3_client = S3Client::default();
 
-        set_s3_client_expectations(&mut s3_client, vec![|| Ok(expected_head_object())]);
+        set_s3_client_expectations(&mut s3_client);
 
         let event = SqsEvent {
             records: vec![SqsMessage {
@@ -376,7 +376,7 @@ pub(crate) mod tests {
         let mut s3_client = S3Client::default();
 
         set_sqs_client_expectations(&mut sqs_client);
-        set_s3_client_expectations(&mut s3_client, vec![|| Ok(expected_head_object())]);
+        set_s3_client_expectations(&mut s3_client);
 
         f(sqs_client, s3_client).await;
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -150,7 +150,7 @@ where
                     .is_delete_marker
                     .map(|v| s3_object::Column::IsDeleteMarker.eq(v)),
             )
-            .add_option(filter.move_id.map(|v| s3_object::Column::MoveId.eq(v)));
+            .add_option(filter.ingest_id.map(|v| s3_object::Column::IngestId.eq(v)));
 
         if let Some(attributes) = filter.attributes {
             let json_conditions = Self::json_conditions(

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -149,7 +149,8 @@ where
                 filter
                     .is_delete_marker
                     .map(|v| s3_object::Column::IsDeleteMarker.eq(v)),
-            );
+            )
+            .add_option(filter.move_id.map(|v| s3_object::Column::MoveId.eq(v)));
 
         if let Some(attributes) = filter.attributes {
             let json_conditions = Self::json_conditions(

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
@@ -3,6 +3,11 @@
 
 use std::ops::Add;
 
+use crate::database::entities::s3_object::ActiveModel as ActiveS3Object;
+use crate::database::entities::s3_object::Model as S3Object;
+use crate::database::entities::sea_orm_active_enums::{EventType, StorageClass};
+use crate::database::Client;
+use crate::uuid::UuidGenerator;
 use chrono::{DateTime, Days};
 use rand::seq::SliceRandom;
 use rand::thread_rng;
@@ -10,12 +15,7 @@ use sea_orm::Set;
 use sea_orm::{ActiveModelTrait, TryIntoModel};
 use serde_json::json;
 use strum::EnumCount;
-
-use crate::database::entities::s3_object::ActiveModel as ActiveS3Object;
-use crate::database::entities::s3_object::Model as S3Object;
-use crate::database::entities::sea_orm_active_enums::{EventType, StorageClass};
-use crate::database::Client;
-use crate::uuid::UuidGenerator;
+use uuid::Uuid;
 
 pub mod get;
 pub mod list;
@@ -41,11 +41,12 @@ impl Entries {
         shuffle: bool,
         bucket_divisor: usize,
         key_divisor: usize,
+        move_id: Option<Uuid>,
     ) -> Vec<S3Object> {
         let mut output = vec![];
 
         let mut entries: Vec<_> = (0..n)
-            .map(|index| Self::generate_entry(index, bucket_divisor, key_divisor))
+            .map(|index| Self::generate_entry(index, bucket_divisor, key_divisor, move_id))
             .collect();
 
         if shuffle {
@@ -70,6 +71,7 @@ impl Entries {
         index: usize,
         bucket_divisor: usize,
         key_divisor: usize,
+        move_id: Option<Uuid>,
     ) -> ActiveS3Object {
         let event = Self::event_type(index);
         let date = || Set(Some(DateTime::default().add(Days::new(index as u64))));
@@ -82,7 +84,7 @@ impl Entries {
 
         ActiveS3Object {
             s3_object_id: Set(UuidGenerator::generate()),
-            move_id: Set(Some(UuidGenerator::generate())),
+            move_id: Set(Some(move_id.unwrap_or_else(UuidGenerator::generate))),
             event_type: Set(event.clone()),
             bucket: Set((index / bucket_divisor).to_string()),
             key: Set((index / key_divisor).to_string()),
@@ -127,6 +129,7 @@ pub struct EntriesBuilder {
     bucket_divisor: usize,
     key_divisor: usize,
     shuffle: bool,
+    move_id: Option<Uuid>,
 }
 
 impl EntriesBuilder {
@@ -154,6 +157,12 @@ impl EntriesBuilder {
         self
     }
 
+    /// Set whether to shuffle.
+    pub fn with_move_id(mut self, move_id: Uuid) -> Self {
+        self.move_id = Some(move_id);
+        self
+    }
+
     /// Build the entries and initialize the database.
     pub async fn build(self, client: &Client) -> Entries {
         let mut entries = Entries::initialize_database(
@@ -162,6 +171,7 @@ impl EntriesBuilder {
             self.shuffle,
             self.bucket_divisor,
             self.key_divisor,
+            self.move_id,
         )
         .await;
 
@@ -179,6 +189,7 @@ impl Default for EntriesBuilder {
             bucket_divisor: 2,
             key_divisor: 1,
             shuffle: false,
+            move_id: None,
         }
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
@@ -41,12 +41,12 @@ impl Entries {
         shuffle: bool,
         bucket_divisor: usize,
         key_divisor: usize,
-        move_id: Option<Uuid>,
+        ingest_id: Option<Uuid>,
     ) -> Vec<S3Object> {
         let mut output = vec![];
 
         let mut entries: Vec<_> = (0..n)
-            .map(|index| Self::generate_entry(index, bucket_divisor, key_divisor, move_id))
+            .map(|index| Self::generate_entry(index, bucket_divisor, key_divisor, ingest_id))
             .collect();
 
         if shuffle {
@@ -71,7 +71,7 @@ impl Entries {
         index: usize,
         bucket_divisor: usize,
         key_divisor: usize,
-        move_id: Option<Uuid>,
+        ingest_id: Option<Uuid>,
     ) -> ActiveS3Object {
         let event = Self::event_type(index);
         let date = || Set(Some(DateTime::default().add(Days::new(index as u64))));
@@ -84,7 +84,7 @@ impl Entries {
 
         ActiveS3Object {
             s3_object_id: Set(UuidGenerator::generate()),
-            move_id: Set(Some(move_id.unwrap_or_else(UuidGenerator::generate))),
+            ingest_id: Set(Some(ingest_id.unwrap_or_else(UuidGenerator::generate))),
             event_type: Set(event.clone()),
             bucket: Set((index / bucket_divisor).to_string()),
             key: Set((index / key_divisor).to_string()),
@@ -129,7 +129,7 @@ pub struct EntriesBuilder {
     bucket_divisor: usize,
     key_divisor: usize,
     shuffle: bool,
-    move_id: Option<Uuid>,
+    ingest_id: Option<Uuid>,
 }
 
 impl EntriesBuilder {
@@ -158,8 +158,8 @@ impl EntriesBuilder {
     }
 
     /// Set whether to shuffle.
-    pub fn with_move_id(mut self, move_id: Uuid) -> Self {
-        self.move_id = Some(move_id);
+    pub fn with_ingest_id(mut self, ingest_id: Uuid) -> Self {
+        self.ingest_id = Some(ingest_id);
         self
     }
 
@@ -171,7 +171,7 @@ impl EntriesBuilder {
             self.shuffle,
             self.bucket_divisor,
             self.key_divisor,
-            self.move_id,
+            self.ingest_id,
         )
         .await;
 
@@ -189,7 +189,7 @@ impl Default for EntriesBuilder {
             bucket_divisor: 2,
             key_divisor: 1,
             shuffle: false,
-            move_id: None,
+            ingest_id: None,
         }
     }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
@@ -82,6 +82,7 @@ impl Entries {
 
         ActiveS3Object {
             s3_object_id: Set(UuidGenerator::generate()),
+            move_id: Set(Some(UuidGenerator::generate())),
             event_type: Set(event.clone()),
             bucket: Set((index / bucket_divisor).to_string()),
             key: Set((index / key_divisor).to_string()),

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
@@ -68,8 +68,8 @@ pub struct S3ObjectsFilter {
     /// Query by the object delete marker.
     pub(crate) is_delete_marker: Option<bool>,
     #[param(required = false)]
-    /// Query by the object delete marker.
-    pub(crate) move_id: Option<Uuid>,
+    /// Query by the ingest id that objects get tagged with.
+    pub(crate) ingest_id: Option<Uuid>,
     #[param(required = false)]
     /// Query by JSON attributes. Supports nested syntax to access inner
     /// fields, e.g. `attributes[attribute_id]=...`. This only deserializes

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
@@ -1,13 +1,13 @@
 //! Routing logic for query filtering.
 //!
 
+use crate::database::entities::sea_orm_active_enums::{EventType, StorageClass};
+use crate::routes::filter::wildcard::{Wildcard, WildcardEither};
 use sea_orm::prelude::{DateTimeWithTimeZone, Json};
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
 use utoipa::IntoParams;
-
-use crate::database::entities::sea_orm_active_enums::{EventType, StorageClass};
-use crate::routes::filter::wildcard::{Wildcard, WildcardEither};
+use uuid::Uuid;
 
 pub mod wildcard;
 
@@ -67,6 +67,9 @@ pub struct S3ObjectsFilter {
     #[param(required = false)]
     /// Query by the object delete marker.
     pub(crate) is_delete_marker: Option<bool>,
+    #[param(required = false)]
+    /// Query by the object delete marker.
+    pub(crate) move_id: Option<Uuid>,
     #[param(required = false)]
     /// Query by JSON attributes. Supports nested syntax to access inner
     /// fields, e.g. `attributes[attribute_id]=...`. This only deserializes


### PR DESCRIPTION
Closes #584

### Mechanism
* Introduces a mechanism by which the filemanager can track how an object moves by using S3 tags.
    * For each object, a tag is added to S3 to track the `ingest_id`.
    * The ingest id gets copied to the database as well.
    * When an object is moved with tags, the `ingest_id` is reused, which allows creating the sequence of records representing the moved object.
    * Attributes are also copied as the object moves.

### Implementation
* Added `GetObjectTagging` and `PutObjectTagging` capabilities to filemanager.
* Added `ingest_id` column to database which matches the `ingest_id` on the S3 object tags.
* Test cases for move logic.