### PR TITLE
feat(event-source): ignore cache directories

### DIFF
--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -94,9 +94,12 @@ const getEventSourceConstructProps = (stage: AppStage): EventSourceProps => {
     rules: [
       {
         bucket: oncoanalyserBucket[stage],
+        eventTypes: ['Object Created', 'Object Deleted'],
       },
       {
         bucket: icav2PipelineCacheBucket[stage],
+        eventTypes: ['Object Created', 'Object Deleted'],
+        key: [{ 'anything-but': { wildcard: 'byob-icav2/*/cache/*' } }],
       },
     ],
   };

--- a/lib/workload/stateful/stacks/shared/constructs/event-source/index.ts
+++ b/lib/workload/stateful/stacks/shared/constructs/event-source/index.ts
@@ -13,16 +13,18 @@ export type EventSourceRule = {
    * Bucket to receive events from. If not specified, captures events from all buckets.
    */
   bucket?: string;
+
   /**
    * The types of events to capture for the bucket. If not specified, captures all events.
    * This should be from the list S3 EventBridge events:
    * https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventBridge.html
    */
   eventTypes?: string[];
+
   /**
-   * A prefix of the objects that are matched when receiving events from the buckets.
+   * Rules matching specified keys in buckets.
    */
-  prefix?: string;
+  key?: { [key: string]: any }[];
 };
 
 /**
@@ -33,13 +35,15 @@ export type EventSourceProps = {
    * The name of the queue to construct.
    */
   queueName: string;
+
   /**
    * The maximum number of times a message can be unsuccessfully received before
    * pushing it to the DLQ.
    */
   maxReceiveCount: number;
+
   /**
-   * A set of EventBridge rules to define..
+   * A set of EventBridge rules to define.
    */
   rules: EventSourceRule[];
 };
@@ -80,13 +84,9 @@ export class EventSourceConstruct extends Construct {
                 name: [prop.bucket],
               },
             }),
-            ...(prop.prefix && {
+            ...(prop.key && {
               object: {
-                key: [
-                  {
-                    prefix: prop.prefix,
-                  },
-                ],
+                key: prop.key,
               },
             }),
           },

--- a/test/stateful/shared/eventSourceConstruct.test.ts
+++ b/test/stateful/shared/eventSourceConstruct.test.ts
@@ -75,14 +75,14 @@ test('Test EventSourceConstruct created props with event types', () => {
   });
 });
 
-test('Test EventSourceConstruct created props with prefix', () => {
+test('Test EventSourceConstruct created props with key rule', () => {
   new EventSourceConstruct(stack, 'TestEventSourceConstruct', {
     queueName: 'queue',
     maxReceiveCount: 100,
     rules: [
       {
         bucket: 'bucket',
-        prefix: 'prefix',
+        key: [{ 'anything-but': { wildcard: 'wildcard/*' } }, { prefix: 'prefix' }],
       },
     ],
   });
@@ -94,6 +94,9 @@ test('Test EventSourceConstruct created props with prefix', () => {
       detail: {
         object: {
           key: [
+            {
+              'anything-but': { wildcard: 'wildcard/*' },
+            },
             {
               prefix: 'prefix',
             },


### PR DESCRIPTION
Related to https://github.com/umccr/infrastructure/pull/489

### Changes
* Ignore cache directories under `byob-icav2` when processing incoming EventBridge events, and only forward `Created` and `Deleted` events to filemanager.