### PR TITLE
fix(filemanager): version_id for S3 API calls

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
@@ -25,6 +25,6 @@ export class ApiFunction extends fn.Function {
       ...props,
     });
 
-    this.addPoliciesForBuckets(props.buckets);
+    this.addPoliciesForBuckets(props.buckets, fn.Function.getObjectActions());
   }
 }

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
@@ -165,15 +165,34 @@ export class Function extends Construct {
   /**
    * Add policies for 's3:List*' and 's3:Get*' on the buckets to this function's role.
    */
-  addPoliciesForBuckets(buckets: string[], additionalActions?: string[]) {
+  addPoliciesForBuckets(buckets: string[], actions: string[]) {
     buckets.map((bucket) => {
       this.addToPolicy(
         new PolicyStatement({
-          actions: [...['s3:ListBucket', 's3:GetObject'], ...(additionalActions ?? [])],
+          actions,
           resources: [`arn:aws:s3:::${bucket}`, `arn:aws:s3:::${bucket}/*`],
         })
       );
     });
+  }
+
+  /**
+   * Get policy actions for fetching objects.
+   */
+  static getObjectActions(): string[] {
+    return ['s3:ListBucket', 's3:GetObject', 's3:GetObjectVersion'];
+  }
+
+  /**
+   * Get policy actions for using object tags.
+   */
+  static objectTaggingActions(): string[] {
+    return [
+      's3:GetObjectTagging',
+      's3:GetObjectVersionTagging',
+      's3:PutObjectTagging',
+      's3:PutObjectVersionTagging',
+    ];
   }
 
   /**

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/ingest.ts
@@ -52,10 +52,8 @@ export class IngestFunction extends fn.Function {
       this.function.addEventSource(eventSource);
     });
     this.addPoliciesForBuckets(props.buckets, [
-      's3:GetObjectTagging',
-      's3:GetObjectVersionTagging',
-      's3:PutObjectTagging',
-      's3:PutObjectVersionTagging',
+      ...fn.Function.getObjectActions(),
+      ...fn.Function.objectTaggingActions(),
     ]);
   }
 }

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/inventory.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/inventory.ts
@@ -34,6 +34,9 @@ export class InventoryFunction extends fn.Function {
       functionName: INVENTORY_FUNCTION_NAME,
     });
 
-    this.addPoliciesForBuckets(props.buckets);
+    this.addPoliciesForBuckets(props.buckets, [
+      ...fn.Function.getObjectActions(),
+      ...fn.Function.objectTaggingActions(),
+    ]);
   }
 }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
@@ -159,7 +159,7 @@ impl Inventory {
     async fn get_object_bytes<K: AsRef<str>>(&self, key: K, bucket: K) -> Result<Vec<u8>> {
         Ok(self
             .client
-            .get_object(key.as_ref(), bucket.as_ref())
+            .get_object(key.as_ref(), bucket.as_ref(), default_version_id().as_ref())
             .await
             .map_err(|err| S3Error(err.to_string()))?
             .body
@@ -668,9 +668,13 @@ pub(crate) mod tests {
 
         client
             .expect_get_object()
-            .with(eq("manifest.checksum"), eq(MANIFEST_BUCKET))
+            .with(
+                eq("manifest.checksum"),
+                eq(MANIFEST_BUCKET),
+                eq(default_version_id()),
+            )
             .once()
-            .returning(move |_, _| {
+            .returning(move |_, _, _| {
                 Ok(GetObjectOutput::builder()
                     .body(ByteStream::from(checksum.clone()))
                     .build())
@@ -863,9 +867,13 @@ pub(crate) mod tests {
     fn set_client_manifest_expectations(s3_client: &mut Client, data: Vec<u8>) {
         s3_client
             .expect_get_object()
-            .with(eq("manifest.json"), eq(MANIFEST_BUCKET))
+            .with(
+                eq("manifest.json"),
+                eq(MANIFEST_BUCKET),
+                eq(default_version_id()),
+            )
             .once()
-            .returning(move |_, _| {
+            .returning(move |_, _, _| {
                 Ok(GetObjectOutput::builder()
                     .body(ByteStream::from(data.clone()))
                     .build())
@@ -924,9 +932,10 @@ pub(crate) mod tests {
             .with(
                 eq(format!("{}{}", MANIFEST_KEY, ending)),
                 eq(MANIFEST_BUCKET),
+                eq(default_version_id()),
             )
             .once()
-            .returning(move |_, _| {
+            .returning(move |_, _, _| {
                 Ok(GetObjectOutput::builder()
                     .body(ByteStream::from(data.clone()))
                     .build())

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/presign.rs
@@ -7,6 +7,7 @@ use url::Url;
 use utoipa::{IntoParams, ToSchema};
 
 use crate::clients::aws::s3;
+use crate::clients::aws::s3::ResponseHeaders;
 use crate::database::entities::s3_object;
 use crate::env::Config;
 use crate::error::Error::PresignedUrlError;
@@ -86,6 +87,7 @@ impl<'a> PresignedUrlBuilder<'a> {
         &self,
         key: &str,
         bucket: &str,
+        version_id: &str,
         response_content_disposition: ContentDisposition,
         response_content_type: Option<String>,
         response_content_encoding: Option<String>,
@@ -111,9 +113,12 @@ impl<'a> PresignedUrlBuilder<'a> {
                 .presign_url(
                     key,
                     bucket,
-                    content_disposition,
-                    response_content_type,
-                    response_content_encoding,
+                    version_id,
+                    ResponseHeaders::new(
+                        content_disposition.to_string(),
+                        response_content_type,
+                        response_content_encoding,
+                    ),
                     self.config
                         .api_presign_expiry()
                         .unwrap_or(DEFAULT_PRESIGN_EXPIRY),
@@ -141,6 +146,7 @@ impl<'a> PresignedUrlBuilder<'a> {
             .presign_url(
                 &model.key,
                 &model.bucket,
+                &model.version_id,
                 response_content_disposition,
                 response_content_type,
                 response_content_encoding,
@@ -160,6 +166,7 @@ pub(crate) mod tests {
 
     use crate::clients::aws::s3;
     use crate::env::Config;
+    use crate::events::aws::message::default_version_id;
     use crate::routes::list::tests::mock_get_object;
 
     use super::*;
@@ -175,7 +182,14 @@ pub(crate) mod tests {
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(None);
         let url = builder
-            .presign_url("0", "1", ContentDisposition::Inline, None, None)
+            .presign_url(
+                "0",
+                "1",
+                &default_version_id(),
+                ContentDisposition::Inline,
+                None,
+                None,
+            )
             .await
             .unwrap()
             .unwrap();
@@ -187,7 +201,14 @@ pub(crate) mod tests {
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
         let url = builder
-            .presign_url("0", "1", ContentDisposition::Inline, None, None)
+            .presign_url(
+                "0",
+                "1",
+                &default_version_id(),
+                ContentDisposition::Inline,
+                None,
+                None,
+            )
             .await
             .unwrap()
             .unwrap();
@@ -212,6 +233,7 @@ pub(crate) mod tests {
             .presign_url(
                 "0",
                 "1",
+                &default_version_id(),
                 ContentDisposition::Inline,
                 Some("application/json".to_string()),
                 Some("gzip".to_string()),
@@ -236,7 +258,14 @@ pub(crate) mod tests {
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(None);
         let url = builder
-            .presign_url("0", "1", ContentDisposition::Attachment, None, None)
+            .presign_url(
+                "0",
+                "1",
+                &default_version_id(),
+                ContentDisposition::Attachment,
+                None,
+                None,
+            )
             .await
             .unwrap()
             .unwrap();
@@ -261,7 +290,14 @@ pub(crate) mod tests {
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
         let url = builder
-            .presign_url("0", "1", ContentDisposition::Inline, None, None)
+            .presign_url(
+                "0",
+                "1",
+                &default_version_id(),
+                ContentDisposition::Inline,
+                None,
+                None,
+            )
             .await
             .unwrap();
 
@@ -282,7 +318,14 @@ pub(crate) mod tests {
 
         let builder = PresignedUrlBuilder::new(&client, &config).set_object_size(Some(2));
         let url = builder
-            .presign_url("0", "1", ContentDisposition::Inline, None, None)
+            .presign_url(
+                "0",
+                "1",
+                &default_version_id(),
+                ContentDisposition::Inline,
+                None,
+                None,
+            )
             .await
             .unwrap()
             .unwrap();


### PR DESCRIPTION
Closes #586

Depends on #585

### Changes
* Use version_ids for `HeadObject`, `GetObjectTagging`, `PutObjectTagging` and presigned `GetObject` requests.
    * If versioning is not enabled, then the default `"null"` string version is used, which lines up with how AWS treats buckets without versioning enabled.