### PR TITLE
Handle orcabus_id with prefix when saving model objects

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/models/base.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/models/base.py
@@ -80,6 +80,8 @@ class OrcaBusBaseModel(models.Model):
     class Meta:
         abstract = True
 
+    orcabus_id_prefix = None
+
     orcabus_id = models.CharField(
         primary_key=True,
         unique=True,
@@ -90,9 +92,18 @@ class OrcaBusBaseModel(models.Model):
     )
 
     def save(self, *args, **kwargs):
+        # handle the OrcaBus ID
         if not self.orcabus_id:
+            # if no OrcaBus ID was provided, then generate one
             self.orcabus_id = ulid.new().str
-        self.full_clean()  # make sure we are validating
+        else:
+            # check provided OrcaBus ID
+            if len(self.orcabus_id) > 26:
+                # assume the OrcaBus ID carries the prefix
+                # we strip it off and continue to the validation
+                l = len(self.orcabus_id_prefix)
+                self.orcabus_id = str(self.orcabus_id)[l:]
+        self.full_clean()  # make sure we are validating the inputs (especially the OrcaBus ID)
         return super(OrcaBusBaseModel, self).save(*args, **kwargs)
 
 

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/tests/test_models.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/tests/test_models.py
@@ -3,6 +3,7 @@ from unittest import skip
 
 from django.test import TestCase
 
+from workflow_manager.models import Library
 from workflow_manager.models.workflow import Workflow
 
 logger = logging.getLogger()
@@ -24,3 +25,30 @@ class WorkflowModelTests(TestCase):
         logger.info(mock_wfl)
 
         self.assertEqual(1, Workflow.objects.count())
+
+
+    def test_save_library(self):
+        """
+        python manage.py test workflow_manager.tests.test_models.WorkflowModelTests.test_save_library
+        """
+
+        lib = Library(
+            library_id="L2400001"
+        )
+        lib.save()
+        logger.info(lib)
+        self.assertEqual(1, Library.objects.count())
+
+
+    def test_save_library_with_orcabus_id(self):
+        """
+        python manage.py test workflow_manager.tests.test_models.WorkflowModelTests.test_save_library_with_orcabus_id
+        """
+
+        lib = Library(
+            library_id="L2400001",
+            orcabus_id="lib.01J8ES4ZDRQAP2BN3SDYYV5PKW"
+        )
+        lib.save()
+        logger.info(lib)
+        self.assertEqual(1, Library.objects.count())


### PR DESCRIPTION
Fixes https://github.com/umccr/orcabus/issues/611