### PR TITLE
Max results can't be more than 100

### DIFF
--- a/lib/workload/components/gzip-raw-md5sum-fq-pair-sfn/step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json
+++ b/lib/workload/components/gzip-raw-md5sum-fq-pair-sfn/step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json
@@ -6,7 +6,7 @@
       "Type": "Task",
       "Parameters": {
         "Cluster": "${__cluster_arn__}",
-        "MaxResults": 401
+        "MaxResults": 100
       },
       "Resource": "arn:aws:states:::aws-sdk:ecs:listTasks",
       "ResultSelector": {
@@ -20,7 +20,7 @@
       "Choices": [
         {
           "Variable": "$.get_num_tasks_step.num_tasks_running",
-          "NumericGreaterThan": 400,
+          "NumericGreaterThan": 99,
           "Next": "Sleep a minute",
           "Comment": "More than 400 tasks running"
         }

--- a/lib/workload/components/ora-file-decompression-fq-pair-sfn/step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json
+++ b/lib/workload/components/ora-file-decompression-fq-pair-sfn/step_functions_templates/ecs_task_rate_limiters_sfn_template.asl.json
@@ -6,7 +6,7 @@
       "Type": "Task",
       "Parameters": {
         "Cluster": "${__cluster_arn__}",
-        "MaxResults": 401
+        "MaxResults": 100
       },
       "Resource": "arn:aws:states:::aws-sdk:ecs:listTasks",
       "ResultSelector": {
@@ -20,7 +20,7 @@
       "Choices": [
         {
           "Variable": "$.get_num_tasks_step.num_tasks_running",
-          "NumericGreaterThan": 400,
+          "NumericGreaterThan": 99,
           "Next": "Sleep a minute",
           "Comment": "More than 400 tasks running"
         }

--- a/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/set_compression_outputs.asl.json
+++ b/lib/workload/stateless/stacks/ora-compression-manager/step_functions_templates/set_compression_outputs.asl.json
@@ -90,6 +90,7 @@
           "instrument_run_folder_uri.$": "$.analysis_outputs_step.output_json.instrumentRunOraOutputUri"
         }
       },
+      "ResultPath": null,
       "End": true
     }
   }


### PR DESCRIPTION
Quick fix, reduce max number of simultaneous ECS tasks to 99