### PR TITLE
fix(filemanager): add permissions for analysis and fastq archive buckets

### DIFF
--- a/config/stacks/fileManager.ts
+++ b/config/stacks/fileManager.ts
@@ -9,6 +9,8 @@ import {
   eventSourceQueueName,
   fileManagerIngestRoleName,
   fileManagerInventoryBucket,
+  icav2ArchiveAnalysisBucket,
+  icav2ArchiveFastqBucket,
   icav2PipelineCacheBucket,
   logsApiGatewayConfig,
   oncoanalyserBucket,
@@ -21,6 +23,12 @@ export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => 
     inventorySourceBuckets.push(fileManagerInventoryBucket[stage]);
   }
 
+  const eventSourceBuckets = [oncoanalyserBucket[stage], icav2PipelineCacheBucket[stage]];
+  if (stage == AppStage.PROD) {
+    eventSourceBuckets.push(icav2ArchiveAnalysisBucket[stage]);
+    eventSourceBuckets.push(icav2ArchiveFastqBucket[stage]);
+  }
+
   return {
     securityGroupName: computeSecurityGroupName,
     vpcProps,
@@ -29,7 +37,7 @@ export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => 
     port: databasePort,
     migrateDatabase: true,
     inventorySourceBuckets,
-    eventSourceBuckets: [oncoanalyserBucket[stage], icav2PipelineCacheBucket[stage]],
+    eventSourceBuckets,
     fileManagerRoleName: fileManagerIngestRoleName,
     apiGatewayCognitoProps: {
       ...cognitoApiGatewayConfig,

--- a/config/stacks/fileManager.ts
+++ b/config/stacks/fileManager.ts
@@ -24,6 +24,7 @@ export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => 
   }
 
   const eventSourceBuckets = [oncoanalyserBucket[stage], icav2PipelineCacheBucket[stage]];
+  // Note, that we only archive production data, so we only need access to the archive buckets in prod.
   if (stage == AppStage.PROD) {
     eventSourceBuckets.push(icav2ArchiveAnalysisBucket[stage]);
     eventSourceBuckets.push(icav2ArchiveFastqBucket[stage]);

--- a/test/stateless/deployment.test.ts
+++ b/test/stateless/deployment.test.ts
@@ -174,18 +174,12 @@ function applyNagSuppression(stackId: string, stack: Stack) {
           {
             id: 'AwsSolutions-IAM5',
             reason: "'*' is required to access objects in the indexed bucket by filemanager.",
-            appliesTo: ['Resource::arn:aws:s3:::org.umccr.data.oncoanalyser/*'],
-          },
-        ],
-        true
-      );
-      NagSuppressions.addResourceSuppressions(
-        stack,
-        [
-          {
-            id: 'AwsSolutions-IAM5',
-            reason: "'*' is required to access objects in the indexed bucket by filemanager.",
-            appliesTo: ['Resource::arn:aws:s3:::pipeline-prod-cache-503977275616-ap-southeast-2/*'],
+            appliesTo: [
+              'Resource::arn:aws:s3:::org.umccr.data.oncoanalyser/*',
+              'Resource::arn:aws:s3:::pipeline-prod-cache-503977275616-ap-southeast-2/*',
+              'Resource::arn:aws:s3:::archive-prod-analysis-503977275616-ap-southeast-2/*',
+              'Resource::arn:aws:s3:::archive-prod-fastq-503977275616-ap-southeast-2/*',
+            ],
           },
         ],
         true


### PR DESCRIPTION
Closes #790 

### Changes
* Fixes missing permissions that let the filemanager tag objects in the archive analysis and fastq buckets.