### PR TITLE
Upgrade memory for pieriandx glue lambdas

### DIFF
--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
@@ -15,6 +15,7 @@ import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import path from 'path';
 import { NagSuppressions } from 'cdk-nag';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as secretsManager from 'aws-cdk-lib/aws-secretsmanager';
 import * as events from 'aws-cdk-lib/aws-events';
@@ -163,7 +164,7 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
     Handle lambda permissions
     */
     // FIXME - cannot get the 'current' version of an IFunction object
-    NagSuppressions.addResourceSuppressions(getDataFromRedCapPyLambdaObj, [
+    NagSuppressions.addResourceSuppressions(<iam.Role>getDataFromRedCapPyLambdaObj.role, [
       {
         id: 'AwsSolutions-IAM5',
         reason: 'Cannot get latest version of redcap lambda function ($LATEST) will not work',

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
@@ -13,6 +13,7 @@ Given a cttsov2 success event we need to
 import { Construct } from 'constructs';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import path from 'path';
+import { NagSuppressions } from 'cdk-nag';
 import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as secretsManager from 'aws-cdk-lib/aws-secretsmanager';
@@ -161,7 +162,15 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
     /*
     Handle lambda permissions
     */
-    props.redcapLambdaObj.latestVersion.grantInvoke(getDataFromRedCapPyLambdaObj.currentVersion);
+    // FIXME - cannot get the 'current' version of an IFunction object
+    NagSuppressions.addResourceSuppressions(getDataFromRedCapPyLambdaObj, [
+      {
+        id: 'AwsSolutions-IAM5[Resource::*',
+        reason: 'Cannot get latest version of redcap lambda function ($LATEST) will not work',
+        appliesTo: [`Resource::arn:aws:lambda:::function:${props.redcapLambdaObj.functionName}*`],
+      },
+    ]);
+    props.redcapLambdaObj.grantInvoke(getDataFromRedCapPyLambdaObj.currentVersion);
     getDataFromRedCapPyLambdaObj.addEnvironment(
       'REDCAP_LAMBDA_FUNCTION_NAME',
       props.redcapLambdaObj.functionName

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
@@ -164,12 +164,16 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
     Handle lambda permissions
     */
     // FIXME - cannot get the 'current' version of an IFunction object
-    NagSuppressions.addResourceSuppressions(<iam.Role>getDataFromRedCapPyLambdaObj.role, [
-      {
-        id: 'AwsSolutions-IAM5',
-        reason: 'Cannot get latest version of redcap lambda function ($LATEST) will not work',
-      },
-    ]);
+    NagSuppressions.addResourceSuppressions(
+      getDataFromRedCapPyLambdaObj,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'Cannot get latest version of redcap lambda function ($LATEST) will not work',
+        },
+      ],
+      true
+    );
     props.redcapLambdaObj.grantInvoke(getDataFromRedCapPyLambdaObj.currentVersion);
     getDataFromRedCapPyLambdaObj.addEnvironment(
       'REDCAP_LAMBDA_FUNCTION_NAME',

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
@@ -165,9 +165,8 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
     // FIXME - cannot get the 'current' version of an IFunction object
     NagSuppressions.addResourceSuppressions(getDataFromRedCapPyLambdaObj, [
       {
-        id: 'AwsSolutions-IAM5[Resource::*',
+        id: 'AwsSolutions-IAM5',
         reason: 'Cannot get latest version of redcap lambda function ($LATEST) will not work',
-        appliesTo: [`Resource::arn:aws:lambda:::function:${props.redcapLambdaObj.functionName}*`],
       },
     ]);
     props.redcapLambdaObj.grantInvoke(getDataFromRedCapPyLambdaObj.currentVersion);

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
@@ -163,6 +163,11 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
     /*
     Handle lambda permissions
     */
+    props.redcapLambdaObj.grantInvoke(getDataFromRedCapPyLambdaObj.currentVersion);
+    getDataFromRedCapPyLambdaObj.addEnvironment(
+      'REDCAP_LAMBDA_FUNCTION_NAME',
+      props.redcapLambdaObj.functionName
+    );
     // FIXME - cannot get the 'current' version of an IFunction object
     NagSuppressions.addResourceSuppressions(
       getDataFromRedCapPyLambdaObj,
@@ -173,11 +178,6 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
         },
       ],
       true
-    );
-    props.redcapLambdaObj.grantInvoke(getDataFromRedCapPyLambdaObj.currentVersion);
-    getDataFromRedCapPyLambdaObj.addEnvironment(
-      'REDCAP_LAMBDA_FUNCTION_NAME',
-      props.redcapLambdaObj.functionName
     );
 
     // Allow the getPieriandxDataFilesPyLambdaObj to read the secret

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/index.ts
@@ -107,6 +107,7 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
       index: 'get_data_from_redcap.py',
       handler: 'handler',
       timeout: Duration.seconds(60),
+      memorySize: 2048,
     });
 
     const getDeidentifiedCaseMetadataPyLambdaObj = new PythonFunction(
@@ -118,6 +119,7 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
         architecture: lambda.Architecture.ARM_64,
         index: 'get_deidentified_case_metadata.py',
         handler: 'handler',
+        memorySize: 1024,
       }
     );
     const getIdentifiedCaseMetadataPyLambdaObj = new PythonFunction(
@@ -129,6 +131,7 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
         architecture: lambda.Architecture.ARM_64,
         index: 'get_identified_case_metadata.py',
         handler: 'handler',
+        memorySize: 1024,
       }
     );
     const getPieriandxDataFilesPyLambdaObj = new PythonFunction(
@@ -144,6 +147,7 @@ export class Cttsov2CompleteToPieriandxConstruct extends Construct {
         environment: {
           ICAV2_ACCESS_TOKEN_SECRET_ID: props.icav2AccessTokenSecretObj.secretName,
         },
+        memorySize: 1024,
       }
     );
     const getProjectInfoPyLambdaObj = new PythonFunction(this, 'getProjectInfoPyLambdaObj', {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
@@ -25,7 +25,8 @@ if typing.TYPE_CHECKING:
 
 # Set logger
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+logger = logging.getLogger()
+logger.setLevel(level=logging.INFO)
 
 # Globals
 AUS_TIMEZONE = pytz.timezone("Australia/Melbourne")
@@ -288,10 +289,10 @@ def handler(event, context) -> Dict:
     :return:
     """
     # Wait for lambda to warm up
-    print("Warming up redcap lambda")
+    logger.info("Warming up redcap lambda")
     while not warm_up_lambda():
         sleep(10)
-    print("Redcap lambda warmup complete!")
+    logger.info("Redcap lambda warmup complete!")
 
     # Return
     try:

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
@@ -7,6 +7,7 @@ We really only need the disease name if it exists
 """
 
 # Standard imports
+import logging
 import typing
 from typing import List
 from time import sleep
@@ -18,7 +19,6 @@ from botocore.exceptions import ClientError
 import json
 import pytz
 from datetime import datetime
-import logging
 
 if typing.TYPE_CHECKING:
     from mypy_boto3_lambda import LambdaClient
@@ -287,8 +287,10 @@ def handler(event, context) -> Dict:
     :return:
     """
     # Wait for lambda to warm up
+    logger.info("Warming up redcap lambda")
     while not warm_up_lambda():
         sleep(10)
+    logger.info("Redcap lambda warmup complete!")
 
     # Return
     try:
@@ -314,6 +316,42 @@ def handler(event, context) -> Dict:
 #             handler(
 #                 event={
 #                     "library_id": 'L2401380'
+#                 },
+#                 context=None
+#             ),
+#             indent=4
+#         )
+#     )
+#
+# # {
+# #     "redcap_data": {
+# #         "disease_id": 254637007,
+# #         "requesting_physicians_first_name": "XXX",
+# #         "requesting_physicians_last_name": "XXX",
+# #         "library_id": "L2401380",
+# #         "date_collected": "2024-09-06T23:00:00+1000",
+# #         "date_received": "2024-09-06T00:00:00+1000",
+# #         "patient_urn": "0038-61302",
+# #         "sample_type": "Patient Care Sample",
+# #         "disease_name": "Non-small cell lung cancer",
+# #         "gender": "Unknown",
+# #         "pierian_metadata_complete": "Complete"
+# #     },
+# #     "in_redcap": true
+# # }
+
+
+# if __name__ == '__main__':
+#     # Or 'umccr-staging' / 'umccr-production'
+#     environ['AWS_PROFILE'] = 'umccr-development'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     # Or 'redcap-apis-stg-lambda-function' / 'redcap-apis-prod-lambda-function'
+#     environ['REDCAP_LAMBDA_FUNCTION_NAME'] = 'redcap-apis-dev-lambda-function'
+#     print(
+#         json.dumps(
+#             handler(
+#                 event={
+#                     "library_id": 'L2401529'
 #                 },
 #                 context=None
 #             ),

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
@@ -86,6 +86,7 @@ def warm_up_lambda():
         )
         return True
     except ClientError as e:
+        print(f"Error warming up lambda: {e}")
         logger.info(f"Error warming up lambda: {e}")
         return False
 
@@ -287,10 +288,10 @@ def handler(event, context) -> Dict:
     :return:
     """
     # Wait for lambda to warm up
-    logger.info("Warming up redcap lambda")
+    print("Warming up redcap lambda")
     while not warm_up_lambda():
         sleep(10)
-    logger.info("Redcap lambda warmup complete!")
+    print("Redcap lambda warmup complete!")
 
     # Return
     try:
@@ -322,23 +323,6 @@ def handler(event, context) -> Dict:
 #             indent=4
 #         )
 #     )
-#
-# # {
-# #     "redcap_data": {
-# #         "disease_id": 254637007,
-# #         "requesting_physicians_first_name": "XXX",
-# #         "requesting_physicians_last_name": "XXX",
-# #         "library_id": "L2401380",
-# #         "date_collected": "2024-09-06T23:00:00+1000",
-# #         "date_received": "2024-09-06T00:00:00+1000",
-# #         "patient_urn": "0038-61302",
-# #         "sample_type": "Patient Care Sample",
-# #         "disease_name": "Non-small cell lung cancer",
-# #         "gender": "Unknown",
-# #         "pierian_metadata_complete": "Complete"
-# #     },
-# #     "in_redcap": true
-# # }
 
 
 # if __name__ == '__main__':
@@ -351,7 +335,7 @@ def handler(event, context) -> Dict:
 #         json.dumps(
 #             handler(
 #                 event={
-#                     "library_id": 'L2401529'
+#                     "library_id": "L2401529"
 #                 },
 #                 context=None
 #             ),

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_deidentified_case_metadata_py/get_deidentified_case_metadata.py
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_deidentified_case_metadata_py/get_deidentified_case_metadata.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # Globals
 AUS_TIMEZONE = pytz.timezone("Australia/Melbourne")
 AUS_TIME = datetime.now(AUS_TIMEZONE)
-AUS_TIME_AS_STR = f"{AUS_TIME.date().isoformat()}T{AUS_TIME.time().isoformat(timespec='seconds')}{AUS_TIME.strftime("%z")}"
+AUS_TIME_AS_STR = f"{AUS_TIME.date().isoformat()}T{AUS_TIME.time().isoformat(timespec='seconds')}{AUS_TIME.strftime('%z')}"
 
 DEFAULT_INDICATION = "NA"
 

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_deidentified_case_metadata_py/get_deidentified_case_metadata.py
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_deidentified_case_metadata_py/get_deidentified_case_metadata.py
@@ -28,7 +28,6 @@ Payload will look a bit like this:
 """
 
 # Imports
-import typing
 from typing import Dict
 
 import pytz


### PR DESCRIPTION
Note that this still doesn't seem to fix the issue.

https://ap-southeast-2.console.aws.amazon.com/states/home?region=ap-southeast-2#/v2/executions/details/arn:aws:states:ap-southeast-2:843407916570:execution:nails-cttsov2-complete-to-pdx-sfn:f9fde40f-5986-437a-80b5-adcc0f34f07e

Fails because the 'get recap info' step times out.  

Most recent logs don't show anything

https://ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252FOrcaBusBeta-StackyMcStack-cttsov2topieriandxgetDat-K0RFO3ts0afo/log-events/2024$252F10$252F31$252F$255B7$255Dd4b12f54af964991a4c0244662496c1f

Max memory used is only about 116 Mb, far shy of the 2048 limit.
