### PR TITLE
Retry 5 mins when capacity is limited

### DIFF
--- a/lib/workload/components/gzip-raw-md5sum-fq-pair-sfn/step_functions_templates/get_raw_md5sum_for_fastq_gzip_pair_template.asl.json
+++ b/lib/workload/components/gzip-raw-md5sum-fq-pair-sfn/step_functions_templates/get_raw_md5sum_for_fastq_gzip_pair_template.asl.json
@@ -67,6 +67,15 @@
               }
             },
             "TimeoutSeconds": 7200,
+            "Retry": [
+              {
+                "ErrorEquals": ["ECS.AmazonECSException"],
+                "BackoffRate": 2,
+                "IntervalSeconds": 300,
+                "MaxAttempts": 3,
+                "JitterStrategy": "FULL"
+              }
+            ],
             "ResultPath": "$.gzip_to_raw_md5sum_step_result",
             "Next": "Read md5sum output"
           },

--- a/lib/workload/components/ora-file-decompression-fq-pair-sfn/step_functions_templates/decompress_ora_fastq_pair_sfn_template.asl.json
+++ b/lib/workload/components/ora-file-decompression-fq-pair-sfn/step_functions_templates/decompress_ora_fastq_pair_sfn_template.asl.json
@@ -113,6 +113,15 @@
               }
             },
             "TimeoutSeconds": 7200,
+            "Retry": [
+              {
+                "ErrorEquals": ["ECS.AmazonECSException"],
+                "BackoffRate": 2,
+                "IntervalSeconds": 300,
+                "MaxAttempts": 3,
+                "JitterStrategy": "FULL"
+              }
+            ],
             "End": true
           },
           "Decompress ORA File": {


### PR DESCRIPTION
Backoff of 5 means a second retry will retry in five minutes, and then 25 minutes, then in 125 minutes

https://repost.aws/knowledge-center/ecs-fargate-runtask-capacity