### PR TITLE
Fix(mm): Broken Comparison on Update

### DIFF
--- a/lib/workload/stateless/stacks/metadata-manager/app/models/base.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/models/base.py
@@ -106,7 +106,8 @@ class BaseManager(models.Manager):
         try:
             obj = self.get(**search_key)
             for key, value in data.items():
-                if getattr(obj, key) != value:
+                # compare both value in str format to avoid any type mismatch
+                if str(getattr(obj, key)) != str(value):
                     setattr(obj, key, value)
                     is_updated = True
         except self.model.DoesNotExist:


### PR DESCRIPTION
The comparison is broken because the tracking sheet is all string and coverage is stored in float. It will then think this is always an update although the values are the same.

Fix #690 