### PR TITLE
feat: filemanager partitions

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/Makefile
+++ b/lib/workload/stateless/stacks/filemanager/Makefile
@@ -70,7 +70,7 @@ clean: docker-clean
 psql:
 	@docker compose exec postgres psql filemanager -U filemanager
 restore:
-	@docker compose exec postgres pg_restore -U filemanager -f $(FILE)
+	@docker compose exec -T postgres pg_restore -U filemanager -d filemanager
 
 ## Targets related to top-level database management and S3.
 apply-schema:

--- a/lib/workload/stateless/stacks/filemanager/Makefile
+++ b/lib/workload/stateless/stacks/filemanager/Makefile
@@ -69,6 +69,8 @@ clean: docker-clean
 ## Database related targets
 psql:
 	@docker compose exec postgres psql filemanager -U filemanager
+restore:
+	@docker compose exec postgres pg_restore -U filemanager -f $(FILE)
 
 ## Targets related to top-level database management and S3.
 apply-schema:

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0003_partition_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0003_partition_state.sql
@@ -20,3 +20,6 @@ where s3_object.s3_object_id = to_update.s3_object_id;
 
 -- Then, set the default to true to match new logic using `is_current_state`.
 alter table s3_object alter column is_current_state set default true;
+
+-- Create an index for now, although partitioning will be required later.
+create index is_current_state_index on s3_object (is_current_state);

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0003_partition_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0003_partition_state.sql
@@ -1,0 +1,22 @@
+-- Creates the `is_current_state` column to partition objects by current and historical records.
+
+-- Initially, set the `is_current_state` to false to make migrating existing data easier.
+alter table s3_object add column is_current_state boolean not null default false;
+
+-- Find the current state and update existing records.
+with to_update as (
+    -- Get all records representing the current state.
+    select * from (
+        select distinct on (bucket, key, version_id) * from s3_object
+        order by bucket, key, version_id, sequencer desc
+    ) as s3_object
+    where event_type = 'Created' and is_delete_marker = false
+)
+-- Update `is_current_state` on existing records.
+update s3_object
+set is_current_state = true
+from to_update
+where s3_object.s3_object_id = to_update.s3_object_id;
+
+-- Then, set the default to true to match new logic using `is_current_state`.
+alter table s3_object alter column is_current_state set default true;

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0003_s3_current_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0003_s3_current_state.sql
@@ -1,5 +1,7 @@
 -- Creates the `is_current_state` column to separate objects by current and historical records.
 
+begin;
+
 -- -- Initially, set the `is_current_state` to false to make migrating existing data easier.
 alter table s3_object add column is_current_state boolean not null default false;
 
@@ -25,3 +27,5 @@ alter table s3_object alter column is_current_state set default true;
 create index is_current_state_index on s3_object (is_current_state);
 -- This helps the query which resets the current state when ingesting objects.
 create index reset_current_state_index on s3_object (bucket, key, version_id, sequencer, is_current_state);
+
+commit;

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0003_s3_current_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0003_s3_current_state.sql
@@ -1,9 +1,9 @@
--- Creates the `is_current_state` column to partition objects by current and historical records.
+-- Creates the `is_current_state` column to separate objects by current and historical records.
 
--- Initially, set the `is_current_state` to false to make migrating existing data easier.
+-- -- Initially, set the `is_current_state` to false to make migrating existing data easier.
 alter table s3_object add column is_current_state boolean not null default false;
 
--- Find the current state and update existing records.
+-- This migrates existing data, first find the current state and update existing records.
 with to_update as (
     -- Get all records representing the current state.
     select * from (
@@ -21,5 +21,7 @@ where s3_object.s3_object_id = to_update.s3_object_id;
 -- Then, set the default to true to match new logic using `is_current_state`.
 alter table s3_object alter column is_current_state set default true;
 
--- Create an index for now, although partitioning will be required later.
+-- Create an indexes for now, although partitioning will be required later.
 create index is_current_state_index on s3_object (is_current_state);
+-- This helps the query which resets the current state when ingesting objects.
+create index reset_current_state_index on s3_object (bucket, key, version_id, sequencer);

--- a/lib/workload/stateless/stacks/filemanager/database/migrations/0003_s3_current_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/migrations/0003_s3_current_state.sql
@@ -24,4 +24,4 @@ alter table s3_object alter column is_current_state set default true;
 -- Create an indexes for now, although partitioning will be required later.
 create index is_current_state_index on s3_object (is_current_state);
 -- This helps the query which resets the current state when ingesting objects.
-create index reset_current_state_index on s3_object (bucket, key, version_id, sequencer);
+create index reset_current_state_index on s3_object (bucket, key, version_id, sequencer, is_current_state);

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/reset_current_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/reset_current_state.sql
@@ -1,0 +1,41 @@
+-- Resets the `is_current_state` to false for a set of objects based on the `bucket`, `key`, `version_id`
+-- and `sequencer`. This is used to reset the current state so that a new object can have it's `is_current_state`
+-- set to true.
+
+-- Unnest input.
+with input as (
+    select
+        *
+    from unnest(
+        $1::text[],
+        $2::text[],
+        $3::text[],
+        $4::text[]
+    ) as input (
+        bucket,
+        key,
+        version_id,
+        sequencer
+    )
+),
+-- Select objects to update.
+to_update as (
+    select s3_object_id from input cross join lateral (
+        select
+            s3_object_id
+        from s3_object
+        where
+            input.bucket = s3_object.bucket and
+            input.key = s3_object.key and
+            input.version_id = s3_object.version_id and
+            -- Only the objects older than the input.
+            input.sequencer >= s3_object.sequencer and
+            -- Only need to update current objects.
+            s3_object.is_current_state = true
+        for update
+    ) s3_object
+)
+update s3_object
+set is_current_state = false
+from to_update
+where s3_object.s3_object_id = to_update.s3_object_id;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/reset_current_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/reset_current_state.sql
@@ -20,22 +20,35 @@ with input as (
 ),
 -- Select objects to update.
 to_update as (
-    select s3_object_id from input cross join lateral (
+    select * from input cross join lateral (
         select
-            s3_object_id
+            s3_object_id,
+            -- This finds the first value in the set which represents the most up-to-date state.
+            -- If ordered by the sequencer, the first row is the one that needs to have `is_current_state`
+            -- set to 'true' only for `Created` events, as `Deleted` events are always non-current state.
+            case when row_number() over (order by s3_object.sequencer desc) = 1 then
+                event_type = 'Created'
+            -- Set `is_current_state` to 'false' for all other rows, as this is now historical data.
+            else
+                false
+            end as updated_state
         from s3_object
         where
             input.bucket = s3_object.bucket and
             input.key = s3_object.key and
             input.version_id = s3_object.version_id and
-            -- Only the objects older than the input.
-            input.sequencer >= s3_object.sequencer and
-            -- Only need to update current objects.
-            s3_object.is_current_state = true
-        for update
+            -- This is an optimization which prevents querying against all objects in the set.
+            (
+                -- Only need to update current objects
+                s3_object.is_current_state = true or
+                -- Or objects where there is a newer sequencer than the one being processed.
+                -- This is required in case an out-of-order event is encountered.
+                s3_object.sequencer > input.sequencer
+            )
     ) s3_object
 )
 update s3_object
-set is_current_state = false
+set is_current_state = updated_state
 from to_update
-where s3_object.s3_object_id = to_update.s3_object_id;
+where s3_object.s3_object_id = to_update.s3_object_id
+returning s3_object.s3_object_id, s3_object.is_current_state;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/reset_current_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/reset_current_state.sql
@@ -42,8 +42,9 @@ to_update as (
                 -- Only need to update current objects
                 s3_object.is_current_state = true or
                 -- Or objects where there is a newer sequencer than the one being processed.
-                -- This is required in case an out-of-order event is encountered.
-                s3_object.sequencer > input.sequencer
+                -- This is required in case an out-of-order event is encountered. This always
+                -- includes the object being processed as it's required for the above row-logic.
+                s3_object.sequencer >= input.sequencer
             )
     ) s3_object
 )

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
@@ -36,6 +36,7 @@ select
     event_type,
     ingest_id,
     attributes,
+    is_current_state,
     0::bigint as "number_reordered"
 from input
 -- Grab the most recent object in each input group.

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/insert_s3_objects.sql
@@ -14,6 +14,7 @@ insert into s3_object (
     is_delete_marker,
     event_type,
     ingest_id,
+    is_current_state,
     attributes
 )
 values (
@@ -31,7 +32,8 @@ values (
     unnest($12::boolean[]),
     unnest($13::event_type[]),
     unnest($14::uuid[]),
-    unnest($15::jsonb[])
+    unnest($15::boolean[]),
+    unnest($16::jsonb[])
 ) on conflict on constraint sequencer_unique do update
     set number_duplicate_events = s3_object.number_duplicate_events + 1
     returning s3_object_id, number_duplicate_events;

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_created.sql
@@ -134,6 +134,7 @@ select
     size,
     is_delete_marker,
     ingest_id,
+    is_current_state,
     attributes,
     -- This is used to simplify re-constructing the FlatS3EventMessages in the Lambda. I.e. this update detected an
     -- out of order created event, so return a created event back.

--- a/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/ingester/aws/update_reordered_for_deleted.sql
@@ -99,6 +99,7 @@ select
     size,
     is_delete_marker,
     ingest_id,
+    is_current_state,
     attributes,
     -- This is used to simplify re-constructing the FlatS3EventMessages in the Lambda. I.e. this update detected an
     -- out of order deleted event, so return a deleted event back.

--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/migrate.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/migrate.ts
@@ -16,7 +16,8 @@ export class MigrateFunction extends fn.Function {
   constructor(scope: Construct, id: string, props: MigrateFunctionProps) {
     super(scope, id, {
       package: 'filemanager-migrate-lambda',
-      timeout: Duration.minutes(2),
+      // This needs to be higher to account for longer migrations.
+      timeout: Duration.minutes(15),
       ...props,
     });
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager-api-server/src/main.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager-api-server/src/main.rs
@@ -115,7 +115,8 @@ async fn main() -> Result<()> {
             .with_key_divisor(key_divisor)
             .with_shuffle(shuffle)
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
     }
 
     if args.migrate {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
@@ -1044,6 +1044,10 @@ pub(crate) mod tests {
             s3_object_results.get::<bool, _>("is_delete_marker")
         );
         assert_eq!(
+            message.is_current_state,
+            s3_object_results.get::<bool, _>("is_current_state")
+        );
+        assert_eq!(
             message.event_type,
             s3_object_results.get::<EventType, _>("event_type")
         );

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester.rs
@@ -1,7 +1,7 @@
 //! This module handles logic associated with event ingestion.
 //!
 
-use sqlx::query;
+use sqlx::{query, PgConnection};
 use tracing::debug;
 
 use crate::database::aws::query::Query;
@@ -30,14 +30,10 @@ impl Ingester {
         Ok(Self::new(Client::from_generator(generator, config).await?))
     }
 
-    /// Ingest the events into the database by calling the insert and update queries.
-    pub async fn ingest_events(self, events: TransposedS3EventMessages) -> Result<()> {
-        let mut tx = self.client().pool().begin().await?;
-
-        debug!(
-                s3_object_ids = ?events.s3_object_ids,
-                "inserting events into s3_object table"
-        );
+    pub(crate) async fn ingest_query(
+        events: &TransposedS3EventMessages,
+        conn: &mut PgConnection,
+    ) -> Result<()> {
         query(include_str!(
             "../../../../database/queries/ingester/aws/insert_s3_objects.sql"
         ))
@@ -57,8 +53,21 @@ impl Ingester {
         .bind(&events.ingest_ids)
         .bind(&events.is_current_state)
         .bind(&events.attributes)
-        .fetch_all(&mut *tx)
+        .fetch_all(conn)
         .await?;
+
+        Ok(())
+    }
+
+    /// Ingest the events into the database by calling the insert and update queries.
+    pub async fn ingest_events(self, events: TransposedS3EventMessages) -> Result<()> {
+        let mut tx = self.client().pool().begin().await?;
+
+        debug!(
+                s3_object_ids = ?events.s3_object_ids,
+                "inserting events into s3_object table"
+        );
+        Self::ingest_query(&events, &mut tx).await?;
 
         // Reset state for records which represent the new state.
         Query::new(self.client.clone())
@@ -138,7 +147,7 @@ pub(crate) mod tests {
         let message = expected_message(Some(0), EXPECTED_VERSION_ID.to_string(), true, Deleted)
             .with_is_current_state(false);
         assert_row(
-            &s3_object_results[0],
+            &s3_object_results[1],
             message,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(Default::default()),
@@ -147,7 +156,7 @@ pub(crate) mod tests {
         let message = expected_message(None, EXPECTED_VERSION_ID.to_string(), false, Deleted)
             .with_is_current_state(false);
         assert_row(
-            &s3_object_results[1],
+            &s3_object_results[0],
             message,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             Some(Default::default()),
@@ -224,8 +233,8 @@ pub(crate) mod tests {
             s3_object_results[1].get::<i64, _>("number_duplicate_events")
         );
         assert_ingest_events(
-            &s3_object_results[0],
             &s3_object_results[1],
+            &s3_object_results[0],
             false,
             false,
             EXPECTED_VERSION_ID,
@@ -254,12 +263,6 @@ pub(crate) mod tests {
         let s3_object_results = fetch_results(&ingester).await;
 
         assert_eq!(s3_object_results.len(), 3);
-        assert_missing_deleted(
-            &s3_object_results[1],
-            &s3_object_results[2],
-            EXPECTED_VERSION_ID,
-            false,
-        );
         assert_with(
             &s3_object_results[0],
             None,
@@ -267,6 +270,24 @@ pub(crate) mod tests {
             EXPECTED_VERSION_ID.to_string(),
             Some(Default::default()),
             Deleted,
+            false,
+        );
+        assert_with(
+            &s3_object_results[1],
+            Some(0),
+            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
+            Some(Default::default()),
+            Created,
+            false,
+        );
+        assert_with(
+            &s3_object_results[2],
+            Some(0),
+            Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
+            Some(Default::default()),
+            Created,
             false,
         );
     }
@@ -294,12 +315,12 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 3);
         assert_missing_created(
+            &s3_object_results[2],
             &s3_object_results[0],
-            &s3_object_results[1],
             EXPECTED_VERSION_ID,
         );
         assert_with(
-            &s3_object_results[2],
+            &s3_object_results[1],
             Some(0),
             Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
             EXPECTED_VERSION_ID.to_string(),
@@ -361,9 +382,9 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 2);
         assert_ingest_events(
-            &s3_object_results[0],
             &s3_object_results[1],
-            true,
+            &s3_object_results[0],
+            false,
             false,
             &default_version_id(),
         );
@@ -393,9 +414,9 @@ pub(crate) mod tests {
             s3_object_results[1].get::<i64, _>("number_duplicate_events")
         );
         assert_ingest_events(
-            &s3_object_results[0],
             &s3_object_results[1],
-            true,
+            &s3_object_results[0],
+            false,
             false,
             &default_version_id(),
         );
@@ -409,6 +430,7 @@ pub(crate) mod tests {
         let event = expected_flat_events_simple().sort_and_dedup().into_inner();
         let mut event = event[0].clone();
         event.version_id = "version_id".to_string();
+        event.sequencer = Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string());
 
         let mut events = vec![event];
         events.extend(expected_flat_events_simple().sort_and_dedup().into_inner());
@@ -419,6 +441,7 @@ pub(crate) mod tests {
 
         let s3_object_results = fetch_results(&ingester).await;
 
+        println!("{:#?}", s3_object_results);
         assert_eq!(s3_object_results.len(), 3);
         assert_eq!(
             0,
@@ -434,20 +457,31 @@ pub(crate) mod tests {
         );
 
         assert_with(
-            &s3_object_results[0],
+            &s3_object_results[2],
             Some(0),
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
+            Some(Default::default()),
+            Created,
+            false,
+        );
+        assert_with(
+            &s3_object_results[0],
+            Some(0),
+            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
             "version_id".to_string(),
             Some(Default::default()),
             Created,
             true,
         );
-        assert_ingest_events(
+        assert_with(
             &s3_object_results[1],
-            &s3_object_results[2],
-            true,
+            None,
+            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
+            Some(Default::default()),
+            Deleted,
             false,
-            EXPECTED_VERSION_ID,
         );
     }
 
@@ -455,14 +489,11 @@ pub(crate) mod tests {
     async fn ingest_object_missing_deleted(pool: PgPool) {
         let ingester = test_ingester(pool);
 
-        let events_one = test_events(Some(Created));
-
+        let mut events_one = test_events(Some(Created));
+        events_one.sequencers[0] = Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string());
         // New created event with a higher sequencer.
-        let events_two = replace_sequencers(
-            test_events(Some(Created)),
-            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
-            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
-        );
+        let mut events_two = test_events(Some(Created));
+        events_two.sequencers[0] = Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string());
 
         ingester.ingest(S3(events_one)).await.unwrap();
         ingester.ingest(S3(events_two)).await.unwrap();
@@ -471,10 +502,11 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 2);
         assert_missing_deleted(
-            &s3_object_results[0],
             &s3_object_results[1],
+            &s3_object_results[0],
             EXPECTED_VERSION_ID,
             false,
+            true,
         );
     }
 
@@ -482,14 +514,11 @@ pub(crate) mod tests {
     async fn ingest_object_missing_deleted_reorder(pool: PgPool) {
         let ingester = test_ingester(pool);
 
-        let events_one = test_events(Some(Created));
-
+        let mut events_one = test_events(Some(Created));
+        events_one.sequencers[0] = Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string());
         // New created event with a higher sequencer.
-        let events_two = replace_sequencers(
-            test_events(Some(Created)),
-            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
-            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
-        );
+        let mut events_two = test_events(Some(Created));
+        events_two.sequencers[0] = Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string());
 
         // Re-order
         ingester.ingest(S3(events_two)).await.unwrap();
@@ -503,6 +532,7 @@ pub(crate) mod tests {
             &s3_object_results[1],
             EXPECTED_VERSION_ID,
             false,
+            true,
         );
     }
 
@@ -510,14 +540,11 @@ pub(crate) mod tests {
     async fn ingest_object_missing_created(pool: PgPool) {
         let ingester = test_ingester(pool);
 
-        let events_one = test_events(Some(Deleted));
-
-        // New deleted event with a higher sequencer.
-        let events_two = replace_sequencers(
-            test_events(Some(Deleted)),
-            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
-            Some(EXPECTED_SEQUENCER_DELETED_TWO.to_string()),
-        );
+        let mut events_one = test_events(Some(Deleted));
+        events_one.sequencers[0] = Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string());
+        // New created event with a higher sequencer.
+        let mut events_two = test_events(Some(Deleted));
+        events_two.sequencers[0] = Some(EXPECTED_SEQUENCER_DELETED_TWO.to_string());
 
         ingester.ingest(S3(events_one)).await.unwrap();
         ingester.ingest(S3(events_two)).await.unwrap();
@@ -536,14 +563,11 @@ pub(crate) mod tests {
     async fn ingest_object_missing_created_reorder(pool: PgPool) {
         let ingester = test_ingester(pool);
 
-        let events_one = test_events(Some(Deleted));
-
-        // New deleted event with a higher sequencer.
-        let events_two = replace_sequencers(
-            test_events(Some(Deleted)),
-            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
-            Some(EXPECTED_SEQUENCER_DELETED_TWO.to_string()),
-        );
+        let mut events_one = test_events(Some(Deleted));
+        events_one.sequencers[0] = Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string());
+        // New created event with a higher sequencer.
+        let mut events_two = test_events(Some(Deleted));
+        events_two.sequencers[0] = Some(EXPECTED_SEQUENCER_DELETED_TWO.to_string());
 
         // Re-order
         ingester.ingest(S3(events_two)).await.unwrap();
@@ -563,8 +587,10 @@ pub(crate) mod tests {
     async fn ingest_object_no_sequencer_created(pool: PgPool) {
         let ingester = test_ingester(pool);
 
-        let events_one = replace_sequencers(test_events(Some(Created)), None, None);
-        let events_two = replace_sequencers(test_events(Some(Created)), None, None);
+        let mut events_one = test_events(Some(Created));
+        events_one.sequencers[0] = None;
+        let mut events_two = test_events(Some(Created));
+        events_two.sequencers[0] = None;
 
         ingester.ingest(S3(events_one)).await.unwrap();
         ingester.ingest(S3(events_two)).await.unwrap();
@@ -588,7 +614,7 @@ pub(crate) mod tests {
             EXPECTED_VERSION_ID.to_string(),
             Some(Default::default()),
             Created,
-            true,
+            false,
         );
     }
 
@@ -596,8 +622,10 @@ pub(crate) mod tests {
     async fn ingest_object_no_sequencer_deleted(pool: PgPool) {
         let ingester = test_ingester(pool);
 
-        let events_one = replace_sequencers(test_events(Some(Deleted)), None, None);
-        let events_two = replace_sequencers(test_events(Some(Deleted)), None, None);
+        let mut events_one = test_events(Some(Deleted));
+        events_one.sequencers[0] = None;
+        let mut events_two = test_events(Some(Deleted));
+        events_two.sequencers[0] = None;
 
         ingester.ingest(S3(events_one)).await.unwrap();
         ingester.ingest(S3(events_two)).await.unwrap();
@@ -636,7 +664,7 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 2);
         assert_with(
-            &s3_object_results[0],
+            &s3_object_results[1],
             Some(0),
             None,
             EXPECTED_VERSION_ID.to_string(),
@@ -645,7 +673,7 @@ pub(crate) mod tests {
             true,
         );
         assert_with(
-            &s3_object_results[1],
+            &s3_object_results[0],
             None,
             None,
             EXPECTED_VERSION_ID.to_string(),
@@ -659,17 +687,13 @@ pub(crate) mod tests {
     async fn ingest_object_multiple_matching_rows_created(pool: PgPool) {
         let ingester = test_ingester(pool);
 
-        let events_one = replace_sequencers(
-            test_events(Some(Created)),
-            Some(EXPECTED_SEQUENCER_CREATED_ZERO.to_string()),
-            Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
-        );
-        let events_two = test_events(Some(Created));
-        let events_three = replace_sequencers(
-            test_events(Some(Deleted)),
-            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
-            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
-        );
+        let mut events_one = test_events(Some(Created));
+        events_one.sequencers[0] = Some(EXPECTED_SEQUENCER_CREATED_ZERO.to_string());
+        // New created event with a higher sequencer.
+        let mut events_two = test_events(Some(Created));
+        events_two.sequencers[0] = Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string());
+        let mut events_three = test_events(Some(Deleted));
+        events_three.sequencers[0] = Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string());
 
         ingester.ingest(S3(events_one)).await.unwrap();
         ingester.ingest(S3(events_two)).await.unwrap();
@@ -685,12 +709,12 @@ pub(crate) mod tests {
             EXPECTED_VERSION_ID.to_string(),
             Some(Default::default()),
             Created,
-            true,
+            false,
         );
         assert_ingest_events(
             &s3_object_results[1],
             &s3_object_results[2],
-            true,
+            false,
             false,
             EXPECTED_VERSION_ID,
         );
@@ -700,16 +724,11 @@ pub(crate) mod tests {
     async fn ingest_object_multiple_matching_rows_deleted(pool: PgPool) {
         let ingester = test_ingester(pool);
 
-        let events_one = replace_sequencers(
-            test_events(Some(Deleted)),
-            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
-            Some(EXPECTED_SEQUENCER_DELETED_TWO.to_string()),
-        );
-        let events_two = replace_sequencers(
-            test_events(Some(Deleted)),
-            Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
-            Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
-        );
+        let mut events_one = test_events(Some(Deleted));
+        events_one.sequencers[0] = Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string());
+        // New created event with a higher sequencer.
+        let mut events_two = test_events(Some(Deleted));
+        events_two.sequencers[0] = Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string());
         let events_three = test_events(Some(Created));
 
         ingester.ingest(S3(events_one)).await.unwrap();
@@ -722,7 +741,7 @@ pub(crate) mod tests {
         assert_with(
             &s3_object_results[2],
             None,
-            Some(EXPECTED_SEQUENCER_DELETED_TWO.to_string()),
+            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
             EXPECTED_VERSION_ID.to_string(),
             Some(Default::default()),
             Deleted,
@@ -731,7 +750,40 @@ pub(crate) mod tests {
         assert_ingest_events(
             &s3_object_results[0],
             &s3_object_results[1],
+            false,
+            false,
+            EXPECTED_VERSION_ID,
+        );
+    }
+
+    #[sqlx::test(migrator = "MIGRATOR")]
+    async fn ingest_objects_reset_current_state(pool: PgPool) {
+        let ingester = test_ingester(pool);
+
+        let mut events_one = test_events(Some(Created));
+        events_one.sequencers[0] = Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string());
+        let events_two = test_events(None);
+
+        // Out of order.
+        ingester.ingest(S3(events_one)).await.unwrap();
+        ingester.ingest(S3(events_two)).await.unwrap();
+
+        let s3_object_results = fetch_results_ordered(&ingester).await;
+
+        assert_eq!(s3_object_results.len(), 3);
+        assert_with(
+            &s3_object_results[2],
+            Some(0),
+            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
+            EXPECTED_VERSION_ID.to_string(),
+            Some(Default::default()),
+            Created,
             true,
+        );
+        assert_ingest_events(
+            &s3_object_results[0],
+            &s3_object_results[1],
+            false,
             false,
             EXPECTED_VERSION_ID,
         );
@@ -745,40 +797,46 @@ pub(crate) mod tests {
                 .with_key("key".to_string())
                 .with_default_version_id()
                 .with_event_type(Created)
-                .with_sequencer(Some("1".to_string())),
+                .with_sequencer(Some("1".to_string()))
+                .with_is_current_state(true),
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_default_version_id()
                 .with_event_type(Deleted)
-                .with_sequencer(Some("2".to_string())),
+                .with_sequencer(Some("2".to_string()))
+                .with_is_current_state(false),
             // Missing created event.
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_default_version_id()
                 .with_event_type(Deleted)
-                .with_sequencer(Some("3".to_string())),
+                .with_sequencer(Some("3".to_string()))
+                .with_is_current_state(false),
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_default_version_id()
                 .with_event_type(Created)
-                .with_sequencer(Some("4".to_string())),
+                .with_sequencer(Some("4".to_string()))
+                .with_is_current_state(true),
             // Missing deleted event.
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_default_version_id()
                 .with_event_type(Created)
-                .with_sequencer(Some("5".to_string())),
+                .with_sequencer(Some("5".to_string()))
+                .with_is_current_state(true),
             // Different key
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key1".to_string())
                 .with_default_version_id()
                 .with_event_type(Created)
-                .with_sequencer(Some("1".to_string())),
+                .with_sequencer(Some("1".to_string()))
+                .with_is_current_state(true),
         ];
 
         let message = expected_message(None, default_version_id(), false, Created)
@@ -789,37 +847,46 @@ pub(crate) mod tests {
         run_permutation_test(&pool, event_permutations, 6, |s3_object_results| {
             assert_row(
                 &s3_object_results[0],
-                message.clone(),
+                message.clone().with_is_current_state(false),
                 Some("1".to_string()),
                 None,
             );
             assert_row(
                 &s3_object_results[1],
-                message.clone().with_key("key1".to_string()),
+                message
+                    .clone()
+                    .with_key("key1".to_string())
+                    .with_is_current_state(true),
                 Some("1".to_string()),
                 None,
             );
             assert_row(
                 &s3_object_results[2],
-                message.clone().with_event_type(Deleted),
+                message
+                    .clone()
+                    .with_event_type(Deleted)
+                    .with_is_current_state(false),
                 Some("2".to_string()),
                 None,
             );
             assert_row(
                 &s3_object_results[3],
-                message.clone().with_event_type(Deleted),
+                message
+                    .clone()
+                    .with_event_type(Deleted)
+                    .with_is_current_state(false),
                 Some("3".to_string()),
                 None,
             );
             assert_row(
                 &s3_object_results[4],
-                message.clone(),
+                message.clone().with_is_current_state(false),
                 Some("4".to_string()),
                 None,
             );
             assert_row(
                 &s3_object_results[5],
-                message.clone(),
+                message.clone().with_is_current_state(true),
                 Some("5".to_string()),
                 None,
             );
@@ -839,7 +906,7 @@ pub(crate) mod tests {
         run_permutation_test(&pool, event_permutations, 5, |s3_object_results| {
             assert_row(
                 &s3_object_results[0],
-                message.clone(),
+                message.clone().with_is_current_state(false),
                 Some("1".to_string()),
                 None,
             );
@@ -848,25 +915,32 @@ pub(crate) mod tests {
                 message
                     .clone()
                     .with_version_id("version_id1".to_string())
-                    .with_event_type(Deleted),
+                    .with_event_type(Deleted)
+                    .with_is_current_state(false),
                 Some("1".to_string()),
                 None,
             );
             assert_row(
                 &s3_object_results[2],
-                message.clone().with_event_type(Deleted),
+                message
+                    .clone()
+                    .with_event_type(Deleted)
+                    .with_is_current_state(false),
                 Some("2".to_string()),
                 None,
             );
             assert_row(
                 &s3_object_results[3],
-                message.clone(),
+                message.clone().with_is_current_state(false),
                 Some("3".to_string()),
                 None,
             );
             assert_row(
                 &s3_object_results[4],
-                message.clone().with_event_type(Deleted),
+                message
+                    .clone()
+                    .with_event_type(Deleted)
+                    .with_is_current_state(false),
                 Some("4".to_string()),
                 None,
             );
@@ -908,39 +982,45 @@ pub(crate) mod tests {
                 .with_key("key".to_string())
                 .with_version_id("version_id".to_string())
                 .with_event_type(Created)
-                .with_sequencer(Some("1".to_string())),
+                .with_sequencer(Some("1".to_string()))
+                .with_is_current_state(true),
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_version_id("version_id".to_string())
                 .with_event_type(Deleted)
-                .with_sequencer(Some("2".to_string())),
+                .with_sequencer(Some("2".to_string()))
+                .with_is_current_state(false),
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_version_id("version_id".to_string())
                 .with_event_type(Created)
-                .with_sequencer(Some("3".to_string())),
+                .with_sequencer(Some("3".to_string()))
+                .with_is_current_state(true),
             // Duplicate
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_version_id("version_id".to_string())
                 .with_event_type(Created)
-                .with_sequencer(Some("3".to_string())),
+                .with_sequencer(Some("3".to_string()))
+                .with_is_current_state(true),
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_version_id("version_id".to_string())
                 .with_event_type(Deleted)
-                .with_sequencer(Some("4".to_string())),
+                .with_sequencer(Some("4".to_string()))
+                .with_is_current_state(false),
             // Different version id
             FlatS3EventMessage::new_with_generated_id()
                 .with_bucket("bucket".to_string())
                 .with_key("key".to_string())
                 .with_version_id("version_id1".to_string())
                 .with_event_type(Deleted)
-                .with_sequencer(Some("1".to_string())),
+                .with_sequencer(Some("1".to_string()))
+                .with_is_current_state(false),
         ]
     }
 
@@ -988,25 +1068,26 @@ pub(crate) mod tests {
         created: &PgRow,
         deleted: &PgRow,
         version_id: &str,
-        is_current_state: bool,
+        created_state: bool,
+        deleted_state: bool,
     ) {
         assert_with(
             created,
-            Some(0),
-            Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
-            version_id.to_string(),
-            Some(Default::default()),
-            Created,
-            is_current_state,
-        );
-        assert_with(
-            deleted,
             Some(0),
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             version_id.to_string(),
             Some(Default::default()),
             Created,
-            is_current_state,
+            created_state,
+        );
+        assert_with(
+            deleted,
+            Some(0),
+            Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
+            version_id.to_string(),
+            Some(Default::default()),
+            Created,
+            deleted_state,
         );
     }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
@@ -1594,10 +1594,6 @@ pub(crate) mod tests {
             message.is_delete_marker,
             s3_object_results.get::<bool, _>("is_delete_marker")
         );
-        assert_eq!(
-            message.is_current_state,
-            s3_object_results.get::<bool, _>("is_current_state")
-        );
     }
 
     pub(crate) fn expected_message(

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/aws/ingester_paired.rs
@@ -1594,6 +1594,10 @@ pub(crate) mod tests {
             message.is_delete_marker,
             s3_object_results.get::<bool, _>("is_delete_marker")
         );
+        assert_eq!(
+            message.is_current_state,
+            s3_object_results.get::<bool, _>("is_current_state")
+        );
     }
 
     pub(crate) fn expected_message(

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/entities/s3_object.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/entities/s3_object.rs
@@ -38,6 +38,7 @@ pub struct Model {
     pub deleted_sequencer: Option<String>,
     pub number_reordered: i64,
     pub ingest_id: Option<Uuid>,
+    pub is_current_state: bool,
 }
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {}

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
@@ -27,7 +27,6 @@ pub trait CredentialGenerator {
 /// A database client handles database interaction.
 #[derive(Debug, Clone)]
 pub struct Client {
-    // Use a Cow here to allow an owned pool or a shared reference to a pool.
     connection: DatabaseConnection,
 }
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/database/mod.rs
@@ -241,6 +241,7 @@ pub(crate) mod tests {
         .bind(vec![false])
         .bind(vec![event_type])
         .bind(vec![UuidGenerator::generate()])
+        .bind(vec![false])
         .bind(vec![None::<Json>])
         .fetch_all(pool)
         .await

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/collecter.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/collecter.rs
@@ -307,7 +307,7 @@ impl<'a> Collecter<'a> {
             ..Default::default()
         };
         let moved_object = ListQueryBuilder::new(database_client.connection_ref())
-            .filter_all(filter, true)?
+            .filter_all(filter, true, false)?
             .one()
             .await
             .ok()
@@ -588,7 +588,8 @@ pub(crate) mod tests {
             .with_ingest_id(ingest_id)
             .with_n(1)
             .build(&client)
-            .await;
+            .await
+            .unwrap();
 
         collecter.raw_events = FlatS3EventMessages(vec![
             expected_s3_event_message().with_version_id(default_version_id())

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/inventory.rs
@@ -528,6 +528,8 @@ impl From<Record> for FlatS3EventMessage {
             // Anything in an inventory report is always a created event.
             event_type: Created,
             is_delete_marker: is_delete_marker.unwrap_or_default(),
+            // This will also represent the current state since it is a created event.
+            is_current_state: true,
             ingest_id: None,
             attributes: None,
             number_duplicate_events: 0,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -1,11 +1,10 @@
 //! Raw event message definitions from AWS S3, either through EventBridge or SQS directly.
 //!
 
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
-
 use crate::events::aws::{FlatS3EventMessage, FlatS3EventMessages};
 use crate::uuid::UuidGenerator;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 /// The type of S3 event.
 #[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd, Clone, Hash, sqlx::Type)]
@@ -189,6 +188,8 @@ impl From<Record> for FlatS3EventMessage {
             storage_class: None,
             last_modified_date: None,
             sha256: None,
+            // This represents the current state only if the event is a created event.
+            is_current_state: event_type == EventType::Created,
             event_type,
             is_delete_marker,
             ingest_id: None,
@@ -318,6 +319,7 @@ mod tests {
             Some(i64::MAX),
             "null".to_string(),
             false,
+            true,
         );
     }
 
@@ -347,6 +349,7 @@ mod tests {
             None,
             EXPECTED_VERSION_ID.to_string(),
             true,
+            false,
         );
     }
 
@@ -369,6 +372,7 @@ mod tests {
             None,
             EXPECTED_VERSION_ID.to_string(),
             true,
+            false,
         );
     }
 
@@ -388,6 +392,7 @@ mod tests {
             None,
             EXPECTED_VERSION_ID.to_string(),
             false,
+            false,
         );
     }
 
@@ -401,6 +406,7 @@ mod tests {
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
             EXPECTED_VERSION_ID.to_string(),
+            false,
             false,
         );
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/message.rs
@@ -5,9 +5,12 @@ use crate::events::aws::{FlatS3EventMessage, FlatS3EventMessages};
 use crate::uuid::UuidGenerator;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use strum::{EnumCount, FromRepr};
 
 /// The type of S3 event.
-#[derive(Debug, Default, Eq, PartialEq, Ord, PartialOrd, Clone, Hash, sqlx::Type)]
+#[derive(
+    Debug, Default, Eq, PartialEq, Ord, PartialOrd, Clone, Hash, sqlx::Type, FromRepr, EnumCount,
+)]
 #[sqlx(type_name = "event_type")]
 pub enum EventType {
     #[default]

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
@@ -74,6 +74,7 @@ pub struct TransposedS3EventMessages {
     pub event_types: Vec<EventType>,
     pub is_delete_markers: Vec<bool>,
     pub ingest_ids: Vec<Option<Uuid>>,
+    pub is_current_state: Vec<bool>,
     pub attributes: Vec<Option<Json>>,
 }
 
@@ -96,6 +97,7 @@ impl TransposedS3EventMessages {
             event_types: Vec::with_capacity(capacity),
             is_delete_markers: Vec::with_capacity(capacity),
             ingest_ids: Vec::with_capacity(capacity),
+            is_current_state: Vec::with_capacity(capacity),
             attributes: Vec::with_capacity(capacity),
         }
     }
@@ -117,6 +119,7 @@ impl TransposedS3EventMessages {
             event_type,
             is_delete_marker,
             ingest_id,
+            is_current_state,
             attributes,
             ..
         } = message;
@@ -135,6 +138,7 @@ impl TransposedS3EventMessages {
         self.event_types.push(event_type);
         self.is_delete_markers.push(is_delete_marker);
         self.ingest_ids.push(ingest_id);
+        self.is_current_state.push(is_current_state);
         self.attributes.push(attributes);
     }
 }
@@ -174,6 +178,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
             messages.event_types,
             messages.is_delete_markers,
             messages.ingest_ids,
+            messages.is_current_state,
             messages.attributes,
         )
         .map(
@@ -192,6 +197,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
                 event_type,
                 is_delete_marker,
                 ingest_id,
+                is_current_state,
                 attributes,
             )| {
                 FlatS3EventMessage {
@@ -209,6 +215,7 @@ impl From<TransposedS3EventMessages> for FlatS3EventMessages {
                     event_type,
                     is_delete_marker,
                     ingest_id,
+                    is_current_state,
                     attributes,
                     number_duplicate_events: 0,
                     number_reordered: 0,
@@ -443,6 +450,7 @@ pub struct FlatS3EventMessage {
     pub event_type: EventType,
     pub is_delete_marker: bool,
     pub ingest_id: Option<Uuid>,
+    pub is_current_state: bool,
     pub attributes: Option<Json>,
     pub number_duplicate_events: i64,
     pub number_reordered: i64,
@@ -582,6 +590,12 @@ impl FlatS3EventMessage {
         self
     }
 
+    /// Set the is current state flag.
+    pub fn with_is_current_state(mut self, is_current_state: bool) -> Self {
+        self.is_current_state = is_current_state;
+        self
+    }
+
     /// Set the attributes.
     pub fn with_attributes(mut self, attributes: Option<Json>) -> Self {
         self.attributes = attributes;
@@ -644,6 +658,7 @@ pub(crate) mod tests {
             None,
             EXPECTED_VERSION_ID.to_string(),
             false,
+            false,
         );
 
         let second = result.next().unwrap();
@@ -654,6 +669,7 @@ pub(crate) mod tests {
             Some(0),
             EXPECTED_VERSION_ID.to_string(),
             false,
+            true,
         );
 
         let third = result.next().unwrap();
@@ -664,6 +680,7 @@ pub(crate) mod tests {
             Some(0),
             EXPECTED_VERSION_ID.to_string(),
             false,
+            true,
         );
     }
 
@@ -680,6 +697,7 @@ pub(crate) mod tests {
             Some(0),
             EXPECTED_VERSION_ID.to_string(),
             false,
+            true,
         );
 
         let second = result.next().unwrap();
@@ -689,6 +707,7 @@ pub(crate) mod tests {
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
             EXPECTED_VERSION_ID.to_string(),
+            false,
             false,
         );
     }
@@ -718,6 +737,7 @@ pub(crate) mod tests {
             Some(0),
             EXPECTED_VERSION_ID.to_string(),
             false,
+            true,
         );
 
         let second = result.next().unwrap();
@@ -727,6 +747,7 @@ pub(crate) mod tests {
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             None,
             EXPECTED_VERSION_ID.to_string(),
+            false,
             false,
         );
 
@@ -738,6 +759,7 @@ pub(crate) mod tests {
             None,
             "version_id".to_string(),
             false,
+            false,
         );
     }
 
@@ -748,6 +770,7 @@ pub(crate) mod tests {
         size: Option<i64>,
         version_id: String,
         is_delete_marker: bool,
+        is_current_state: bool,
     ) {
         assert_eq!(event.event_time, Some(DateTime::<Utc>::default()));
         assert_eq!(&event.event_type, event_type);
@@ -760,6 +783,7 @@ pub(crate) mod tests {
         assert_eq!(event.storage_class, None);
         assert_eq!(event.last_modified_date, None);
         assert_eq!(event.is_delete_marker, is_delete_marker);
+        assert_eq!(event.is_current_state, is_current_state);
     }
 
     fn assert_object(

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/events/aws/mod.rs
@@ -14,13 +14,26 @@ use crate::events::aws::message::{default_version_id, EventType};
 use crate::events::aws::EventType::{Created, Deleted, Other};
 use crate::uuid::UuidGenerator;
 use sea_orm::prelude::Json;
+use strum::{EnumCount, FromRepr};
 
 pub mod collecter;
 pub mod inventory;
 pub mod message;
 
 /// A wrapper around AWS storage types with sqlx support.
-#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Clone, sqlx::Type, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Clone,
+    sqlx::Type,
+    Serialize,
+    Deserialize,
+    FromRepr,
+    EnumCount,
+)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 #[sqlx(type_name = "storage_class")]
 pub enum StorageClass {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
@@ -213,8 +213,7 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::database::aws::ingester::tests::{
-        assert_row, expected_message, fetch_results, remove_version_ids, replace_sequencers,
-        test_events, test_ingester,
+        assert_row, expected_message, fetch_results, remove_version_ids, test_events, test_ingester,
     };
     use crate::database::aws::migration::tests::MIGRATOR;
     use crate::events::aws::collecter::tests::{
@@ -229,8 +228,8 @@ pub(crate) mod tests {
     use crate::events::aws::message::EventType::Deleted;
     use crate::events::aws::tests::{
         expected_event_record_simple, EXPECTED_QUOTED_E_TAG, EXPECTED_SEQUENCER_CREATED_ONE,
-        EXPECTED_SEQUENCER_CREATED_TWO, EXPECTED_SEQUENCER_DELETED_ONE,
-        EXPECTED_SEQUENCER_DELETED_TWO, EXPECTED_SHA256, EXPECTED_VERSION_ID,
+        EXPECTED_SEQUENCER_CREATED_TWO, EXPECTED_SEQUENCER_DELETED_ONE, EXPECTED_SHA256,
+        EXPECTED_VERSION_ID,
     };
     use crate::events::aws::FlatS3EventMessage;
     use crate::events::EventSourceType::S3;
@@ -274,7 +273,7 @@ pub(crate) mod tests {
         assert_eq!(s3_object_results.len(), 2);
         let message = expected_message(Some(0), EXPECTED_VERSION_ID.to_string(), false, Created);
         assert_row(
-            &s3_object_results[0],
+            &s3_object_results[1],
             message,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(Default::default()),
@@ -284,7 +283,7 @@ pub(crate) mod tests {
             .with_sha256(None)
             .with_last_modified_date(None);
         assert_row(
-            &s3_object_results[1],
+            &s3_object_results[0],
             message,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             Some(Default::default()),
@@ -330,13 +329,13 @@ pub(crate) mod tests {
                 .await;
         assert_row(
             &s3_object_results[3],
-            message.clone(),
+            message.clone().with_is_current_state(false),
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(DateTime::default()),
         );
         assert_row(
             &s3_object_results[4],
-            message.with_size(None).with_event_type(Deleted).clone(),
+            message.with_size(None).with_event_type(Deleted),
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             Some(DateTime::default()),
         );
@@ -344,15 +343,9 @@ pub(crate) mod tests {
 
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_inventory_ingestion_reorder_delete_event(pool: PgPool) {
-        let (s3_object_results, message) = test_inventory_ingestion_reorder(
-            pool,
-            replace_sequencers(
-                remove_version_ids(test_events(Some(Created))),
-                Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
-                Some(EXPECTED_SEQUENCER_DELETED_TWO.to_string()),
-            ),
-        )
-        .await;
+        let mut events = remove_version_ids(test_events(Some(Created)));
+        events.sequencers[0] = Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string());
+        let (s3_object_results, message) = test_inventory_ingestion_reorder(pool, events).await;
         assert_row(
             &s3_object_results[3],
             message
@@ -365,7 +358,7 @@ pub(crate) mod tests {
         );
         assert_row(
             &s3_object_results[4],
-            message,
+            message.with_is_current_state(true),
             Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
             Some(DateTime::default()),
         );
@@ -388,9 +381,9 @@ pub(crate) mod tests {
 
         assert_eq!(s3_object_results.len(), 2);
         let message = expected_message(Some(0), EXPECTED_VERSION_ID.to_string(), false, Created)
-            .with_is_current_state(true);
+            .with_is_current_state(false);
         assert_row(
-            &s3_object_results[0],
+            &s3_object_results[1],
             message,
             Some(EXPECTED_SEQUENCER_CREATED_ONE.to_string()),
             Some(Default::default()),
@@ -401,7 +394,7 @@ pub(crate) mod tests {
             .with_last_modified_date(None)
             .with_is_current_state(false);
         assert_row(
-            &s3_object_results[1],
+            &s3_object_results[0],
             message,
             Some(EXPECTED_SEQUENCER_DELETED_ONE.to_string()),
             Some(Default::default()),
@@ -447,6 +440,7 @@ pub(crate) mod tests {
             0,
             EXPECTED_LAST_MODIFIED_ONE,
             EXPECTED_QUOTED_E_TAG,
+            true,
         );
         assert_inventory_records(
             &s3_object_results[1],
@@ -454,6 +448,7 @@ pub(crate) mod tests {
             0,
             EXPECTED_LAST_MODIFIED_TWO,
             EXPECTED_QUOTED_E_TAG,
+            false,
         );
         assert_inventory_records(
             &s3_object_results[2],
@@ -461,6 +456,7 @@ pub(crate) mod tests {
             5,
             EXPECTED_LAST_MODIFIED_THREE,
             EXPECTED_QUOTED_E_TAG_KEY_2,
+            true,
         );
 
         (
@@ -473,7 +469,7 @@ pub(crate) mod tests {
                 .with_e_tag(Some(EXPECTED_QUOTED_E_TAG.to_string()))
                 .with_last_modified_date(Some(DateTime::default()))
                 .with_sha256(Some(EXPECTED_SHA256.to_string()))
-                .with_is_current_state(true),
+                .with_is_current_state(false),
         )
     }
 
@@ -500,6 +496,7 @@ pub(crate) mod tests {
             0,
             EXPECTED_LAST_MODIFIED_ONE,
             EXPECTED_QUOTED_E_TAG,
+            true,
         );
         assert_inventory_records(
             &s3_object_results[1],
@@ -507,6 +504,7 @@ pub(crate) mod tests {
             0,
             EXPECTED_LAST_MODIFIED_TWO,
             EXPECTED_QUOTED_E_TAG,
+            true,
         );
         assert_inventory_records(
             &s3_object_results[2],
@@ -514,6 +512,7 @@ pub(crate) mod tests {
             5,
             EXPECTED_LAST_MODIFIED_THREE,
             EXPECTED_QUOTED_E_TAG_KEY_2,
+            true,
         );
     }
 
@@ -523,6 +522,7 @@ pub(crate) mod tests {
         size: i64,
         last_modified: &str,
         e_tag: &str,
+        is_current_state: bool,
     ) {
         let message = FlatS3EventMessage::default()
             .with_bucket("bucket".to_string())
@@ -531,7 +531,7 @@ pub(crate) mod tests {
             .with_version_id(default_version_id())
             .with_last_modified_date(Some(last_modified.parse().unwrap()))
             .with_e_tag(Some(e_tag.to_string()))
-            .with_is_current_state(true);
+            .with_is_current_state(is_current_state);
 
         assert_row(row, message, Some("".to_string()), None);
     }

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/handlers/aws.rs
@@ -118,7 +118,7 @@ pub async fn ingest_s3_inventory(
     let transposed_events: TransposedS3EventMessages =
         FlatS3EventMessages::from(records).sort_and_dedup().into();
 
-    let query = Query::new(&database_client);
+    let query = Query::new(database_client.clone());
 
     let mut tx = query.transaction().await?;
     let database_records = query
@@ -229,8 +229,8 @@ pub(crate) mod tests {
     use crate::events::aws::message::EventType::Deleted;
     use crate::events::aws::tests::{
         expected_event_record_simple, EXPECTED_QUOTED_E_TAG, EXPECTED_SEQUENCER_CREATED_ONE,
-        EXPECTED_SEQUENCER_CREATED_TWO, EXPECTED_SEQUENCER_DELETED_ONE, EXPECTED_SHA256,
-        EXPECTED_VERSION_ID,
+        EXPECTED_SEQUENCER_CREATED_TWO, EXPECTED_SEQUENCER_DELETED_ONE,
+        EXPECTED_SEQUENCER_DELETED_TWO, EXPECTED_SHA256, EXPECTED_VERSION_ID,
     };
     use crate::events::aws::FlatS3EventMessage;
     use crate::events::EventSourceType::S3;
@@ -349,6 +349,7 @@ pub(crate) mod tests {
             replace_sequencers(
                 remove_version_ids(test_events(Some(Created))),
                 Some(EXPECTED_SEQUENCER_CREATED_TWO.to_string()),
+                Some(EXPECTED_SEQUENCER_DELETED_TWO.to_string()),
             ),
         )
         .await;

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/get.rs
@@ -45,7 +45,11 @@ mod tests {
     #[sqlx::test(migrator = "MIGRATOR")]
     async fn test_list_s3(pool: PgPool) {
         let client = Client::from_pool(pool);
-        let entries = EntriesBuilder::default().build(&client).await.s3_objects;
+        let entries = EntriesBuilder::default()
+            .build(&client)
+            .await
+            .unwrap()
+            .s3_objects;
 
         let first = entries.first().unwrap();
         let builder = GetQueryBuilder::new(client.connection_ref());

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
@@ -97,6 +97,7 @@ impl Entries {
             storage_class: Set(Some(Self::storage_class(index))),
             sequencer: Set(Some(index.to_string())),
             is_delete_marker: Set(false),
+            is_current_state: Set(event == EventType::Created),
             number_duplicate_events: Set(0),
             attributes: Set(attributes),
             deleted_date: if event == EventType::Deleted {

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/get.rs
@@ -96,6 +96,7 @@ pub async fn presign_s3_by_id(
                 ..Default::default()
             },
             true,
+            true,
         )?
         .all()
         .await?;
@@ -158,6 +159,7 @@ mod tests {
         let entries = EntriesBuilder::default()
             .build(state.database_client())
             .await
+            .unwrap()
             .s3_objects;
 
         let first = entries.first().unwrap();
@@ -194,7 +196,8 @@ mod tests {
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         let result = response_from_get::<Option<Url>>(
             state,
@@ -223,7 +226,8 @@ mod tests {
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         let result = response_from_get::<Option<Url>>(
             state,
@@ -260,7 +264,8 @@ mod tests {
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         let result: Option<Url> = response_from_get(
             state,
@@ -285,7 +290,8 @@ mod tests {
         let entries = EntriesBuilder::default()
             .with_shuffle(true)
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         let result: Option<Url> = response_from_get(
             state,
@@ -312,7 +318,8 @@ mod tests {
             .with_key_divisor(3)
             .with_shuffle(true)
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         let result: Option<Url> = response_from_get(
             state,

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/pagination.rs
@@ -239,6 +239,7 @@ mod tests {
             .with_shuffle(true)
             .build(state.database_client())
             .await
+            .unwrap()
             .s3_objects;
 
         let result: ListResponse<S3Object> =
@@ -311,6 +312,7 @@ mod tests {
             .with_n(1001)
             .build(state.database_client())
             .await
+            .unwrap()
             .s3_objects;
 
         let result: ListResponse<S3Object> =
@@ -337,6 +339,7 @@ mod tests {
             .with_shuffle(true)
             .build(state.database_client())
             .await
+            .unwrap()
             .s3_objects;
 
         let result: ListResponse<S3Object> = response_from_get(
@@ -370,6 +373,7 @@ mod tests {
             .with_shuffle(true)
             .build(state.database_client())
             .await
+            .unwrap()
             .s3_objects;
 
         let result: ListResponse<S3Object> = response_from_get(
@@ -406,6 +410,7 @@ mod tests {
             .with_shuffle(true)
             .build(state.database_client())
             .await
+            .unwrap()
             .s3_objects;
 
         let result: ListResponse<S3Object> =

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/update.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/routes/update.rs
@@ -131,12 +131,11 @@ pub async fn update_s3_collection_attributes(
 ) -> Result<extract::Json<Vec<S3>>> {
     let txn = state.database_client().connection_ref().begin().await?;
 
-    let mut results = UpdateQueryBuilder::<_, s3_object::Entity>::new(&txn)
-        .filter_all(filter_all, wildcard.case_sensitive())?;
-
-    if list.current_state() {
-        results = results.current_state();
-    }
+    let results = UpdateQueryBuilder::<_, s3_object::Entity>::new(&txn).filter_all(
+        filter_all,
+        wildcard.case_sensitive(),
+        list.current_state(),
+    )?;
 
     let results = results.update_s3_attributes(patch).await?.all().await?;
 
@@ -177,7 +176,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_attributes(
             state.database_client(),
@@ -210,7 +210,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_attributes(
             state.database_client(),
@@ -244,7 +245,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_attributes(
             state.database_client(),
@@ -294,7 +296,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_attributes(
             state.database_client(),
@@ -344,7 +347,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_attributes(
             state.database_client(),
@@ -388,7 +392,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_attributes(
             state.database_client(),
@@ -428,7 +433,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_many(
             state.database_client(),
@@ -465,7 +471,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_many(
             state.database_client(),
@@ -511,7 +518,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_many(
             state.database_client(),
@@ -542,7 +550,8 @@ mod tests {
         let state = AppState::from_pool(pool).await;
         let mut entries = EntriesBuilder::default()
             .build(state.database_client())
-            .await;
+            .await
+            .unwrap();
 
         change_many(
             state.database_client(),


### PR DESCRIPTION
Related to #614, finishes first task.

### Changes
* Add `is_current_state` column to database for later partitioning.
    * Migrates existing data to the correct `is_current_state`.
    * API uses this column now instead of performing the calculation every time.
    * Tests are updated to take this into account.
    
I know this adds some overhead to the ingester, but it is performing pretty well in testing (< a few ms per insert), and I think it's worth it because it reduces the performance issues on the API side. If this ever is a problem for the ingester to handle, then it can always be run as a separate asynchronous process. 