### PR TITLE
add distinct to remove duplicate results

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/viewsets/workflow_run.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/viewsets/workflow_run.py
@@ -94,7 +94,7 @@ class WorkflowRunViewSet(BaseViewSet):
                 Q(libraries__library_id__icontains=search_params) |
                 Q(libraries__orcabus_id__icontains=search_params) |
                 Q(workflow__workflow_name__icontains=search_params)
-            )
+            ).distinct() # Add distinct to remove duplicates
             
         return result_set
 


### PR DESCRIPTION
### Fix
Duplicate workflows when using workflow search: https://github.com/umccr/orca-ui/issues/82

### Analysis
The duplicate results occur because of the OR conditions in the search query combined with the related table joins. And The duplicate results occur selectively because of how JOIN operations work with OR conditions in the search query. 
No Duplicates Case:
```sql
-- When searching only direct fields (workflow_run_name or comment)
-- Example search: "test" matching workflow_run_name
SELECT * FROM workflow_run 
WHERE workflow_run_name ILIKE '%test%'
-- No JOINs needed = No duplicates
```
Duplicates Case:
```sql
-- When searching related fields (libraries or workflow)
-- Example search: "oncoanalyser_wgs" matching multiple libraries
SELECT workflow_run.* 
FROM workflow_run 
JOIN libraries ON workflow_run.id = libraries.workflow_run_id
WHERE libraries.library_id ILIKE '%oncoanalyser_wgs%'
-- One workflow_run might have multiple matching libraries = Duplicates
```

🥲 So, to be simple, in our case, if there are multiple libraries related to that workflow_run, there will be duplicate case of search results.