### PR TITLE
Fix: Drop incomplete record before metadata processing

### DIFF
--- a/lib/workload/stateless/stacks/metadata-manager/README.md
+++ b/lib/workload/stateless/stacks/metadata-manager/README.md
@@ -104,22 +104,24 @@ In the near future, we might introduce different ways to load data into the appl
 loading data
 from the Google tracking sheet and mapping it to its respective model as follows.
 
-| Sheet Header      | Table        | Field Name         |
-|-------------------|--------------|--------------------|
-| SubjectID         | `Individual` | individual_id      |
-| ExternalSubjectID | `Subject`    | subject_id         |
-| SampleID          | `Sample`     | sample_id          |
-| ExternalSampleID  | `Sample`     | external_sample_id |
-| Source            | `Sample`     | source             |
-| LibraryID         | `Library`    | library_id         |
-| Phenotype         | `Library`    | phenotype          |
-| Workflow          | `Library`    | workflow           |
-| Quality           | `Library`    | quality            |
-| Type              | `Library`    | type               |
-| Coverage (X)      | `Library`    | coverage           |
-| Assay             | `Library`    | assay              |
-| ProjectName       | `Project`    | project_id         |
-| ProjectOwner      | `Contact`    | contact_id         |
+| Sheet Header       | Table        | Field Name         |
+|--------------------|--------------|--------------------|
+| *SubjectID         | `Individual` | individual_id      |
+| *ExternalSubjectID | `Subject`    | subject_id         |
+| *SampleID          | `Sample`     | sample_id          |
+| ExternalSampleID   | `Sample`     | external_sample_id |
+| Source             | `Sample`     | source             |
+| *LibraryID         | `Library`    | library_id         |
+| Phenotype          | `Library`    | phenotype          |
+| Workflow           | `Library`    | workflow           |
+| Quality            | `Library`    | quality            |
+| Type               | `Library`    | type               |
+| Coverage (X)       | `Library`    | coverage           |
+| Assay              | `Library`    | assay              |
+| *ProjectName       | `Project`    | project_id         |
+| *ProjectOwner      | `Contact`    | contact_id         |
+
+All asterisked (*) header are required fields to process a record.
 
 Some important notes of the sync:
 
@@ -144,12 +146,12 @@ The application also supports loading data from a custom CSV file. The CSV file 
 | Sheet Header         | Table        | Field Name         |
 |----------------------|--------------|--------------------|
 | Individual_id        | `Individual` | individual_id      |
-| individual_id_source | `Individual` | subject_id         |
-| subject_id           | `Subject`    | subject_id         |
+| individual_id_source | `Individual` | source             |
+| *subject_id          | `Subject`    | subject_id         |
 | sample_id            | `Sample`     | sample_id          |
 | external_sample_id   | `Sample`     | external_sample_id |
 | source               | `Sample`     | source             |
-| library_id           | `Library`    | library_id         |
+| *library_id          | `Library`    | library_id         |
 | phenotype            | `Library`    | phenotype          |
 | workflow             | `Library`    | workflow           |
 | quality              | `Library`    | quality            |
@@ -158,6 +160,8 @@ The application also supports loading data from a custom CSV file. The CSV file 
 | assay                | `Library`    | assay              |
 | project_name         | `Project`    | project_id         |
 | project_owner        | `Contact`    | contact_id         |
+
+All asterisked (*) header are required fields to process a record.
 
 The CSV file should be in a presigned URL format, where the loader will read and insert to the database.
 To trigger the loader please look at `./deploy/README.md` for more info.

--- a/lib/workload/stateless/stacks/metadata-manager/app/management/commands/load_from_csv.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/management/commands/load_from_csv.py
@@ -14,6 +14,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         event = {
             "url": "SOME_URL",
+            "is_emit_eb_events": False
         }
 
         print(f"Trigger lambda handler for sync tracking sheet. Event {libjson.dumps(event)}")

--- a/lib/workload/stateless/stacks/metadata-manager/app/management/commands/trigger_sync_handler.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/management/commands/trigger_sync_handler.py
@@ -13,7 +13,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         event = {
-            "year": 2024
+            "year": 2024,
+            "is_emit_eb_events": False
         }
 
         print(f"Trigger lambda handler for sync tracking sheet. Event {libjson.dumps(event)}")

--- a/lib/workload/stateless/stacks/metadata-manager/deploy/README.md
+++ b/lib/workload/stateless/stacks/metadata-manager/deploy/README.md
@@ -40,11 +40,14 @@ To query in a local terminal
 gsheet_sync_lambda_arn=$(aws ssm get-parameter --name '/orcabus/metadata-manager/sync-gsheet-lambda-arn' --with-decryption | jq -r .Parameter.Value)
 ```
 
-The lambda handler will accept a single year from which sheet to run from the GSheet workbook. If no year is specified, it will run the current year.
+The lambda handler accepts a json with two parameters: 
+- `year` - a single year from which to run the sheet from the GSheet workbook. Default is the current year.
+- `is_emit_eb_events` - determines whether or not to emit events. Default is `true`.
 
 ```json
 {
-  "year": "2024"
+  "year": "2024",
+  "is_emit_eb_events": false
 }
 ```
 
@@ -72,11 +75,14 @@ To query in a local terminal
 load_custom_csv_lambda_arn=$(aws ssm get-parameter --name '/orcabus/metadata-manager/load-custom-csv-lambda-arn' --with-decryption | jq -r .Parameter.Value)
 ```
 
-The lambda handler will accept a json which only accepts a single key `url` which is the presigned url of the csv file.
+The lambda handler accepts a json with two parameters: 
+- `url` - a presigned url of the csv file
+- `is_emit_eb_events` - determines whether or not to emit events. Default is `true`.
 
 ```json
 {
-  "url": "https://example.com/csv"
+  "url": "https://example.com/csv",
+  "is_emit_eb_events": false
 }
 ```
 

--- a/lib/workload/stateless/stacks/metadata-manager/handler/load_custom_metadata_csv.py
+++ b/lib/workload/stateless/stacks/metadata-manager/handler/load_custom_metadata_csv.py
@@ -8,7 +8,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings.base')
 django.setup()
 
 from proc.service.utils import sanitize_lab_metadata_df, warn_drop_duplicated_library
-from proc.service.load_csv_srv import load_metadata_csv, download_csv_to_pandas
+from proc.service.load_csv_srv import load_metadata_csv, download_csv_to_pandas, drop_incomplete_csv_records
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -21,10 +21,14 @@ def handler(event, _context):
     if csv_url is None:
         raise ValueError("URL is required")
 
+    is_emit_eb_events: bool = event.get('is_emit_eb_events', True)
+
     csv_df = download_csv_to_pandas(csv_url)
     sanitize_df = sanitize_lab_metadata_df(csv_df)
     duplicate_clean_df = warn_drop_duplicated_library(sanitize_df)
-    result = load_metadata_csv(duplicate_clean_df)
+    clean_df = drop_incomplete_csv_records(duplicate_clean_df)
+
+    result = load_metadata_csv(clean_df, is_emit_eb_events)
 
     logger.info(f'persist report: {libjson.dumps(result)}')
     return result

--- a/lib/workload/stateless/stacks/metadata-manager/handler/sync_tracking_sheet.py
+++ b/lib/workload/stateless/stacks/metadata-manager/handler/sync_tracking_sheet.py
@@ -8,7 +8,8 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'app.settings.base')
 django.setup()
 
 from proc.service.utils import warn_drop_duplicated_library
-from proc.service.tracking_sheet_srv import download_tracking_sheet, sanitize_lab_metadata_df, persist_lab_metadata
+from proc.service.tracking_sheet_srv import download_tracking_sheet, sanitize_lab_metadata_df, persist_lab_metadata, \
+    drop_incomplete_tracking_sheet_records
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -22,10 +23,14 @@ def handler(event, context):
     if isinstance(year, list):
         raise ValueError("Year cannot be an array")
 
+    is_emit_eb_events: bool = event.get('is_emit_eb_events', True)
+
     tracking_sheet_df = download_tracking_sheet(year)
     sanitize_df = sanitize_lab_metadata_df(tracking_sheet_df)
     duplicate_clean_df = warn_drop_duplicated_library(sanitize_df)
-    result = persist_lab_metadata(duplicate_clean_df, year)
+    clean_df = drop_incomplete_tracking_sheet_records(duplicate_clean_df)
+
+    result = persist_lab_metadata(clean_df, year, is_emit_eb_events)
 
     logger.info(f'persist report: {libjson.dumps(result)}')
     return result


### PR DESCRIPTION
Fixes where it loads records where their internal Ids (e.g. `individualId`) are still null (as it is incomplete entry) by dropping the record entirely.