### PR TITLE
feat(filemanager): accept multiple keys in API

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -149,9 +149,8 @@ or `bucket2`:
 curl -H "Authorization: Bearer $TOKEN" "https://file.dev.umccr.org/api/v1/s3?bucket[]=bucket1&bucket[]=bucket2" | jq
 ```
 
-Note that the extra `[]` is required in the query parameters to specify multiple keys with the same name. Multiple keys
-are also supported on attributes. For example, the following finds records where the `portalRunId` is either `20240521aecb782`
-or `20240521aecb783`:
+Multiple keys are also supported on attributes. For example, the following finds records where the `portalRunId` is
+either `20240521aecb782` or `20240521aecb783`:
  
 ```sh
 curl --get -H "Authorization: Bearer $TOKEN" \
@@ -159,6 +158,10 @@ curl --get -H "Authorization: Bearer $TOKEN" \
 --data-urlencode "attributes[portalRunId][]=20240521aecb783" \
 "https://file.dev.umccr.org/api/v1/s3" | jq
 ```
+
+Note that the extra `[]` is required in the query parameters to specify multiple keys with the same name. Specifying
+multiple of the same key without `[]` results in an error. It is also an error to specify some keys with `[]` and some
+without for keys with the same name.
 
 ## Updating records
 

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -139,6 +139,27 @@ curl --get -H "Authorization: Bearer $TOKEN" --data-urlencode "attributes[portal
 "https://file.dev.umccr.org/api/v1/s3" | jq
 ```
 
+## Multiple keys
+
+The API supports querying using multiple keys with the same name. This represents an `or` condition in the SQL query, where
+records are fetched if any of the keys match. For example, the following finds records where the bucket is either `bucket1`
+or `bucket2`:
+
+```sh
+curl -H "Authorization: Bearer $TOKEN" "https://file.dev.umccr.org/api/v1/s3?bucket[]=bucket1&bucket[]=bucket2" | jq
+```
+
+Note that the extra `[]` is required in the query parameters to specify multiple keys with the same name. Multiple keys
+are also supported on attributes. For example, the following finds records where the `portalRunId` is either `20240521aecb782`
+or `20240521aecb783`:
+ 
+```sh
+curl --get -H "Authorization: Bearer $TOKEN" \
+--data-urlencode "attributes[portalRunId][]=20240521aecb782" \
+--data-urlencode "attributes[portalRunId][]=20240521aecb783" \
+"https://file.dev.umccr.org/api/v1/s3" | jq
+```
+
 ## Updating records
 
 As part of allowing filemanager to link and query on attributes, attributes can be updated using PATCH requests.
@@ -202,7 +223,7 @@ curl -H "Authorization: Bearer $TOKEN" "https://file.dev.umccr.org/api/v1/s3/pre
 There are some missing features in the query API which are planned, namely:
 
 * There is no way to compare values with `>`, `>=`, `<`, `<=`.
-* There is no way to express `and` or `or` conditions in the API.
+* There is no way to express `and` or `or` conditions in the API (except for multiple keys representing `or` conditions).
 
 There are also some feature missing for attribute linking. For example, there is no way
 to capture matching wildcard groups which can later be used in the JSON patch body.

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/collecter.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/collecter.rs
@@ -303,7 +303,7 @@ impl<'a> Collecter<'a> {
 
         // Get the attributes from the old record to update the new record with.
         let filter = S3ObjectsFilter {
-            ingest_id: Some(ingest_id),
+            ingest_id: vec![ingest_id],
             ..Default::default()
         };
         let moved_object = ListQueryBuilder::new(database_client.connection_ref())

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/update.rs
@@ -491,9 +491,9 @@ pub(crate) mod tests {
             .current_state()
             .filter_all(
                 S3ObjectsFilter {
-                    event_time: Some(WildcardEither::Wildcard(Wildcard::new(
+                    event_time: vec![WildcardEither::Wildcard(Wildcard::new(
                         "1970-01-0*".to_string(),
-                    ))),
+                    ))],
                     ..Default::default()
                 },
                 true,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
@@ -113,7 +113,7 @@ mod tests {
     fn deserialize_empty_params() {
         let params: S3ObjectsFilter = serde_qs::from_str("").unwrap();
 
-        assert_eq!(params, Default::default(),);
+        assert_eq!(params, Default::default());
     }
 
     #[test]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/filter/mod.rs
@@ -6,6 +6,8 @@ use crate::routes::filter::wildcard::{Wildcard, WildcardEither};
 use sea_orm::prelude::{DateTimeWithTimeZone, Json};
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
+use serde_with::serde_as;
+use serde_with::{DisplayFromStr, OneOrMany};
 use utoipa::IntoParams;
 use uuid::Uuid;
 
@@ -30,60 +32,184 @@ impl From<AttributesOnlyFilter> for S3ObjectsFilter {
 /// The available fields to filter `s3_object` queries by. Each query parameter represents
 /// an `and` clause in the SQL statement. Nested query string style syntax is supported on
 /// JSON attributes. Wildcards are supported on some of the fields.
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Default, IntoParams, Clone, PartialEq, Eq)]
 #[serde(default, rename_all = "camelCase")]
 #[into_params(parameter_in = Query)]
 pub struct S3ObjectsFilter {
-    #[param(required = false)]
     /// Query by event type.
+    #[param(required = false)]
     pub(crate) event_type: Option<EventType>,
-    #[param(required = false)]
     /// Query by bucket. Supports wildcards.
-    pub(crate) bucket: Option<Wildcard>,
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
     #[param(required = false)]
+    pub(crate) bucket: Vec<Wildcard>,
     /// Query by key. Supports wildcards.
-    pub(crate) key: Option<Wildcard>,
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
     #[param(required = false)]
+    pub(crate) key: Vec<Wildcard>,
     /// Query by version_id. Supports wildcards.
-    pub(crate) version_id: Option<Wildcard>,
-    #[param(required = false, value_type = Wildcard)]
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
+    #[param(required = false)]
+    pub(crate) version_id: Vec<Wildcard>,
     /// Query by event_time. Supports wildcards.
-    pub(crate) event_time: Option<WildcardEither<DateTimeWithTimeZone>>,
-    #[param(required = false)]
-    /// Query by size.
-    pub(crate) size: Option<i64>,
-    #[param(required = false)]
-    /// Query by the sha256 checksum.
-    pub(crate) sha256: Option<String>,
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
     #[param(required = false, value_type = Wildcard)]
+    pub(crate) event_time: Vec<WildcardEither<DateTimeWithTimeZone>>,
+    /// Query by size.
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<DisplayFromStr>")]
+    #[param(required = false)]
+    pub(crate) size: Vec<i64>,
+    /// Query by the sha256 checksum.
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
+    #[param(required = false)]
+    pub(crate) sha256: Vec<String>,
     /// Query by the last modified date. Supports wildcards.
-    pub(crate) last_modified_date: Option<WildcardEither<DateTimeWithTimeZone>>,
-    #[param(required = false)]
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
+    #[param(required = false, value_type = Wildcard)]
+    pub(crate) last_modified_date: Vec<WildcardEither<DateTimeWithTimeZone>>,
     /// Query by the e_tag.
-    pub(crate) e_tag: Option<String>,
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
     #[param(required = false)]
-    /// Query by the storage class. Supports wildcards.
-    pub(crate) storage_class: Option<StorageClass>,
+    pub(crate) e_tag: Vec<String>,
+    /// Query by the storage class.
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
     #[param(required = false)]
+    pub(crate) storage_class: Vec<StorageClass>,
     /// Query by the object delete marker.
+    #[param(required = false)]
     pub(crate) is_delete_marker: Option<bool>,
-    #[param(required = false)]
     /// Query by the ingest id that objects get tagged with.
-    pub(crate) ingest_id: Option<Uuid>,
+    /// Repeated parameters are joined with an `or` condition.
+    #[serde_as(as = "OneOrMany<_>")]
     #[param(required = false)]
+    pub(crate) ingest_id: Vec<Uuid>,
     /// Query by JSON attributes. Supports nested syntax to access inner
     /// fields, e.g. `attributes[attribute_id]=...`. This only deserializes
     /// into string fields, and does not support other JSON types. E.g.
     /// `attributes[attribute_id]=1` converts to `{ "attribute_id" = "1" }`
     /// rather than `{ "attribute_id" = 1 }`. Supports wildcards.
+    #[param(required = false)]
     pub(crate) attributes: Option<Json>,
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::routes::filter::wildcard::Wildcard;
     use serde_json::json;
 
     use super::*;
+
+    #[test]
+    fn deserialize_empty_params() {
+        let params: S3ObjectsFilter = serde_qs::from_str("").unwrap();
+
+        assert_eq!(params, Default::default(),);
+    }
+
+    #[test]
+    fn deserialize_single_params() {
+        let qs = "\
+        eventType=Deleted&\
+        key=key1&\
+        bucket=bucket1&\
+        versionId=version_id1&\
+        eventTime=1970-01-02T00:00:00Z&\
+        size=4&\
+        sha256=sha256&\
+        lastModifiedDate=1970-01-02T00:00:00Z&\
+        eTag=eTag&\
+        storageClass=DeepArchive&\
+        isDeleteMarker=true&\
+        ingestId=00000000-0000-0000-0000-000000000000&\
+        attributes[attributeId]=id\
+        ";
+        let params: S3ObjectsFilter = serde_qs::from_str(qs).unwrap();
+
+        assert_eq!(
+            params,
+            S3ObjectsFilter {
+                event_type: Some(EventType::Deleted),
+                key: vec![Wildcard::new("key1".to_string())],
+                bucket: vec![Wildcard::new("bucket1".to_string())],
+                version_id: vec![Wildcard::new("version_id1".to_string())],
+                event_time: vec![WildcardEither::Or("1970-01-02T00:00:00Z".parse().unwrap())],
+                size: vec![4],
+                sha256: vec!["sha256".to_string()],
+                last_modified_date: vec![WildcardEither::Or(
+                    "1970-01-02T00:00:00Z".parse().unwrap()
+                )],
+                e_tag: vec!["eTag".to_string()],
+                storage_class: vec![StorageClass::DeepArchive],
+                is_delete_marker: Some(true),
+                ingest_id: vec![Uuid::nil()],
+                attributes: Some(json!({"attributeId": "id"}))
+            }
+        );
+    }
+
+    #[test]
+    fn deserialize_many_params() {
+        let qs = "\
+        eventType=Created&\
+        key[]=key1&key[]=key2&\
+        bucket[]=bucket1&bucket[]=bucket2&\
+        versionId[]=version_id1&versionId[]=version_id2&\
+        eventTime[]=1970-01-02T00:00:00Z&eventTime[]=1970-01-02T00:00:01Z&\
+        size[]=4&size[]=5&\
+        sha256[]=sha256&sha256[]=sha1&\
+        lastModifiedDate[]=1970-01-02T00:00:00Z&lastModifiedDate[]=1970-01-02T00:00:01Z&\
+        eTag[]=eTag1&eTag[]=eTag2&\
+        storageClass[]=DeepArchive&storageClass[]=Glacier&\
+        isDeleteMarker=true&\
+        ingestId[]=00000000-0000-0000-0000-000000000000&ingestId[]=FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF&\
+        attributes[attributeId]=id1\
+        ";
+        let params: S3ObjectsFilter = serde_qs::from_str(qs).unwrap();
+
+        assert_eq!(
+            params,
+            S3ObjectsFilter {
+                event_type: Some(EventType::Created),
+                key: vec![
+                    Wildcard::new("key1".to_string()),
+                    Wildcard::new("key2".to_string())
+                ],
+                bucket: vec![
+                    Wildcard::new("bucket1".to_string()),
+                    Wildcard::new("bucket2".to_string())
+                ],
+                version_id: vec![
+                    Wildcard::new("version_id1".to_string()),
+                    Wildcard::new("version_id2".to_string())
+                ],
+                event_time: vec![
+                    WildcardEither::Or("1970-01-02T00:00:00Z".parse().unwrap()),
+                    WildcardEither::Or("1970-01-02T00:00:01Z".parse().unwrap())
+                ],
+                size: vec![4, 5],
+                sha256: vec!["sha256".to_string(), "sha1".to_string()],
+                last_modified_date: vec![
+                    WildcardEither::Or("1970-01-02T00:00:00Z".parse().unwrap()),
+                    WildcardEither::Or("1970-01-02T00:00:01Z".parse().unwrap())
+                ],
+                e_tag: vec!["eTag1".to_string(), "eTag2".to_string()],
+                storage_class: vec![StorageClass::DeepArchive, StorageClass::Glacier],
+                is_delete_marker: Some(true),
+                ingest_id: vec![Uuid::nil(), Uuid::max()],
+                attributes: Some(json!({"attributeId": "id1"}))
+            }
+        );
+    }
 
     #[test]
     fn deserialize_attribute_only_filter() {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
@@ -90,9 +90,9 @@ pub async fn presign_s3_by_id(
     let current = ListQueryBuilder::<_, s3_object::Entity>::new(&txn)
         .filter_all(
             S3ObjectsFilter {
-                bucket: Some(Wildcard::new(response.bucket.to_string())),
-                key: Some(Wildcard::new(response.key.to_string())),
-                version_id: Some(Wildcard::new(response.version_id.to_string())),
+                bucket: vec![Wildcard::new(response.bucket.to_string())],
+                key: vec![Wildcard::new(response.key.to_string())],
+                version_id: vec![Wildcard::new(response.version_id.to_string())],
                 ..Default::default()
             },
             true,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -870,6 +870,8 @@ pub(crate) mod tests {
             .unwrap()
             .to_vec();
 
+        println!("{}", String::from_utf8(bytes.clone()).unwrap());
+
         (status, from_slice::<T>(bytes.as_slice()).unwrap())
     }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/list.rs
@@ -580,7 +580,7 @@ pub(crate) mod tests {
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
-    async fn list_s3_multiple_filters(pool: PgPool) {
+    async fn list_s3_multiple_and_filters(pool: PgPool) {
         let state = AppState::from_pool(pool).await;
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
@@ -591,6 +591,23 @@ pub(crate) mod tests {
         let result: ListResponse<S3> = response_from_get(state, "/s3?bucket=1&key=2").await;
         assert_eq!(result.results(), vec![entries[2].clone()]);
         assert_eq!(result.pagination().count, 1);
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn list_s3_multiple_or_filters(pool: PgPool) {
+        let state = AppState::from_pool(pool).await;
+        let entries = EntriesBuilder::default()
+            .with_shuffle(true)
+            .build(state.database_client())
+            .await
+            .s3_objects;
+
+        let result: ListResponse<S3> = response_from_get(state, "/s3?key[]=3&key[]=4").await;
+        assert_eq!(
+            result.results(),
+            vec![entries[3].clone(), entries[4].clone()]
+        );
+        assert_eq!(result.pagination().count, 2);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]
@@ -660,9 +677,28 @@ pub(crate) mod tests {
         assert_eq!(result.pagination().count, 0);
 
         let result: ListResponse<S3> =
-            response_from_get(state, "/s3?attributes[attributeId]=1&key=1").await;
+            response_from_get(state.clone(), "/s3?attributes[attributeId]=1&key=1").await;
         assert_eq!(result.results(), vec![entries[1].clone()]);
         assert_eq!(result.pagination().count, 1);
+
+        let result: ListResponse<S3> = response_from_get(
+            state.clone(),
+            "/s3?attributes[attributeId]=1&attributes[nestedId][attributeId]=1",
+        )
+        .await;
+        assert_eq!(result.results(), vec![entries[1].clone()]);
+        assert_eq!(result.pagination().count, 1);
+
+        let result: ListResponse<S3> = response_from_get(
+            state.clone(),
+            "/s3?attributes[attributeId][]=1&attributes[attributeId][]=2",
+        )
+        .await;
+        assert_eq!(
+            result.results(),
+            vec![entries[1].clone(), entries[2].clone()]
+        );
+        assert_eq!(result.pagination().count, 2);
     }
 
     #[sqlx::test(migrator = "MIGRATOR")]


### PR DESCRIPTION
Closes #595 

### Changes
* The filemanager API can now accept multiple keys in the API, where each additional key represents an `or` statement in the SQL query.
    * Additional keys need to use the `[]` syntax to specify a list. E.g. `/api/v1/s3?key[]=key1&key[]=key2`.
* Multiple keys are also supported on attributes.
    * The logic involving attributes has been fixed so that JSON arrays represent an `or` condition.
