### PR TITLE
feat(htsget): add htsget support

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -65,6 +65,7 @@ import {
 import { getOraDecompressionManagerStackProps } from './stacks/oraDecompressionPipelineManager';
 import { getPgDDProps } from './stacks/pgDD';
 import { getDataMigrateStackProps } from './stacks/dataMigrate';
+import { getHtsgetProps } from './stacks/htsget';
 
 interface EnvironmentConfig {
   name: string;
@@ -133,6 +134,7 @@ export const getEnvironmentConfig = (stage: AppStage): EnvironmentConfig | null 
       stackyMcStackFaceProps: getGlueStackProps(stage),
       fmAnnotatorProps: getFmAnnotatorProps(),
       dataMigrateProps: getDataMigrateStackProps(stage),
+      htsgetProps: getHtsgetProps(stage),
       pgDDProps: getPgDDProps(stage),
     },
   };

--- a/config/stacks/htsget.ts
+++ b/config/stacks/htsget.ts
@@ -1,0 +1,21 @@
+import {
+  AppStage,
+  cognitoApiGatewayConfig,
+  corsAllowOrigins,
+  logsApiGatewayConfig,
+  vpcProps,
+} from '../constants';
+import { HtsgetStackConfigurableProps } from '../../lib/workload/stateless/stacks/htsget/stack';
+
+export const getHtsgetProps = (stage: AppStage): HtsgetStackConfigurableProps => {
+  return {
+    vpcProps,
+    apiGatewayCognitoProps: {
+      ...cognitoApiGatewayConfig,
+      corsAllowOrigins: corsAllowOrigins[stage],
+      apiGwLogsConfig: logsApiGatewayConfig[stage],
+      apiName: 'Htsget',
+      customDomainNamePrefix: 'htsget-file',
+    },
+  };
+};

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -244,6 +244,17 @@ returned by the filemanager, it can be reached via htsget by combining the key a
 curl -H "Authorization: Bearer $TOKEN" "https://htsget-file.dev.umccr.org/reads/<filemanager_bucket>/<filemanager_key>" | jq
 ```
 
+For example, fetching a current object:
+
+```sh
+export RESULT=$(curl -H "Authorization: Bearer $TOKEN" "https://file.dev.umccr.org/api/v1/s3?bucket=umccr-temp-dev&key=*analysis*.bam&rowsPerPage=1&currentState=true" | jq)
+export BUCKET=$(echo $RESULT | jq -r '.results[] | .bucket')
+export KEY=$(echo $RESULT | jq -r '.results[] | .key')
+
+# Note that you must remove the file extension.
+curl -H "Authorization: Bearer $TOKEN" "https://htsget-file.dev.umccr.org/reads/${BUCKET}/${KEY%.*}" | jq
+```
+
 [json-patch]: https://jsonpatch.com/
 [qs]: https://github.com/ljharb/qs
 [s3-events]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventNotifications.html

--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -235,7 +235,17 @@ There is also no way to POST an attribute linking rule, which can be used to upd
 as they are received by filemanager. See [ATTRIBUTE_LINKING.md][attribute-linking] for a discussion on some approaches
 for this. The likely solution will involve merging the above wildcard matching logic with attribute rules.
 
+## Htsget
+
+Htsget support is enabled under the `htsget.file` subdomain, see [here] for more details. For each current object
+returned by the filemanager, it can be reached via htsget by combining the key and the bucket in the query path:
+
+```sh
+curl -H "Authorization: Bearer $TOKEN" "https://htsget-file.dev.umccr.org/reads/<filemanager_bucket>/<filemanager_key>" | jq
+```
+
 [json-patch]: https://jsonpatch.com/
 [qs]: https://github.com/ljharb/qs
 [s3-events]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/EventNotifications.html
 [attribute-linking]: ATTRIBUTE_LINKING.md
+[here]: ../../htsget/README.md

--- a/lib/workload/stateless/stacks/htsget/README.md
+++ b/lib/workload/stateless/stacks/htsget/README.md
@@ -1,0 +1,18 @@
+# htsget stack
+
+This stack deploys [htsget-rs] to access files. Any files accessible by filemanager are also accessible using htsget.
+
+The deployed instance of the htsget-rs can be reached using stage at `https://htsget-file.<stage>.umccr.org`
+and the orcabus API token. To retrieve the token, run:
+
+```sh
+export TOKEN=$(aws secretsmanager get-secret-value --secret-id orcabus/token-service-jwt --output json --query SecretString | jq -r 'fromjson | .id_token')
+```
+
+Then, the API can be queried:
+
+```sh
+curl -H "Authorization: Bearer $TOKEN" "https://htsget-file.dev.umccr.org/reads/service-info" | jq
+```
+
+[htsget-rs]: https://github.com/umccr/htsget-rs

--- a/lib/workload/stateless/stacks/htsget/deploy.toml
+++ b/lib/workload/stateless/stacks/htsget/deploy.toml
@@ -1,0 +1,24 @@
+# TODO this will eventually be removed for props-only configuration.
+
+ticket_server_cors_allow_headers = "All"
+ticket_server_cors_allow_origins = "Mirror"
+ticket_server_cors_allow_methods = "All"
+ticket_server_cors_allow_credentials = true
+ticket_server_cors_max_age = 300
+
+data_server_enabled = false
+
+name = "orcabus-htsget-rs"
+version = "0.1.0"
+organization_name = "UMCCR"
+organization_url = "https://umccr.org/"
+contact_url = "https://umccr.org/"
+documentation_url = "https://github.com/umccr/htsget-rs"
+
+# The role should prevent any access to other files, although it should probably
+# be set here as well.
+[[resolvers]]
+regex = '^(?P<bucket>.*?)/(?P<key>.*)$'
+substitution_string = '$key'
+storage.backend = 'S3'
+

--- a/lib/workload/stateless/stacks/htsget/stack.ts
+++ b/lib/workload/stateless/stacks/htsget/stack.ts
@@ -1,0 +1,54 @@
+import { Construct } from 'constructs';
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Role } from 'aws-cdk-lib/aws-iam';
+import { IVpc, Vpc, VpcLookupOptions } from 'aws-cdk-lib/aws-ec2';
+import { ApiGatewayConstruct, ApiGatewayConstructProps } from '../../../components/api-gateway';
+import path from 'path';
+import { HtsgetLambdaConstruct } from 'htsget-lambda';
+
+/**
+ * Configurable props for the htsget stack.
+ */
+export type HtsgetStackConfigurableProps = {
+  /**
+   * Props to lookup vpc.
+   */
+  vpcProps: VpcLookupOptions;
+  /**
+   * API gateway construct props.
+   */
+  apiGatewayCognitoProps: ApiGatewayConstructProps;
+};
+
+/**
+ * Props for the data migrate stack.
+ */
+export type HtsgetStackProps = HtsgetStackConfigurableProps & {
+  /**
+   * The role to use.
+   */
+  role: Role;
+};
+
+/**
+ * Deploys htsget-rs with access to filemanager data.
+ */
+export class HtsgetStack extends Stack {
+  private readonly vpc: IVpc;
+  private readonly apiGateway: ApiGatewayConstruct;
+
+  constructor(scope: Construct, id: string, props: StackProps & HtsgetStackProps) {
+    super(scope, id, props);
+
+    this.vpc = Vpc.fromLookup(this, 'MainVpc', props.vpcProps);
+    this.apiGateway = new ApiGatewayConstruct(this, 'ApiGateway', props.apiGatewayCognitoProps);
+
+    const configPath = path.join(__dirname, 'deploy.toml');
+    new HtsgetLambdaConstruct(this, 'Htsget', {
+      config: configPath,
+      vpc: this.vpc,
+      role: props.role,
+      httpApi: this.apiGateway.httpApi,
+    });
+  }
+}

--- a/lib/workload/stateless/statelessStackCollectionClass.ts
+++ b/lib/workload/stateless/statelessStackCollectionClass.ts
@@ -81,6 +81,7 @@ import {
 } from './stacks/ora-decompression-manager/deploy';
 import { PgDDStack, PgDDStackProps } from './stacks/pg-dd/deploy/stack';
 import { DataMigrateStack, DataMigrateStackProps } from './stacks/data-migrate/deploy/stack';
+import { HtsgetStack, HtsgetStackConfigurableProps } from './stacks/htsget/stack';
 
 export interface StatelessStackCollectionProps {
   metadataManagerStackProps: MetadataManagerStackProps;
@@ -107,6 +108,7 @@ export interface StatelessStackCollectionProps {
   stackyMcStackFaceProps: GlueStackProps;
   fmAnnotatorProps: FMAnnotatorConfigurableProps;
   dataMigrateProps: DataMigrateStackProps;
+  htsgetProps: HtsgetStackConfigurableProps;
   pgDDProps?: PgDDStackProps;
 }
 
@@ -136,6 +138,7 @@ export class StatelessStackCollection {
   readonly stackyMcStackFaceStack: Stack;
   readonly fmAnnotator: Stack;
   readonly dataMigrate: Stack;
+  readonly htsgetStack: Stack;
   readonly pgDDStack: Stack;
 
   constructor(
@@ -318,6 +321,11 @@ export class StatelessStackCollection {
     this.dataMigrate = new DataMigrateStack(scope, 'DataMigrateStack', {
       ...this.createTemplateProps(env, 'DataMigrateStack'),
       ...statelessConfiguration.dataMigrateProps,
+    });
+    this.htsgetStack = new HtsgetStack(scope, 'HtsgetStack', {
+      ...this.createTemplateProps(env, 'DataMigrateStack'),
+      ...statelessConfiguration.htsgetProps,
+      role: fileManagerStack.role,
     });
 
     if (statelessConfiguration.pgDDProps) {

--- a/lib/workload/stateless/statelessStackCollectionClass.ts
+++ b/lib/workload/stateless/statelessStackCollectionClass.ts
@@ -323,7 +323,7 @@ export class StatelessStackCollection {
       ...statelessConfiguration.dataMigrateProps,
     });
     this.htsgetStack = new HtsgetStack(scope, 'HtsgetStack', {
-      ...this.createTemplateProps(env, 'DataMigrateStack'),
+      ...this.createTemplateProps(env, 'HtsgetStack'),
       ...statelessConfiguration.htsgetProps,
       role: fileManagerStack.role,
     });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "constructs": "^10.4.2",
     "core-js-pure": "^3.38.1",
     "dotenv": "^16.4.5",
+    "htsget-lambda": "^0.6.2",
     "source-map-support": "^0.5.21",
     "sqs-dlq-monitoring": "^1.2.16"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -681,6 +681,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@iarna/toml@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@iarna/toml@npm:3.0.0"
+  checksum: 10/c52161263aaed8c548befd868b1522506e4ea55cf51267f386a6acb468cedc05ab3e80a8b8dffca52344d553cdaea6dff89473ed2655f1fca4dd307561cddcf6
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -1572,7 +1579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk-lib@npm:^2.164.1":
+"aws-cdk-lib@npm:2.164.1, aws-cdk-lib@npm:^2.164.1":
   version: 2.164.1
   resolution: "aws-cdk-lib@npm:2.164.1"
   dependencies:
@@ -1832,6 +1839,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cargo-lambda-cdk@npm:^0.0.31":
+  version: 0.0.31
+  resolution: "cargo-lambda-cdk@npm:0.0.31"
+  dependencies:
+    js-toml: "npm:^0.1.1"
+  peerDependencies:
+    aws-cdk-lib: ^2.63.0
+    constructs: ^10.0.5
+  checksum: 10/a1b4373cf66ad4262a3f6a7208a9e277649363351096172b0279f892d47d2b513f53a0cd9a1c7088ea6976b24269408e07fe9913e56d7b7a3de035ad0f3ca9c3
+  languageName: node
+  linkType: hard
+
 "case@npm:1.6.3":
   version: 1.6.3
   resolution: "case@npm:1.6.3"
@@ -1992,7 +2011,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"constructs@npm:^10.4.2":
+"constructs@npm:10.4.2, constructs@npm:^10.4.2":
   version: 10.4.2
   resolution: "constructs@npm:10.4.2"
   checksum: 10/0322de2ff7bca27dc71419b0437e2bcabc572bdce565b6cc0a34d12c74b32a27c69431975f2947503cbd31166f08ce3c98d1904fe469005b23c95fc2f5cef829
@@ -2736,6 +2755,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^11.0.0":
+  version: 11.0.0
+  resolution: "glob@npm:11.0.0"
+  dependencies:
+    foreground-child: "npm:^3.1.0"
+    jackspeak: "npm:^4.0.1"
+    minimatch: "npm:^10.0.0"
+    minipass: "npm:^7.1.2"
+    package-json-from-dist: "npm:^1.0.0"
+    path-scurry: "npm:^2.0.0"
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 10/e66939201d11ae30fe97e3364ac2be5c59d6c9bfce18ac633edfad473eb6b46a7553f6f73658f67caaf6cccc1df1ae336298a45e9021fa5695fd78754cc1603e
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -2812,6 +2847,22 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: 10/034d74029dcca544a34fb6135e98d427acd73019796ffc17383eaa3ec2fe1c0471dcbbc8f8ed39e46e86d43ccd753a160631615e4048285e313569609b66d5b7
+  languageName: node
+  linkType: hard
+
+"htsget-lambda@npm:^0.6.2":
+  version: 0.6.2
+  resolution: "htsget-lambda@npm:0.6.2"
+  dependencies:
+    "@iarna/toml": "npm:^3.0.0"
+    aws-cdk-lib: "npm:2.164.1"
+    cargo-lambda-cdk: "npm:^0.0.31"
+    constructs: "npm:10.4.2"
+    glob: "npm:^11.0.0"
+    source-map-support: "npm:^0.5.21"
+  bin:
+    htsget_app: bin/htsget-lambda.js
+  checksum: 10/a70f2508b4d78c33d45b960b21b94833087b2e0b46f909202014e7783c3e396f321a2ca8b8c5cb7212acfdf50bd1b1aacde66bc3a0766318efe9cbe6817b6129
   languageName: node
   linkType: hard
 
@@ -3091,6 +3142,15 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 10/96f8786eaab98e4bf5b2a5d6d9588ea46c4d06bbc4f2eb861fdd7b6b182b16f71d8a70e79820f335d52653b16d4843b29dd9cdcf38ae80406756db9199497cf3
+  languageName: node
+  linkType: hard
+
+"jackspeak@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "jackspeak@npm:4.0.2"
+  dependencies:
+    "@isaacs/cliui": "npm:^8.0.2"
+  checksum: 10/d9722f0e55f6c322c57aedf094c405f4201b834204629817187953988075521cfddb23df83e2a7b845723ca7eb0555068c5ce1556732e9c275d32a531881efa8
   languageName: node
   linkType: hard
 
@@ -3772,6 +3832,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.0.0":
+  version: 11.0.2
+  resolution: "lru-cache@npm:11.0.2"
+  checksum: 10/25fcb66e9d91eaf17227c6abfe526a7bed5903de74f93bfde380eb8a13410c5e8d3f14fe447293f3f322a7493adf6f9f015c6f1df7a235ff24ec30f366e1c058
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -3870,6 +3937,15 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: 10/d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "minimatch@npm:10.0.1"
+  dependencies:
+    brace-expansion: "npm:^2.0.1"
+  checksum: 10/082e7ccbc090d5f8c4e4e029255d5a1d1e3af37bda837da2b8b0085b1503a1210c91ac90d9ebfe741d8a5f286ece820a1abb4f61dc1f82ce602a055d461d93f3
   languageName: node
   linkType: hard
 
@@ -4136,6 +4212,7 @@ __metadata:
     eslint: "npm:^9.13.0"
     eslint-config-prettier: "npm:^9.1.0"
     globals: "npm:^15.11.0"
+    htsget-lambda: "npm:^0.6.2"
     jest: "npm:^29.7.0"
     jest-junit: "npm:^16.0.0"
     prettier: "npm:^3.3.3"
@@ -4263,6 +4340,16 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "path-scurry@npm:2.0.0"
+  dependencies:
+    lru-cache: "npm:^11.0.0"
+    minipass: "npm:^7.1.2"
+  checksum: 10/285ae0c2d6c34ae91dc1d5378ede21981c9a2f6de1ea9ca5a88b5a270ce9763b83dbadc7a324d512211d8d36b0c540427d3d0817030849d97a60fa840a2c59ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #758 

### Changes
* Enables htsget-rs support for all htsget-compatible filemanager files.
    * This reuses the filemanager-ingest-role to access files.
    * The htsget-rs endpoint can be queried using `https://htsget-file.<stage>.umccr.org`.
    
See related PR https://github.com/umccr/htsget-deploy/pull/1