### PR TITLE
Update dragen somatic pipeline id

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -334,7 +334,7 @@ TN Stateless stack
 */
 
 // Deployed under dev/stg/prod
-export const tnIcav2PipelineIdSSMParameterPath = '/icav2/umccr-prod/tumor_normal_4.2.4_pipeline_id'; // 0f5575bc-6cf8-4a90-a80e-05088aae8ed7
+export const tnIcav2PipelineIdSSMParameterPath = '/icav2/umccr-prod/tumor_normal_4.2.4_pipeline_id'; // 6ce2b636-ba2f-4004-8065-f3557f286c98
 export const tnIcav2PipelineWorkflowType = 'tumor-normal';
 export const tnIcav2PipelineWorkflowTypeVersion = '4.2.4';
 export const tnIcav2ServiceVersion = '2024.07.01';

--- a/lib/workload/stateless/stacks/tumor-normal-pipeline-manager/lambdas/get_boolean_parameters_from_event_input_py/get_boolean_parameters_from_event_input.py
+++ b/lib/workload/stateless/stacks/tumor-normal-pipeline-manager/lambdas/get_boolean_parameters_from_event_input_py/get_boolean_parameters_from_event_input.py
@@ -19,12 +19,15 @@ def handler(event, context) -> Dict[str, Dict]:
 
     # Get the boolean parameters from the event input
     cwl_parameter_dict: Dict = {
+        # Write normal bam in somatic workflow
+        # But take the vcf from the germline workflow
         "enable_map_align_somatic": True,
         "enable_map_align_output_somatic": event_data_input.get('enableMapAlignOutput', True),
         "enable_map_align_germline": True,
         "enable_map_align_output_germline": False,
         "enable_duplicate_marking": event_data_input.get('enableDuplicateMarking', True),
         "enable_cnv_somatic": event_data_input.get('enableCnvSomatic', None),
+        # HRD is somatic Only
         "enable_hrd": event_data_input.get('enableHrdSomatic', None),
         "enable_sv_somatic": event_data_input.get('enableSvSomatic', None),
         "cnv_use_somatic_vc_baf": event_data_input.get('cnvUseSomaticVcBaf', None)


### PR DESCRIPTION
Dragen somatic with germline pipeline didn't have the enable_cnv_somatic flag available in the workflow (and in the past we have just used enable_cnv), since we do not need the cnv on the germline calls we use just enable_cnv_somatic instead.

Updated ssm parameter in dev/stg and prod