### PR TITLE
Remove null inputs from inputs payload

### DIFF
--- a/lib/workload/stateless/stacks/transcriptome-pipeline-manager/step_functions_templates/set_wts_cwl_inputs_sfn.asl.json
+++ b/lib/workload/stateless/stacks/transcriptome-pipeline-manager/step_functions_templates/set_wts_cwl_inputs_sfn.asl.json
@@ -520,6 +520,12 @@
       "ResultPath": "$.merge_boolean_enable_parameters_step",
       "Next": "Update Database Entry"
     },
+    "Remove Null objects": {
+      "QueryLanguage": "JSONata",
+      "Type": "Pass",
+      "Output": "{% \n  (\n    $input_json_null_removed := $each(\n      $states.input.merge_boolean_enable_parameters_step.input_json, \n      function($v, $k){ \n        ($v != null) ? { $k: $v } : {} \n      }\n    ) ~> $merge;\n    /*\n    FIXME, solution to combine jsonata to jsonpath\n    Since variables are not supported in jsonpath\n    And ResultPath is not supported in jsonata\n    */ \n    $merge(\n      [\n        $states.input,\n        {\n          \"input_json_null_removed\": $input_json_null_removed\n        }\n      ]\n    )\n  )\n%}",
+      "Next": "Update Database Entry"
+    },
     "Update Database Entry": {
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:updateItem",
@@ -532,7 +538,7 @@
         "UpdateExpression": "SET input_json = :input_json",
         "ExpressionAttributeValues": {
           ":input_json": {
-            "S.$": "States.JsonToString($.merge_boolean_enable_parameters_step.input_json)"
+            "S.$": "States.JsonToString($.input_json_null_removed)"
           }
         }
       },


### PR DESCRIPTION
This occurs when no fastqs are in ora format and therefore the ora reference is omitted. 

Created this step with JSONata.
@andrewpatto kinda annoying this JSONata wasn't introduced earlier (like six months ago, before I built around 70 different step functions). It's so much easier to handle / transform data in JSONata compared to JSONPath, AND there are online emulators available to help validate things prior to writing. 

A step function can now be JSONPath or JSONata, to help onboarding, the allow one to place a JSONata task INSIDE a JSONPath step function (and vice versa)
One downside is this compatibility between JSONPath and JSONata within AWS Step Functions is a bit flaky. 
For example the JSONata 'variables' functionality isn't parsed into downstream steps if the overall workflow is a JSONPath workflow. But ResultPath isn't supported in JSONata so it's difficult to place an output without removing the information in the previous state. 

In this case, I need to use 'output' instead of 'variables' and then append the value I want to the state input.

```
{% 
  (
    $input_json_null_removed := $each(
      $states.input.merge_boolean_enable_parameters_step.input_json, 
      function($v, $k){ 
        ($v != null) ? { $k: $v } : {} 
      }
    ) ~> $merge;
    /*
    FIXME, solution to combine jsonata to jsonpath
    Since variables are not supported in jsonpath
    And ResultPath is not supported in jsonata
    */ 
    $merge(
      [
        $states.input,
        {
          "input_json_null_removed": $input_json_null_removed
        }
      ]
    )
  )
%}
```

Read more on JSONata here: 
https://docs.aws.amazon.com/step-functions/latest/dg/workflow-variables.html

JSONata playground also very useful - https://www.stedi.com/jsonata/playground

