### PR TITLE
Remove unused stacky tables

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -754,7 +754,6 @@ export const sashPipelineVersionSSMParameterPath = '/nextflow_stack/sash/pipelin
 // Stacky Stack
 export const stackyEventBusName = eventBusName;
 export const stackyInstrumentRunTableName = 'stacky-instrument-run-table';
-export const stackyInputMakerTableName = 'stacky-input-maker-table';
 export const stackyCttsov2InputGlueTableName = 'stacky-cttsov2-workflow-glue-table';
 export const stackyWgtsQcGlueTableName = 'stacky-wgts-qc-glue-table';
 export const stackyTnGlueTableName = 'stacky-tn-glue-table';

--- a/config/stacks/stackyMcStackFace.ts
+++ b/config/stacks/stackyMcStackFace.ts
@@ -5,9 +5,7 @@ import {
   stackyAnalysisOutputUriSsmParameterName,
   stackyEventBusName,
   stackyIcav2ProjectIdSsmParameterName,
-  stackyInputMakerTableName,
   stackyInstrumentRunTableName,
-  stackyWorkflowManagerTableName,
   stackyCttsov2InputGlueTableName,
   icav2AccessTokenSecretName,
   stackyWgtsQcGlueTableName,
@@ -31,9 +29,7 @@ export const getGlueStackProps = (stage: AppStage): GlueStackConfig => {
     eventBusName: stackyEventBusName,
 
     /* Tables */
-    inputMakerTableName: stackyInputMakerTableName,
     instrumentRunTableName: stackyInstrumentRunTableName,
-    workflowManagerTableName: stackyWorkflowManagerTableName,
     cttsov2GlueTableName: stackyCttsov2InputGlueTableName,
     wgtsQcGlueTableName: stackyWgtsQcGlueTableName,
     tnGlueTableName: stackyTnGlueTableName,
@@ -65,8 +61,6 @@ export const getGlueStackProps = (stage: AppStage): GlueStackConfig => {
 export const getStatefulGlueStackProps = (): StackyStatefulTablesConfig => {
   return {
     dynamodbInstrumentRunManagerTableName: stackyInstrumentRunTableName,
-    dynamodbWorkflowManagerTableName: stackyWorkflowManagerTableName,
-    dynamodbInputGlueTableName: stackyInputMakerTableName,
     dynamodbCttsov2WorkflowGlueTableName: stackyCttsov2InputGlueTableName,
     dynamodbWgtsQcGlueTableName: stackyWgtsQcGlueTableName,
     dynamodbTnGlueTableName: stackyTnGlueTableName,

--- a/lib/workload/stateful/stacks/stacky-mcstackface-dynamodb/index.ts
+++ b/lib/workload/stateful/stacks/stacky-mcstackface-dynamodb/index.ts
@@ -6,8 +6,6 @@ import * as cdk from 'aws-cdk-lib';
 
 export interface StackyStatefulTablesConfig {
   dynamodbInstrumentRunManagerTableName: string;
-  dynamodbWorkflowManagerTableName: string;
-  dynamodbInputGlueTableName: string;
   dynamodbCttsov2WorkflowGlueTableName: string;
   dynamodbWgtsQcGlueTableName: string;
   dynamodbTnGlueTableName: string;
@@ -24,8 +22,6 @@ export type StackyStatefulTablesStackProps = StackyStatefulTablesConfig & cdk.St
 
 export class StackyStatefulTablesStack extends Stack {
   public readonly instrumentRunManagerTable: dynamodb.ITableV2;
-  public readonly workflowManagerTable: dynamodb.ITableV2;
-  public readonly inputGlueTable: dynamodb.ITableV2;
   public readonly cttsov2WorkflowGlueTable: dynamodb.ITableV2;
   public readonly wgtsQcGlueTable: dynamodb.ITableV2;
   public readonly tnGlueTable: dynamodb.ITableV2;
@@ -49,26 +45,6 @@ export class StackyStatefulTablesStack extends Stack {
         removalPolicy: props.removalPolicy,
       }
     ).tableObj;
-
-    /*
-    Initialise dynamodb table for the metadata manager
-    */
-    this.workflowManagerTable = new DynamodbPartitionedPipelineConstruct(
-      this,
-      'workflowManagerTable',
-      {
-        tableName: props.dynamodbWorkflowManagerTableName,
-        removalPolicy: props.removalPolicy,
-      }
-    ).tableObj;
-
-    /*
-    Initialise dynamodb table for the glue services
-    */
-    this.inputGlueTable = new DynamodbPartitionedPipelineConstruct(this, 'inputGlueTable', {
-      tableName: props.dynamodbInputGlueTableName,
-      removalPolicy: props.removalPolicy,
-    }).tableObj;
 
     /*
     Initialise dynamodb table for the cttsov2 glue service

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/index.ts
@@ -29,8 +29,6 @@ export interface GlueConstructProps {
 
   /* Tables */
   instrumentRunTableObj: dynamodb.ITableV2;
-  inputMakerTableObj: dynamodb.ITableV2;
-  workflowManagerTableObj: dynamodb.ITableV2;
   cttsov2GlueTableObj: dynamodb.ITableV2;
   wgtsQcGlueTableObj: dynamodb.ITableV2;
   tnGlueTableObj: dynamodb.ITableV2;
@@ -257,8 +255,6 @@ export interface GlueStackConfig {
 
   /* Tables */
   instrumentRunTableName: string;
-  inputMakerTableName: string;
-  workflowManagerTableName: string;
   cttsov2GlueTableName: string;
   wgtsQcGlueTableName: string;
   tnGlueTableName: string;
@@ -306,16 +302,6 @@ export class GlueStack extends cdk.Stack {
     /*
     Get the tables
     */
-    const workflowManagerTableObj = dynamodb.Table.fromTableName(
-      this,
-      'workflowManagerTableObj',
-      props.workflowManagerTableName
-    );
-    const inputMakerTableObj = dynamodb.Table.fromTableName(
-      this,
-      'inputMakerTableObj',
-      props.inputMakerTableName
-    );
     const instrumentRunTableObj = dynamodb.Table.fromTableName(
       this,
       'instrumentRunTableObj',
@@ -437,8 +423,6 @@ export class GlueStack extends cdk.Stack {
       eventBusObj: eventBusObj,
 
       /* Tables */
-      workflowManagerTableObj: workflowManagerTableObj,
-      inputMakerTableObj: inputMakerTableObj,
       instrumentRunTableObj: instrumentRunTableObj,
       wgtsQcGlueTableObj: wgtsQcGlueTableObj,
       cttsov2GlueTableObj: cttsov2GlueTableObj,


### PR DESCRIPTION
InputMakerTable and WorkflowTable had uses prior to generation of the workflowmanager which now stores runs.  

Tables no longer needed