### PR TITLE
feat(filemanager): add fastq bucket to ingester event source

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -91,6 +91,11 @@ export const icav2ArchiveAnalysisBucket: Record<AppStage.PROD, string> = {
   [AppStage.PROD]: 'archive-prod-analysis-503977275616-ap-southeast-2',
 };
 
+// The fastq bucket. Noting that this is only present for prod data.
+export const icav2ArchiveFastqBucket: Record<AppStage.PROD, string> = {
+  [AppStage.PROD]: 'archive-prod-fastq-503977275616-ap-southeast-2',
+};
+
 export const gdsBsRunsUploadLogPath: Record<AppStage, string> = {
   [AppStage.BETA]: 'gds://development/primary_data/temp/bs_runs_upload_tes/',
   [AppStage.GAMMA]: 'gds://staging/primary_data/temp/bs_runs_upload_tes/',

--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -15,6 +15,7 @@ import {
   eventSchemaRegistryName,
   eventSourceQueueName,
   icav2ArchiveAnalysisBucket,
+  icav2ArchiveFastqBucket,
   icav2PipelineCacheBucket,
   oncoanalyserBucket,
   rdsMasterSecretName,
@@ -110,6 +111,10 @@ const getEventSourceConstructProps = (stage: AppStage): EventSourceProps => {
   if (stage === AppStage.PROD) {
     props.rules.push({
       bucket: icav2ArchiveAnalysisBucket[stage],
+      eventTypes: ['Object Created', 'Object Deleted'],
+    });
+    props.rules.push({
+      bucket: icav2ArchiveFastqBucket[stage],
       eventTypes: ['Object Created', 'Object Deleted'],
     });
   }


### PR DESCRIPTION
Similar to https://github.com/umccr/orcabus/pull/625

### Changes
* Adds fastq bucket as event source for filemanager.

I think this will need a change to the role similar to [this](https://github.com/umccr/infrastructure/blob/586a87926c90f9c913170096f5670105586abd4f/terraform/stacks/unimelb/data_archive/analysis_archive.tf#L76-L101)?