### PR TITLE
Rate limit ora compression workflow

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -859,7 +859,7 @@ Resources used by the ora compression pipeline
 // Pipeline ID is: 5c1c2fa2-30dc-46ed-9e7f-dc4fefac77b6
 // deployed to dev, stg and prod
 export const oraCompressionIcav2PipelineIdSSMParameterPath =
-  '/icav2/umccr-prod/ora_compression_pipeline_id'; // 5c1c2fa2-30dc-46ed-9e7f-dc4fefac77b6
+  '/icav2/umccr-prod/ora_compression_pipeline_id'; // 0540fca4-cc40-45ac-88e2-d32df69c6954
 
 // Default Reference Uri for compressing ORA files
 // Reference URI is icav2://reference-data/dragen-ora/v2/ora_reference_v2.tar.gz

--- a/lib/workload/components/gzip-raw-md5sum-fq-pair-sfn/step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json
+++ b/lib/workload/components/gzip-raw-md5sum-fq-pair-sfn/step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json
@@ -1,0 +1,38 @@
+{
+  "Comment": "Task Backoff SFN",
+  "StartAt": "ListTasks",
+  "States": {
+    "ListTasks": {
+      "Type": "Task",
+      "Parameters": {
+        "Cluster": "${__cluster_arn__}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ecs:listTasks",
+      "ResultSelector": {
+        "num_tasks_running.$": "States.ArrayLength($.TaskArns)"
+      },
+      "ResultPath": "$.get_num_tasks_step",
+      "Next": "Over 400 tasks running"
+    },
+    "Over 400 tasks running": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.get_num_tasks_step.num_tasks_running",
+          "NumericGreaterThan": 400,
+          "Next": "Sleep a minute",
+          "Comment": "More than 400 tasks running"
+        }
+      ],
+      "Default": "Success"
+    },
+    "Sleep a minute": {
+      "Type": "Wait",
+      "Seconds": 60,
+      "Next": "ListTasks"
+    },
+    "Success": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/lib/workload/components/gzip-raw-md5sum-fq-pair-sfn/step_functions_templates/get_raw_md5sum_for_fastq_gzip_pair_template.asl.json
+++ b/lib/workload/components/gzip-raw-md5sum-fq-pair-sfn/step_functions_templates/get_raw_md5sum_for_fastq_gzip_pair_template.asl.json
@@ -4,7 +4,7 @@
   "States": {
     "Convert Fastq List Row GZ URIs to Array": {
       "Type": "Pass",
-      "Next": "Decompress GZIP Files",
+      "Next": "Wait for Task Availability",
       "Parameters": {
         "gzip_files_map": [
           {
@@ -18,6 +18,16 @@
         ]
       },
       "ResultPath": "$.fastq_list_row_as_map"
+    },
+    "Wait for Task Availability": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::states:startExecution.sync:2",
+      "Parameters": {
+        "StateMachineArn": "${__ecs_task_rate_limit_sfn_arn__}",
+        "Input": {}
+      },
+      "Next": "Decompress GZIP Files",
+      "ResultPath": null
     },
     "Decompress GZIP Files": {
       "Type": "Map",
@@ -71,8 +81,15 @@
               {
                 "ErrorEquals": ["ECS.AmazonECSException"],
                 "BackoffRate": 2,
-                "IntervalSeconds": 300,
-                "MaxAttempts": 3,
+                "IntervalSeconds": 3600,
+                "MaxAttempts": 5,
+                "JitterStrategy": "FULL"
+              },
+              {
+                "ErrorEquals": ["States.TaskFailed"],
+                "BackoffRate": 2,
+                "IntervalSeconds": 3600,
+                "MaxAttempts": 5,
                 "JitterStrategy": "FULL"
               }
             ],

--- a/lib/workload/components/ora-file-decompression-fq-pair-sfn/index.ts
+++ b/lib/workload/components/ora-file-decompression-fq-pair-sfn/index.ts
@@ -77,6 +77,45 @@ export class OraDecompressionConstruct extends Construct {
       }),
     });
 
+    // Set up the step function for rate limiting the number of tasks running simultaneously
+    const rateLimitStateMachine = new sfn.StateMachine(this, 'RateLimitStateMachine', {
+      stateMachineName: `${props.sfnPrefix}-ecs-limiter-sfn`,
+      definitionBody: sfn.DefinitionBody.fromFile(
+        path.join(
+          __dirname,
+          'step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json'
+        )
+      ),
+      definitionSubstitutions: {
+        __cluster_arn__: cluster.clusterArn,
+      },
+    });
+
+    // Allow the rate limit state machine to list the ECS tasks
+    // in the cluster
+    rateLimitStateMachine.addToRolePolicy(
+      new iam.PolicyStatement({
+        resources: ['*'],
+        actions: ['ecs:ListTasks'],
+        conditions: {
+          ArnEquals: {
+            'ecs:cluster': cluster.clusterArn,
+          },
+        },
+      })
+    );
+
+    NagSuppressions.addResourceSuppressions(
+      rateLimitStateMachine,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason: 'Give permissions to resources *, to list tasks with condition on ecs cluster',
+        },
+      ],
+      true
+    );
+
     // Set up step function
     // Build state machine object
     this.sfnObject = new sfn.StateMachine(this, 'state_machine', {
@@ -96,8 +135,39 @@ export class OraDecompressionConstruct extends Construct {
         __ora_container_name__: oraDecompressionContainer.containerName,
         __subnets__: cluster.vpc.privateSubnets.map((subnet) => subnet.subnetId).join(','),
         __sg_group__: securityGroup.securityGroupId,
+        /* Child step functions */
+        __ecs_task_rate_limit_sfn_arn__: rateLimitStateMachine.stateMachineArn,
       },
     });
+
+    // Grant permissions to the state machine
+    rateLimitStateMachine.grantStartExecution(this.sfnObject);
+    rateLimitStateMachine.grantRead(this.sfnObject);
+
+    // Because we run a nested state machine, we need to add the permissions to the state machine role
+    // See https://stackoverflow.com/questions/60612853/nested-step-function-in-a-step-function-unknown-error-not-authorized-to-cr
+    this.sfnObject.addToRolePolicy(
+      new iam.PolicyStatement({
+        resources: [
+          `arn:aws:events:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule`,
+        ],
+        actions: ['events:PutTargets', 'events:PutRule', 'events:DescribeRule'],
+      })
+    );
+
+    // https://docs.aws.amazon.com/step-functions/latest/dg/connect-stepfunctions.html#sync-async-iam-policies
+    // Polling requires permission for states:DescribeExecution
+    NagSuppressions.addResourceSuppressions(
+      this.sfnObject,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason:
+            'grantRead uses asterisk at the end of executions, as we need permissions for all execution invocations',
+        },
+      ],
+      true
+    );
 
     // Allow step function to run the ECS task
     taskDefinition.grantRun(this.sfnObject);

--- a/lib/workload/components/ora-file-decompression-fq-pair-sfn/step_functions_templates/decompress_ora_fastq_pair_sfn_template.asl.json
+++ b/lib/workload/components/ora-file-decompression-fq-pair-sfn/step_functions_templates/decompress_ora_fastq_pair_sfn_template.asl.json
@@ -15,7 +15,7 @@
     },
     "Convert Fastq List Row ORA Validation to Array": {
       "Type": "Pass",
-      "Next": "Decompress ORA Files",
+      "Next": "Wait for Task Availability",
       "Parameters": {
         "ora_files_map": [
           {
@@ -32,7 +32,7 @@
     },
     "Convert Fastq List Row ORA to Array": {
       "Type": "Pass",
-      "Next": "Decompress ORA Files",
+      "Next": "Wait for Task Availability",
       "Parameters": {
         "ora_files_map": [
           {
@@ -48,6 +48,16 @@
         ]
       },
       "ResultPath": "$.fastq_list_row_as_map"
+    },
+    "Wait for Task Availability": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::states:startExecution.sync:2",
+      "Parameters": {
+        "StateMachineArn": "${__ecs_task_rate_limit_sfn_arn__}",
+        "Input": {}
+      },
+      "Next": "Decompress ORA Files",
+      "ResultPath": null
     },
     "Decompress ORA Files": {
       "Type": "Map",
@@ -117,8 +127,15 @@
               {
                 "ErrorEquals": ["ECS.AmazonECSException"],
                 "BackoffRate": 2,
-                "IntervalSeconds": 300,
-                "MaxAttempts": 3,
+                "IntervalSeconds": 3600,
+                "MaxAttempts": 5,
+                "JitterStrategy": "FULL"
+              },
+              {
+                "ErrorEquals": ["States.TaskFailed"],
+                "BackoffRate": 2,
+                "IntervalSeconds": 3600,
+                "MaxAttempts": 2,
                 "JitterStrategy": "FULL"
               }
             ],

--- a/lib/workload/components/ora-file-decompression-fq-pair-sfn/step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json
+++ b/lib/workload/components/ora-file-decompression-fq-pair-sfn/step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json
@@ -1,0 +1,38 @@
+{
+  "Comment": "Task Backoff SFN",
+  "StartAt": "ListTasks",
+  "States": {
+    "ListTasks": {
+      "Type": "Task",
+      "Parameters": {
+        "Cluster": "${__cluster_arn__}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ecs:listTasks",
+      "ResultSelector": {
+        "num_tasks_running.$": "States.ArrayLength($.TaskArns)"
+      },
+      "ResultPath": "$.get_num_tasks_step",
+      "Next": "Over 400 tasks running"
+    },
+    "Over 400 tasks running": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.get_num_tasks_step.num_tasks_running",
+          "NumericGreaterThan": 400,
+          "Next": "Sleep a minute",
+          "Comment": "More than 400 tasks running"
+        }
+      ],
+      "Default": "Success"
+    },
+    "Sleep a minute": {
+      "Type": "Wait",
+      "Seconds": 60,
+      "Next": "ListTasks"
+    },
+    "Success": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/lib/workload/stateless/stacks/ora-compression-manager/deploy/index.ts
+++ b/lib/workload/stateless/stacks/ora-compression-manager/deploy/index.ts
@@ -171,7 +171,7 @@ export class OraCompressionIcav2PipelineManagerStack extends cdk.Stack {
       this,
       'gzip_raw_md5sum_single',
       {
-        sfnPrefix: props.stateMachinePrefix,
+        sfnPrefix: `${props.stateMachinePrefix}-gzip`,
         icav2AccessTokenSecretId: icav2AccessTokenSecretObj.secretName,
       }
     ).sfnObject;
@@ -385,7 +385,7 @@ export class OraCompressionIcav2PipelineManagerStack extends cdk.Stack {
 
     // Generate an ora decompression construct
     const oraDecompressionSfn = new OraDecompressionConstruct(this, 'ora_decompression', {
-      sfnPrefix: props.stateMachinePrefix,
+      sfnPrefix: `${props.stateMachinePrefix}-ora`,
       icav2AccessTokenSecretId: icav2AccessTokenSecretObj.secretName,
     }).sfnObject;
 
@@ -498,6 +498,9 @@ export class OraCompressionIcav2PipelineManagerStack extends cdk.Stack {
         /* Table */
         __table_name__: dynamodbTableObj.tableName,
         __portal_run_id_table_partition_name__: this.globals.tablePartitionNames.portalRunId,
+        /* Lambdas */
+        __set_outputs_json_lambda_function_arn__:
+          setOutputsJsonLambdaFunctionObj.currentVersion.functionArn,
         /* Step functions */
         __rate_limit_get_raw_md5sums_ora_sfn_arn__: oraRawMd5sumRateLimitSfnObj.stateMachineArn,
         __get_raw_md5sums_for_fastq_ora_pair_sfn_arn__:

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/get_raw_md5sum_for_all_fastq_gzips_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/get_raw_md5sum_for_all_fastq_gzips_sfn_template.asl.json
@@ -1,0 +1,75 @@
+{
+  "Comment": "Launch Icav2 Pipeline and log in db",
+  "StartAt": "For each rgid",
+  "States": {
+    "For each rgid": {
+      "Type": "Map",
+      "ItemsPath": "$.rgid_list",
+      "ItemSelector": {
+        "rgid_pair.$": "$$.Map.Item.Value"
+      },
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "DynamoDB Get Fastq RGID",
+        "States": {
+          "DynamoDB Get Fastq RGID": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::dynamodb:getItem",
+            "Parameters": {
+              "TableName": "${__table_name__}",
+              "Key": {
+                "id.$": "$.rgid_pair.rgid",
+                "id_type": "${__fastq_list_row_table_partition_name__}"
+              }
+            },
+            "ResultPath": "$.get_fastq_rgid_from_dynamodb_step",
+            "Next": "Get Raw MD5sum for fastq gzip pair"
+          },
+          "Get Raw MD5sum for fastq gzip pair": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::states:startExecution.sync:2",
+            "Parameters": {
+              "StateMachineArn": "${__gzip_raw_md5sum_sfn_arn__}",
+              "Input": {
+                "read1GzFileUri.$": "$.get_fastq_rgid_from_dynamodb_step.Item.read1_gz_file_uri.S",
+                "read2GzFileUri.$": "$.get_fastq_rgid_from_dynamodb_step.Item.read2_gz_file_uri.S",
+                "cacheDir.$": "$.get_fastq_rgid_from_dynamodb_step.Item.cache_uri.S"
+              }
+            },
+            "ResultSelector": {
+              "read1RawMd5sum.$": "$.Output.read1RawMd5sum",
+              "read2RawMd5sum.$": "$.Output.read2RawMd5sum"
+            },
+            "ResultPath": "$.get_raw_md5sums_step",
+            "Next": "Add raw md5sums to db"
+          },
+          "Add raw md5sums to db": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::dynamodb:updateItem",
+            "Parameters": {
+              "TableName": "${__table_name__}",
+              "Key": {
+                "id.$": "$.rgid_pair.rgid",
+                "id_type": "${__fastq_list_row_table_partition_name__}"
+              },
+              "UpdateExpression": "SET read1_raw_md5sum = :read1RawMd5sum, read2_raw_md5sum = :read2RawMd5sum",
+              "ExpressionAttributeValues": {
+                ":read1RawMd5sum": {
+                  "S.$": "$.get_raw_md5sums_step.read1RawMd5sum"
+                },
+                ":read2RawMd5sum": {
+                  "S.$": "$.get_raw_md5sums_step.read2RawMd5sum"
+                }
+              }
+            },
+            "End": true
+          }
+        }
+      },
+      "End": true,
+      "ResultPath": null
+    }
+  }
+}

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/get_raw_md5sum_for_all_fastq_ora_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/get_raw_md5sum_for_all_fastq_ora_sfn_template.asl.json
@@ -1,0 +1,117 @@
+{
+  "Comment": "Get CWL Outputs from BCLConvert InterOp QC pipeline",
+  "StartAt": "Get RGIDs from DB",
+  "States": {
+    "Get RGIDs from DB": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Parameters": {
+        "TableName": "${__table_name__}",
+        "Key": {
+          "id.$": "$.instrument_run_id",
+          "id_type": "${__instrument_run_id_table_partition_name__}"
+        }
+      },
+      "ResultSelector": {
+        "rgids.$": "$.Item.rgid_list.SS"
+      },
+      "ResultPath": "$.get_rgids_from_db_step",
+      "Next": "Merge fastq list csv with rgids"
+    },
+    "Merge fastq list csv with rgids": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${__merge_fastq_list_csv_with_rgid_lambda_function_arn__}",
+        "Payload": {
+          "rgids_list.$": "$.get_rgids_from_db_step.rgids",
+          "instrument_run_folder_uri.$": "$.instrument_run_folder_uri"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "ResultSelector": {
+        "fastq_ora_file_ora_by_rgid.$": "$.Payload"
+      },
+      "ResultPath": "$.merge_rgids_step",
+      "Next": "Validate Fastq Outputs"
+    },
+    "Validate Fastq Outputs": {
+      "Type": "Map",
+      "ItemsPath": "$.merge_rgids_step.fastq_ora_file_ora_by_rgid",
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "Get Raw md5sums for rgid",
+        "States": {
+          "Get Raw md5sums for rgid": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::dynamodb:getItem",
+            "Parameters": {
+              "TableName": "${__table_name__}",
+              "Key": {
+                "id.$": "$.rgid",
+                "id_type": "${__fastq_list_row_table_partition_name__}"
+              }
+            },
+            "ResultPath": "$.get_raw_md5sums_for_rgid_step",
+            "Next": "Update fastq list row partition with ora outputs"
+          },
+          "Update fastq list row partition with ora outputs": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::dynamodb:updateItem",
+            "Parameters": {
+              "TableName": "${__table_name__}",
+              "Key": {
+                "id.$": "$.rgid",
+                "id_type": "${__fastq_list_row_table_partition_name__}"
+              },
+              "UpdateExpression": "SET read1_ora_file_uri = :read1OraFileUri, read2_ora_file_uri = :read2OraFileUri",
+              "ExpressionAttributeValues": {
+                ":read1OraFileUri": {
+                  "S.$": "$.read_1_file_uri"
+                },
+                ":read2OraFileUri": {
+                  "S.$": "$.read_2_file_uri"
+                }
+              }
+            },
+            "ResultPath": null,
+            "Next": "Step Functions StartExecution"
+          },
+          "Step Functions StartExecution": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::states:startExecution.sync:2",
+            "Parameters": {
+              "StateMachineArn": "${__ora_validation_sfn_arn__}",
+              "Input": {
+                "read1OraFileUri.$": "$.read_1_file_uri",
+                "read2OraFileUri.$": "$.read_2_file_uri",
+                "read1RawMd5sum.$": "$.get_raw_md5sums_for_rgid_step.Item.read1_raw_md5sum.S",
+                "read2RawMd5sum.$": "$.get_raw_md5sums_for_rgid_step.Item.read2_raw_md5sum.S",
+                "validationOnly": true
+              }
+            },
+            "ResultPath": null,
+            "End": true
+          }
+        }
+      },
+      "End": true,
+      "ResultPath": null
+    }
+  }
+}

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/rate_limit_get_raw_md5sum_for_fastq_gzip_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/rate_limit_get_raw_md5sum_for_fastq_gzip_sfn_template.asl.json
@@ -1,0 +1,39 @@
+{
+  "Comment": "Task Backoff SFN",
+  "StartAt": "ListExecutions",
+  "States": {
+    "ListExecutions": {
+      "Type": "Task",
+      "Parameters": {
+        "StateMachineArn": "${__instrument_run_gzip_to_md5_sfn_arn__}",
+        "StatusFilter": "RUNNING"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:listExecutions",
+      "Next": "Over 10 executions running",
+      "ResultSelector": {
+        "num_executions_running.$": "States.ArrayLength(.Executions)"
+      },
+      "ResultPath": "$.get_num_running_executions_step"
+    },
+    "Over 10 executions running": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.get_num_running_executions_step.num_executions_running",
+          "NumericGreaterThan": 10,
+          "Comment": "More than 10 executions running",
+          "Next": "Sleep 5 mins"
+        }
+      ],
+      "Default": "Success"
+    },
+    "Sleep 5 mins": {
+      "Type": "Wait",
+      "Seconds": 300,
+      "Next": "Over 10 executions running"
+    },
+    "Success": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/rate_limit_get_raw_md5sum_for_fastq_gzip_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/rate_limit_get_raw_md5sum_for_fastq_gzip_sfn_template.asl.json
@@ -11,7 +11,7 @@
       "Resource": "arn:aws:states:::aws-sdk:sfn:listExecutions",
       "Next": "Over 10 executions running",
       "ResultSelector": {
-        "num_executions_running.$": "States.ArrayLength(.Executions)"
+        "num_executions_running.$": "States.ArrayLength($.Executions)"
       },
       "ResultPath": "$.get_num_running_executions_step"
     },

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/rate_limit_get_raw_md5sum_for_fastq_ora_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/rate_limit_get_raw_md5sum_for_fastq_ora_sfn_template.asl.json
@@ -1,0 +1,39 @@
+{
+  "Comment": "Task Backoff SFN",
+  "StartAt": "ListExecutions",
+  "States": {
+    "ListExecutions": {
+      "Type": "Task",
+      "Parameters": {
+        "StateMachineArn": "${__instrument_run_ora_to_md5_sfn_arn__}",
+        "StatusFilter": "RUNNING"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:listExecutions",
+      "Next": "Over 10 executions running",
+      "ResultSelector": {
+        "num_executions_running.$": "States.ArrayLength(.Executions)"
+      },
+      "ResultPath": "$.get_num_running_executions_step"
+    },
+    "Over 10 executions running": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.get_num_running_executions_step.num_executions_running",
+          "NumericGreaterThan": 10,
+          "Comment": "More than 10 executions running",
+          "Next": "Sleep 5 mins"
+        }
+      ],
+      "Default": "Success"
+    },
+    "Sleep 5 mins": {
+      "Type": "Wait",
+      "Seconds": 300,
+      "Next": "Over 10 executions running"
+    },
+    "Success": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/rate_limit_get_raw_md5sum_for_fastq_ora_sfn_template.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/rate_limit_get_raw_md5sum_for_fastq_ora_sfn_template.asl.json
@@ -11,7 +11,7 @@
       "Resource": "arn:aws:states:::aws-sdk:sfn:listExecutions",
       "Next": "Over 10 executions running",
       "ResultSelector": {
-        "num_executions_running.$": "States.ArrayLength(.Executions)"
+        "num_executions_running.$": "States.ArrayLength($.Executions)"
       },
       "ResultPath": "$.get_num_running_executions_step"
     },

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/set_compression_inputs.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/set_compression_inputs.asl.json
@@ -259,77 +259,29 @@
           }
         }
       },
-      "Next": "For each rgid",
-      "ResultPath": null
+      "ResultPath": null,
+      "Next": "Rate Limit Get Raw MD5sums for fastq gzip run"
     },
-    "For each rgid": {
-      "Type": "Map",
-      "ItemsPath": "$.get_rgid_pairs.rgids_in_samplesheet",
-      "ItemSelector": {
-        "rgid_pair.$": "$$.Map.Item.Value"
+    "Rate Limit Get Raw MD5sums for fastq gzip run": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::states:startExecution.sync:2",
+      "Parameters": {
+        "StateMachineArn": "${__rate_limit_get_raw_md5sums_gzip_sfn_arn__}",
+        "Input": {}
       },
-      "ItemProcessor": {
-        "ProcessorConfig": {
-          "Mode": "INLINE"
-        },
-        "StartAt": "DynamoDB Get Fastq RGID",
-        "States": {
-          "DynamoDB Get Fastq RGID": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::dynamodb:getItem",
-            "Parameters": {
-              "TableName": "${__table_name__}",
-              "Key": {
-                "id.$": "$.rgid_pair.rgid",
-                "id_type": "${__fastq_list_row_table_partition_name__}"
-              }
-            },
-            "ResultPath": "$.get_fastq_rgid_from_dynamodb_step",
-            "Next": "Get Raw MD5sum for fastq gzip pair"
-          },
-          "Get Raw MD5sum for fastq gzip pair": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::states:startExecution.sync:2",
-            "Parameters": {
-              "StateMachineArn": "${__gzip_raw_md5sum_sfn_arn__}",
-              "Input": {
-                "read1GzFileUri.$": "$.get_fastq_rgid_from_dynamodb_step.Item.read1_gz_file_uri.S",
-                "read2GzFileUri.$": "$.get_fastq_rgid_from_dynamodb_step.Item.read2_gz_file_uri.S",
-                "cacheDir.$": "$.get_fastq_rgid_from_dynamodb_step.Item.cache_uri.S"
-              }
-            },
-            "ResultSelector": {
-              "read1RawMd5sum.$": "$.Output.read1RawMd5sum",
-              "read2RawMd5sum.$": "$.Output.read2RawMd5sum"
-            },
-            "ResultPath": "$.get_raw_md5sums_step",
-            "Next": "Add raw md5sums to db"
-          },
-          "Add raw md5sums to db": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::dynamodb:updateItem",
-            "Parameters": {
-              "TableName": "${__table_name__}",
-              "Key": {
-                "id.$": "$.rgid_pair.rgid",
-                "id_type": "${__fastq_list_row_table_partition_name__}"
-              },
-              "UpdateExpression": "SET read1_raw_md5sum = :read1RawMd5sum, read2_raw_md5sum = :read2RawMd5sum",
-              "ExpressionAttributeValues": {
-                ":read1RawMd5sum": {
-                  "S.$": "$.get_raw_md5sums_step.read1RawMd5sum"
-                },
-                ":read2RawMd5sum": {
-                  "S.$": "$.get_raw_md5sums_step.read2RawMd5sum"
-                }
-              }
-            },
-            "End": true
-          }
+      "ResultPath": null,
+      "Next": "Get Raw MD5sums for fastq gzip pair"
+    },
+    "Get Raw MD5sums for fastq gzip pair": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::states:startExecution.sync:2",
+      "Parameters": {
+        "StateMachineArn": "${__get_raw_md5sums_for_fastq_gzip_pair_sfn_arn__}",
+        "Input": {
+          "rgid_list.$": "$.get_rgid_pairs.rgids_in_samplesheet"
         }
       },
-      "End": true,
-      "ResultPath": null
+      "End": true
     }
   }
 }

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/set_compression_outputs.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/set_compression_outputs.asl.json
@@ -9,7 +9,7 @@
         "TableName": "${__table_name__}",
         "Key": {
           "id.$": "$.portal_run_id",
-          "id_type": "portal_run_id"
+          "id_type": "${__portal_run_id_table_partition_name__}"
         }
       },
       "ResultSelector": {
@@ -58,7 +58,7 @@
         "TableName": "${__table_name__}",
         "Key": {
           "id.$": "$.portal_run_id",
-          "id_type": "portal_run_id"
+          "id_type": "${__portal_run_id_table_partition_name__}"
         },
         "UpdateExpression": "SET analysis_output = :output_json",
         "ExpressionAttributeValues": {
@@ -68,122 +68,28 @@
         }
       },
       "ResultPath": "$.update_entry_post_launch_step",
-      "Next": "Get RGIDs from DB"
+      "Next": "Rate Limit Get Raw MD5sums for fastq ora run"
     },
-    "Get RGIDs from DB": {
+    "Rate Limit Get Raw MD5sums for fastq ora run": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Resource": "arn:aws:states:::states:startExecution.sync:2",
       "Parameters": {
-        "TableName": "${__table_name__}",
-        "Key": {
-          "id.$": "$.get_db_attributes_step.ready_event_data_inputs.instrumentRunId",
-          "id_type": "${__instrument_run_id_table_partition_name__}"
-        }
+        "StateMachineArn": "${__rate_limit_get_raw_md5sums_ora_sfn_arn__}",
+        "Input": {}
       },
-      "ResultSelector": {
-        "rgids.$": "$.Item.rgid_list.SS"
-      },
-      "ResultPath": "$.get_rgids_from_db_step",
-      "Next": "Merge fastq list csv with rgids"
+      "ResultPath": null,
+      "Next": "Get Raw MD5sums for fastq ora pair"
     },
-    "Merge fastq list csv with rgids": {
+    "Get Raw MD5sums for fastq ora pair": {
       "Type": "Task",
-      "Resource": "arn:aws:states:::lambda:invoke",
+      "Resource": "arn:aws:states:::states:startExecution.sync:2",
       "Parameters": {
-        "FunctionName": "${__merge_fastq_list_csv_with_rgid_lambda_function_arn__}",
-        "Payload": {
-          "rgids_list.$": "$.get_rgids_from_db_step.rgids",
+        "StateMachineArn": "${__get_raw_md5sums_for_fastq_ora_pair_sfn_arn__}",
+        "Input": {
+          "instrument_run_id.$": "$.get_db_attributes_step.ready_event_data_inputs.instrumentRunId",
           "instrument_run_folder_uri.$": "$.analysis_outputs_step.output_json.instrumentRunOraOutputUri"
         }
       },
-      "Retry": [
-        {
-          "ErrorEquals": [
-            "Lambda.ServiceException",
-            "Lambda.AWSLambdaException",
-            "Lambda.SdkClientException",
-            "Lambda.TooManyRequestsException"
-          ],
-          "IntervalSeconds": 1,
-          "MaxAttempts": 3,
-          "BackoffRate": 2,
-          "JitterStrategy": "FULL"
-        }
-      ],
-      "ResultSelector": {
-        "fastq_ora_file_ora_by_rgid.$": "$.Payload"
-      },
-      "ResultPath": "$.merge_rgids_step",
-      "Next": "Validate Fastq Outputs"
-    },
-    "Validate Fastq Outputs": {
-      "Type": "Map",
-      "ItemsPath": "$.merge_rgids_step.fastq_ora_file_ora_by_rgid",
-      "ItemProcessor": {
-        "ProcessorConfig": {
-          "Mode": "INLINE"
-        },
-        "StartAt": "Get Raw md5sums for rgid",
-        "States": {
-          "Get Raw md5sums for rgid": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::dynamodb:getItem",
-            "Parameters": {
-              "TableName": "${__table_name__}",
-              "Key": {
-                "id.$": "$.rgid",
-                "id_type": "${__fastq_list_row_table_partition_name__}"
-              }
-            },
-            "ResultPath": "$.get_raw_md5sums_for_rgid_step",
-            "Next": "Update fastq list row partition with ora outputs"
-          },
-          "Update fastq list row partition with ora outputs": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::dynamodb:updateItem",
-            "Parameters": {
-              "TableName": "${__table_name__}",
-              "Key": {
-                "id.$": "$.rgid",
-                "id_type": "${__fastq_list_row_table_partition_name__}"
-              },
-              "UpdateExpression": "SET read1_ora_file_uri = :read1OraFileUri, read2_ora_file_uri = :read2OraFileUri",
-              "ExpressionAttributeValues": {
-                ":read1OraFileUri": {
-                  "S.$": "$.read_1_file_uri"
-                },
-                ":read2OraFileUri": {
-                  "S.$": "$.read_2_file_uri"
-                }
-              }
-            },
-            "ResultPath": null,
-            "Next": "Step Functions StartExecution"
-          },
-          "Step Functions StartExecution": {
-            "Type": "Task",
-            "Resource": "arn:aws:states:::states:startExecution.sync:2",
-            "Parameters": {
-              "StateMachineArn": "${__ora_validation_sfn_arn__}",
-              "Input": {
-                "read1OraFileUri.$": "$.read_1_file_uri",
-                "read2OraFileUri.$": "$.read_2_file_uri",
-                "read1RawMd5sum.$": "$.get_raw_md5sums_for_rgid_step.Item.read1_raw_md5sum.S",
-                "read2RawMd5sum.$": "$.get_raw_md5sums_for_rgid_step.Item.read2_raw_md5sum.S",
-                "validationOnly": true
-              }
-            },
-            "ResultPath": null,
-            "End": true
-          }
-        }
-      },
-      "Next": "Wait 1 Second (Post-update)"
-    },
-    "Wait 1 Second (Post-update)": {
-      "Type": "Wait",
-      "Seconds": 1,
-      "Comment": "Wait for databases to sync before continuing",
       "End": true
     }
   }


### PR DESCRIPTION
1. Rate limit the number of concurrent ecs tasks to 400
2. Rate limit the number of concurrent instrument runs either gzip -> md5sum or ora -> md5sum to 10

Resolves #718 