### PR TITLE
Don't extend portal run id to sequencer run,

### DIFF
--- a/lib/workload/stateless/stacks/pieriandx-pipeline-manager/lambdas/generate_pieriandx_objects_py/generate_pieriandx_objects.py
+++ b/lib/workload/stateless/stacks/pieriandx-pipeline-manager/lambdas/generate_pieriandx_objects_py/generate_pieriandx_objects.py
@@ -215,8 +215,7 @@ def handler(event, context):
     run_id = "__".join(
         [
             event.get("instrument_run_id"),
-            event.get("case_metadata").get("caseAccessionNumber"),
-            event.get('portal_run_id')
+            event.get("case_metadata").get("caseAccessionNumber")
         ]
     )
 


### PR DESCRIPTION
The portal run id is already part of the case accession id, which is why it is currently duplicated

Resolves #729 