### PR TITLE
Need to set 'keep_flowcell_layout' to true for wrapica collection of runinfo xml

### DIFF
--- a/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/runinfo/runinfo_helper.py
+++ b/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/runinfo/runinfo_helper.py
@@ -90,7 +90,8 @@ def read_runinfo_xml(project_id: str, data_id: str) -> Dict:
                 project_id=project_id,
                 data_id=data_id
             )
-        )
+        ),
+        keep_flowcell_layout=True
     )
 
 

--- a/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/samplesheet/samplesheet_helper.py
+++ b/lib/workload/stateless/stacks/bclconvert-manager/translator_service/helper/samplesheet/samplesheet_helper.py
@@ -120,7 +120,7 @@ def read_v2_samplesheet(
     )
 
     # And now append the lane attribute to every
-    v2_samplesheet_dict['bclconvert_data'] = flatten(
+    v2_samplesheet_dict['bclconvert_data'] = list(flatten(
         map(
             lambda bclconvert_data_row_iter: list(
                 map(
@@ -133,6 +133,6 @@ def read_v2_samplesheet(
             ),
             v2_samplesheet_dict['bclconvert_data']
         ),
-    )
+    ))
 
     return v2_samplesheet_dict


### PR DESCRIPTION
Tested with 

```
num_lanes = get_num_lanes_from_run_info(
        project_id="9ec02c1f-53ba-47a5-854d-e6b53101adb7",
        data_id="fil.7d86703bc9e2424c441d08dcf9e059fc"  #/ilmn-runs/bssh_aps2-sh-prod_4515537/RunInfo.xml
    )
)

print(num_lanes)

v2_samplesheet_dict = v2_samplesheet_reader(
    StringIO(
        read_icav2_file_contents_to_string(
            project_id="9ec02c1f-53ba-47a5-854d-e6b53101adb7",
            data_id="fil.b4534c47c0d5481075d308dcfabfb3a9"  #/ilmn-runs/bssh_aps2-sh-prod_4515537/SampleSheet.csv
        )
    )
)

# And now append the lane attribute to every
v2_samplesheet_dict['bclconvert_data'] = list(flatten(
    map(
        lambda bclconvert_data_row_iter: list(
            map(
                lambda lane_iter: {
                    **bclconvert_data_row_iter,
                    **{"lane": lane_iter + 1}
                },
                range(num_lanes)
            )
        ),
        v2_samplesheet_dict['bclconvert_data']
    ),
))

print(
    json.dumps(
        v2_samplesheet_dict,
        indent=4
    )
)
```

Returns

```
4

{
    "header": {
        "file_format_version": 2,
    ....
}
```