### PR TITLE
fix(data-migrate): add structured output to step functions

### DIFF
--- a/lib/workload/stateless/stacks/data-migrate/data_mover/cli.py
+++ b/lib/workload/stateless/stacks/data-migrate/data_mover/cli.py
@@ -5,6 +5,7 @@ import click
 
 from data_mover.data_mover import DataMover
 
+logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
@@ -42,7 +43,7 @@ def move(source, destination):
     data_mover = DataMover(source, destination, logger=logger)
     data_mover.sync()
     data_mover.delete()
-    data_mover.send_output()
+    data_mover.send_output(command="move")
 
 
 @cli.command()
@@ -63,7 +64,7 @@ def copy(source, destination):
     """
     data_mover = DataMover(source, destination, logger=logger)
     data_mover.sync()
-    data_mover.send_output()
+    data_mover.send_output(command="copy")
 
 
 if __name__ == "__main__":

--- a/lib/workload/stateless/stacks/data-migrate/data_mover/cli.py
+++ b/lib/workload/stateless/stacks/data-migrate/data_mover/cli.py
@@ -16,6 +16,7 @@ def main():
         sys.exit(0)
     except Exception as e:
         DataMover.send_failure(str(e))
+        logger.error(str(e))
         sys.exit(1)
 
 

--- a/lib/workload/stateless/stacks/data-migrate/poetry.lock
+++ b/lib/workload/stateless/stacks/data-migrate/poetry.lock
@@ -2,17 +2,17 @@
 
 [[package]]
 name = "boto3"
-version = "1.35.72"
+version = "1.35.76"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.35.72-py3-none-any.whl", hash = "sha256:410bb4ec676c57ee9c3c7824b7b1a3721584f18f8ee8ccc8e8ecdf285136b77f"},
-    {file = "boto3-1.35.72.tar.gz", hash = "sha256:f9fc94413a959c388b1654c6687a5193293f3c69f8d0af3b86fd48b4096a23f3"},
+    {file = "boto3-1.35.76-py3-none-any.whl", hash = "sha256:69458399f41f57a50770c8974796d96978bcca44915c260319696bb43e47dffd"},
+    {file = "boto3-1.35.76.tar.gz", hash = "sha256:31ddcdb6f15dace2b68f6a0f11bdb58dd3ae79b8a3ccb174ff811ef0bbf938e0"},
 ]
 
 [package.dependencies]
-botocore = ">=1.35.72,<1.36.0"
+botocore = ">=1.35.76,<1.36.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -21,13 +21,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.35.72"
+version = "1.35.76"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.35.72-py3-none-any.whl", hash = "sha256:7412877c3f766a1bfd09236e225ce1f0dc2c35e47949ae423e56e2093c8fa23a"},
-    {file = "botocore-1.35.72.tar.gz", hash = "sha256:6b5fac38ef7cfdbc7781a751e0f78833ccb9149ba815bc238b1dbb75c90fbae5"},
+    {file = "botocore-1.35.76-py3-none-any.whl", hash = "sha256:b4729d12d00267b3185628f83543917b6caae292385230ab464067621aa086af"},
+    {file = "botocore-1.35.76.tar.gz", hash = "sha256:a75a42ae53395796b8300c5fefb2d65a8696dc40dc85e49cf3a769e0c0202b13"},
 ]
 
 [package.dependencies]
@@ -145,13 +145,13 @@ crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
 name = "six"
-version = "1.16.0"
+version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]


### PR DESCRIPTION
Related to https://github.com/umccr/orcabus/issues/721

### Changes
* Instead of trying to output the full `stdout` of `aws s3 sync` from the step functions ECS task, use a simplified structured output to avoid the payload limit error.
* Fix output logs so that they show in CloudWatch.