### PR TITLE
Fix (MM): Allow nullable description for sync

### DIFF
--- a/lib/workload/stateless/stacks/metadata-manager/app/viewsets/sync.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/viewsets/sync.py
@@ -79,7 +79,7 @@ class SyncViewSet(ViewSet):
             Payload=json.dumps({
                 "url": serializer.data['presigned_url'],
                 "user_id": requester_email,
-                "reason": serializer.data['reason']
+                "reason": serializer.data.get('reason', None)
             })
         )
 


### PR DESCRIPTION
Will allow description to be `None`

Related #627