### PR TITLE
cttsov2 job checker requires permissions to list executions

### DIFF
--- a/lib/workload/stateless/stacks/cttso-v2-pipeline-manager/deploy/constructs/cttsov2-icav2-manager/index.ts
+++ b/lib/workload/stateless/stacks/cttso-v2-pipeline-manager/deploy/constructs/cttsov2-icav2-manager/index.ts
@@ -137,6 +137,7 @@ export class Cttsov2Icav2PipelineManagerConstruct extends Construct {
           'states:ListActivities',
           'states:DescribeStateMachine',
           'states:DescribeActivity',
+          'states:ListExecutions',
         ],
         resources: [props.icav2CopyFilesStateMachineObj.stateMachineArn],
       })


### PR DESCRIPTION
Error created when cdk-nag forced us to use our own policy statement instead of 'grantRead', missed this permission