### PR TITLE
PierianDx Production Fixes

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -560,7 +560,7 @@ export const pieriandxDagSsmParameterPath = '/umccr/orcabus/stateful/pieriandx/d
 /*
 "s3://pdx-cgwxfer-test/melbournetest" // development
 "s3://pdx-cgwxfer-test/melbournetest" // staging
-"s3://pdx-cgwxfer/melbourne" // production
+"s3://pdx-xfer/melbourne" // production
 */
 export const pieriandxS3SequencerRunRootSsmParameterPath =
   '/umccr/orcabus/pieriandx/s3_sequencer_run_root';

--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/deploy/index.ts
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/deploy/index.ts
@@ -157,7 +157,7 @@ export class PieriandxPipelineManagerStack extends cdk.Stack {
         handler: 'handler',
         memorySize: 1024,
         layers: [lambdaLayerObj.lambdaLayerVersionObj],
-        timeout: Duration.seconds(20),
+        timeout: Duration.seconds(60),
         environment: icav2Envs,
       }
     );

--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/deploy/index.ts
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/deploy/index.ts
@@ -13,6 +13,7 @@ import { PythonFunction } from '@aws-cdk/aws-lambda-python-alpha';
 import { Duration } from 'aws-cdk-lib';
 import { PieriandxMonitorRunsStepFunctionStateMachineConstruct } from './constructs/pieriandx_monitor_runs_step_function';
 import { PythonLambdaLayerConstruct } from '../../../../components/python-lambda-layer';
+import { NagSuppressions } from 'cdk-nag';
 
 export interface PierianDxPipelineManagerConfig {
   /* DynamoDB Table */
@@ -208,6 +209,7 @@ export class PieriandxPipelineManagerStack extends cdk.Stack {
         memorySize: 1024,
         layers: [lambdaLayerObj.lambdaLayerVersionObj],
         environment: pieriandxEnvs,
+        timeout: Duration.seconds(60),
       }
     );
 
@@ -286,30 +288,40 @@ export class PieriandxPipelineManagerStack extends cdk.Stack {
       getInformaticsjobAndReportStatusLambdaObj,
     ].forEach((lambdaFunction) => {
       // Give the lambda permission to access the pieriandx apis
-      pieriandxTokenCollectionLambdaObj.latestVersion.grantInvoke(lambdaFunction);
+      // Fixme, no way to give access to only the current version
+      pieriandxTokenCollectionLambdaObj.grantInvoke(lambdaFunction.currentVersion);
+      NagSuppressions.addResourceSuppressions(
+        lambdaFunction,
+        [
+          {
+            id: 'AwsSolutions-IAM5',
+            reason:
+              'Cannot get latest version of pieriandx collect access token function ($LATEST) will not work',
+          },
+        ],
+        true
+      );
     });
 
     /*
-        Give the upload lambda access to the pieriandx s3 bucket
-        */
-    // @ts-ignore
+    Give the upload lambda access to the pieriandx s3 bucket
+    */
     pieriandxS3AccessTokenSecretObj.grantRead(uploadDataToS3LambdaObj);
 
     /*
-        Give the lambdas permission to access the icav2 apis
-        */
+    Give the lambdas permission to access the icav2 apis
+    */
     [
       generatePieriandxObjectsLambdaObj,
       generateSamplesheetLambdaObj,
       uploadDataToS3LambdaObj,
     ].forEach((lambdaFunction) => {
-      // @ts-ignore
       icav2AccessTokenSecretObj.grantRead(lambdaFunction);
     });
 
     /*
-        Generate State Machines
-        */
+      Generate State Machines
+      */
 
     /* Generate case creation statemachine object */
     const pieriandxLaunchCaseCreationStateMachine =

--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/lambdas/get_informaticsjob_and_report_status_py/get_informaticsjob_and_report_status.py
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/lambdas/get_informaticsjob_and_report_status_py/get_informaticsjob_and_report_status.py
@@ -200,7 +200,7 @@ def handler(event, context):
             "S": job_status
         },
         ":report_id": {
-            "S": reportjob_obj.get("id")
+            "N": reportjob_obj.get("id")
         },
         ":report_status": {
             "S": report_status

--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/lambdas/upload_pieriandx_sample_data_to_s3_py/upload_pieriandx_sample_data_to_s3.py
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/lambdas/upload_pieriandx_sample_data_to_s3_py/upload_pieriandx_sample_data_to_s3.py
@@ -23,14 +23,21 @@ Input will look like this
 
 """
 
+# Standard imports
 from tempfile import TemporaryDirectory
 from pathlib import Path
 from urllib.parse import urlparse
 from wrapica.project_data import read_icav2_file_contents, convert_uri_to_project_data_obj
+import logging
 
+# Layer imports
 from pieriandx_pipeline_tools.utils.s3_helpers import set_s3_access_cred_env_vars, upload_file
 from pieriandx_pipeline_tools.utils.secretsmanager_helpers import set_icav2_env_vars
 from pieriandx_pipeline_tools.utils.compression_helpers import decompress_file
+
+# Logger
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 
 def handler(event, context):
@@ -107,3 +114,21 @@ def handler(event, context):
 #         },
 #         None
 #     )
+
+# if __name__ == "__main__":
+#     from os import environ
+#     environ["AWS_PROFILE"] = 'umccr-production'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     environ["ICAV2_ACCESS_TOKEN_SECRET_ID"] = "ICAv2JWTKey-umccr-prod-service-production"
+#     environ['PIERIANDX_S3_ACCESS_CREDENTIALS_SECRET_ID'] = "PierianDx/S3Credentials"
+#
+#     handler(
+#         {
+#           "needs_decompression": False,
+#           "src_uri": "s3://pipeline-prod-cache-503977275616-ap-southeast-2/byob-icav2/production/analysis/cttsov2/202411053da6481e/Results/L2401560/L2401560_MetricsOutput.tsv",
+#           "contents": None,
+#           "dest_uri": "s3://pdx-xfer/melbourne/241101_A01052_0236_BHVJNMDMXY__L2401560__V2__20241105f6bc3fb9__20241105f6bc3fb9/Data/Intensities/BaseCalls/L2401560_MetricsOutput.tsv"
+#         },
+#         None
+#     )
+#

--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/layers/src/pieriandx_pipeline_tools/utils/s3_helpers.py
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/layers/src/pieriandx_pipeline_tools/utils/s3_helpers.py
@@ -24,7 +24,14 @@ def get_s3_client() -> 'S3Client':
 
 def upload_file(bucket: str, key: str, input_file_path: Path) -> None:
     s3 = get_s3_client()
-    s3.upload_file(str(input_file_path), bucket, key.lstrip("/"))
+    s3.upload_file(
+        str(input_file_path),
+        bucket,
+        key.lstrip("/"),
+        ExtraArgs={
+            'ServerSideEncryption': 'AES256'
+        }
+    )
 
 
 def set_s3_access_cred_env_vars():

--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/step_function_templates/launch_pieriandx.asl.json
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/step_function_templates/launch_pieriandx.asl.json
@@ -402,10 +402,13 @@
                   "id.$": "$.workflow_inputs.portalRunId",
                   "id_type": "portal_run_id"
                 },
-                "UpdateExpression": "SET engine_parameters = :engine_parameters",
+                "UpdateExpression": "SET engine_parameters = :engine_parameters, workflow_status = :workflow_status",
                 "ExpressionAttributeValues": {
                   ":engine_parameters": {
                     "S.$": "States.JsonToString($.set_engine_parameters_step.engine_parameters)"
+                  },
+                  ":workflow_status": {
+                    "S": "RUNNING"
                   }
                 }
               },

--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/step_function_templates/launch_pieriandx.asl.json
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/step_function_templates/launch_pieriandx.asl.json
@@ -85,7 +85,7 @@
               "Type": "Choice",
               "Choices": [
                 {
-                  "Variable": "$.workflowInputs.panelName",
+                  "Variable": "$.workflow_inputs.payload.data.inputs.panelVersion",
                   "IsPresent": true,
                   "Next": "Get Panel Name from inputs",
                   "Comment": "Panel Name is set"
@@ -105,7 +105,7 @@
               "Type": "Pass",
               "Next": "Get Panel Name Value from SSM Parameter",
               "Parameters": {
-                "panel_name.$": "$.workflow_inputs.panelName"
+                "panel_name.$": "$.workflow_inputs.payload.data.inputs.panelVersion"
               },
               "ResultPath": "$.get_panel_name_step"
             },

--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/step_function_templates/monitor_runs.asl.json
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/step_function_templates/monitor_runs.asl.json
@@ -212,7 +212,7 @@
                 "job_id.$": "$.get_portal_run_db_step.Item.informaticsjob_id.N",
                 "case_accession_number.$": "$.get_portal_run_db_step.Item.case_accession_number.S",
                 "report_id.$": "$.get_portal_run_db_step.Item.report_id.N",
-                "pieriandx_base_url": "https://app.uat.pieriandx.com/cgw-api/v2.0.0",
+                "pieriandx_base_url": "${__pieriandx_base_url__}",
                 "sample_name.$": "$.get_portal_run_db_step.Item.sample_name.S"
               }
             },
@@ -252,7 +252,7 @@
                     "workflowName": "${__workflow_name__}",
                     "workflowVersion": "${__workflow_version__}",
                     "workflowRunName.$": "$.get_portal_run_db_step.Item.workflow_run_name.S",
-                    "linkedLibraries.$": "States.StringToJson($.get_portal_run_db_step.Item.linkedLibraries.S)",
+                    "linkedLibraries.$": "States.StringToJson($.get_portal_run_db_step.Item.linked_libraries.S)",
                     "payload": {
                       "version": "${__payload_version__}",
                       "data.$": "$.get_data_payload_step.data_payload"

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
@@ -130,8 +130,8 @@ def launch_redcap_raw_lambda(library_id: str) -> pd.DataFrame:
     # Rename columns
     redcap_raw_df.rename(
         columns={
-            "clinician_firstname": "requesting_physicians_first_name",
-            "clinician_lastname": "requesting_physicians_last_name",
+            "clinician_firstname": "requesting_physician_first_name",
+            "clinician_lastname": "requesting_physician_last_name",
             "libraryid": "library_id",
             "mrn": "patient_urn",
             "disease": "disease_id",

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_2/cttso-v2-output-to-pieriandx-ready-event/lambdas/get_data_from_redcap_py/get_data_from_redcap.py
@@ -257,8 +257,8 @@ def get_and_merge_raw_and_label_data(library_id: str) -> Dict:
     redcap_raw_df = redcap_raw_df[
         [
             "disease_id",
-            "requesting_physicians_first_name",
-            "requesting_physicians_last_name",
+            "requesting_physician_first_name",
+            "requesting_physician_last_name",
             "library_id",
             "date_collected",
             "date_received",


### PR DESCRIPTION
* Prod PierianDx bucket requires KMS encryption
* Can't use LATEST version for invocation of 'collectPierianDxAccessToken'
	* Use '*' on function name followed by NagSuppression
* Fix SSM parameter determining the path of the PierianDx bucket
* Differences between requesting_physicians_x_name and requetsing_physician_x_name was causing default name to be used (Sean)
* Wrong JSON path used in SFN to collect the panel version
* Report ID stored in database as an integer not as a string
* Fixed GET for linked libraries which had an incorrect JSON path when pushing a workflow run state change event
* Fixed analysis path generation for data outputs

P.S have already pushed this to OrcaBus Prod manually