### PR TITLE
Updated aurora automated backup retention

### DIFF
--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -155,6 +155,7 @@ const getDatabaseConstructProps = (stage: AppStage): ConfigurableDatabaseProps =
         enhancedMonitoringInterval: Duration.seconds(60),
         enablePerformanceInsights: true,
         removalPolicy: RemovalPolicy.DESTROY,
+        backupRetention: Duration.days(1),
       };
     case AppStage.GAMMA:
       return {
@@ -165,6 +166,7 @@ const getDatabaseConstructProps = (stage: AppStage): ConfigurableDatabaseProps =
         enhancedMonitoringInterval: Duration.seconds(60),
         enablePerformanceInsights: true,
         removalPolicy: RemovalPolicy.DESTROY,
+        backupRetention: Duration.days(1),
       };
     case AppStage.PROD:
       return {
@@ -172,7 +174,10 @@ const getDatabaseConstructProps = (stage: AppStage): ConfigurableDatabaseProps =
         numberOfInstance: 1,
         minACU: 0.5,
         maxACU: 16,
+        enhancedMonitoringInterval: Duration.seconds(60),
+        enablePerformanceInsights: true,
         removalPolicy: RemovalPolicy.RETAIN,
+        backupRetention: Duration.days(7),
       };
   }
 };

--- a/lib/workload/stateful/stacks/shared/constructs/database/index.ts
+++ b/lib/workload/stateful/stacks/shared/constructs/database/index.ts
@@ -89,6 +89,10 @@ export type ConfigurableDatabaseProps = MonitoringProps & {
    * The schedule (in Duration) that will rotate the master secret
    */
   secretRotationSchedule: Duration;
+  /**
+   * RDS aurora automated backup retention (in Duration)
+   */
+  backupRetention: Duration;
 };
 
 /**
@@ -161,6 +165,10 @@ export class DatabaseConstruct extends Construct {
       writer: rds.ClusterInstance.serverlessV2('WriterClusterInstance', {
         enablePerformanceInsights: props.enablePerformanceInsights,
       }),
+
+      backup: {
+        retention: props.backupRetention,
+      },
     });
 
     new sm.SecretRotation(this, 'MasterDbSecretRotation', {

--- a/test/stateful/pipeline/deployment.test.ts
+++ b/test/stateful/pipeline/deployment.test.ts
@@ -110,6 +110,7 @@ function applyNagSuppression(stackId: string, stack: Stack) {
           '/SharedStack/EventBusConstruct/UniversalEventArchiveBucket/Resource',
           '/SharedStack/EventBusConstruct/UniversalEventArchiver/UniversalEventArchiver/ServiceRole/Resource',
           '/SharedStack/EventBusConstruct/UniversalEventArchiver/UniversalEventArchiver/ServiceRole/DefaultPolicy/Resource',
+          '/SharedStack/DatabaseConstruct/Cluster/MonitoringRole/Resource',
         ],
         [
           {


### PR DESCRIPTION
* This extends point-in-time (PIT) recovery objective (RPO) upto 7 days
  in production RDS aurora cluster. Staging and development maintain
  1 day RPO.
