### PR TITLE
Feat: Django Deployable Swagger

### DIFF
--- a/lib/workload/stateless/stacks/metadata-manager/app/settings/base.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/settings/base.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     "app",
     "aws_xray_sdk.ext.django",
     'simple_history',
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
@@ -164,3 +165,35 @@ XRAY_RECORDER = {
 
 # turn off xray more generally and, you can overwrite with env var AWS_XRAY_SDK_ENABLED=true at runtime
 aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+
+REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'Metadata Manager API',
+    'DESCRIPTION': 'The Metadata Manager API for UMCCR.',
+    'VERSION': '0.0.1',
+    'SERVE_INCLUDE_SCHEMA': False,
+    'SECURITY': [
+        {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
+    ],
+    'CONTACT': {
+        'name': 'UMCCR',
+        'email': 'services@umccr.org'
+    },
+    "LICENSE": {
+        "name": "MIT License",
+    },
+    "EXTERNAL_DOCS": {
+        "description": "Terms of service",
+        "url": "https://umccr.org/",
+    },
+    'CAMELIZE_NAMES': True,
+    'POSTPROCESSING_HOOKS': [
+        'drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields',
+        'drf_spectacular.hooks.postprocess_schema_enums'
+    ],
+    'SCHEMA_PATH_PREFIX': f'/api/{API_VERSION}/',
+}

--- a/lib/workload/stateless/stacks/metadata-manager/app/settings/base.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/settings/base.py
@@ -147,6 +147,9 @@ REST_FRAMEWORK = {
     "JSON_UNDERSCOREIZE": {
         'no_underscore_before_number': True,
     },
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+    ],
 }
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/lib/workload/stateless/stacks/metadata-manager/app/settings/local.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/settings/local.py
@@ -24,49 +24,11 @@ DATABASES = {
 
 INSTALLED_APPS += (
     "django_extensions",
-    "drf_spectacular",
 )
 
 ROOT_URLCONF = "app.urls.local"
 
 RUNSERVER_PLUS_PRINT_SQL_TRUNCATE = sys.maxsize
-
-REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
-
-SPECTACULAR_SETTINGS = {
-    'TITLE': 'Metadata Manager API',
-    'DESCRIPTION': 'The Metadata Manager API for UMCCR.',
-    'VERSION': '0.0.1',
-    'SERVE_INCLUDE_SCHEMA': False,
-    'SECURITY': [
-        {
-            "type": "http",
-            "scheme": "bearer",
-            "bearerFormat": "JWT",
-        }
-    ],
-    'CONTACT': {
-        'name': 'UMCCR',
-        'email': 'services@umccr.org'
-    },
-    "LICENSE": {
-        "name": "MIT License",
-    },
-    "EXTERNAL_DOCS": {
-        "description": "Terms of service",
-        "url": "https://umccr.org/",
-    },
-    'CAMELIZE_NAMES': True,
-    'POSTPROCESSING_HOOKS': [
-        'drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields',
-        'drf_spectacular.hooks.postprocess_schema_enums'
-    ],
-    'SCHEMA_PATH_PREFIX': f'/api/{API_VERSION}/',
-}
-
-REDOC_SETTINGS = {
-    "LAZY_RENDERING": False,
-}
 
 LOGGING = {
     'version': 1,

--- a/lib/workload/stateless/stacks/metadata-manager/app/urls/base.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/urls/base.py
@@ -1,4 +1,6 @@
 from django.urls import path, include
+from django.urls import path
+from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
 
 from app.routers import OptionalSlashDefaultRouter
 from app.viewsets import LibraryViewSet, SubjectViewSet, SampleViewSet, ProjectViewSet, ContactViewSet, \
@@ -20,6 +22,9 @@ router.register(r"sync", SyncViewSet, basename="sync")
 
 urlpatterns = [
     path(f"{api_base}", include(router.urls)),
+    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
+    path('schema/swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'),
+         name='swagger-ui'),
 ]
 
 handler500 = "rest_framework.exceptions.server_error"

--- a/lib/workload/stateless/stacks/metadata-manager/app/urls/local.py
+++ b/lib/workload/stateless/stacks/metadata-manager/app/urls/local.py
@@ -1,10 +1,5 @@
-from django.urls import path
-from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
-
 from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
-    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
-    path('swagger-ui/', SpectacularSwaggerView.as_view(url_name='schema'),
-         name='swagger-ui'),
+    # Some URL that only exists in the local environment
 ]

--- a/lib/workload/stateless/stacks/metadata-manager/deploy/construct/lambda-api/index.ts
+++ b/lib/workload/stateless/stacks/metadata-manager/deploy/construct/lambda-api/index.ts
@@ -1,7 +1,12 @@
 import { Construct } from 'constructs';
 import { Duration } from 'aws-cdk-lib';
 import { Function } from 'aws-cdk-lib/aws-lambda';
-import { HttpMethod, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv2';
+import {
+  HttpMethod,
+  HttpNoneAuthorizer,
+  HttpRoute,
+  HttpRouteKey,
+} from 'aws-cdk-lib/aws-apigatewayv2';
 import { PythonFunction, PythonFunctionProps } from '@aws-cdk/aws-lambda-python-alpha';
 import { ISecret } from 'aws-cdk-lib/aws-secretsmanager';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
@@ -59,6 +64,13 @@ export class LambdaAPIConstruct extends Construct {
 
     // add some integration to the http api gw
     const apiIntegration = new HttpLambdaIntegration('ApiLambdaIntegration', this.lambda);
+
+    new HttpRoute(this, 'GetSchemaHttpRoute', {
+      httpApi: apiGW.httpApi,
+      integration: apiIntegration,
+      authorizer: new HttpNoneAuthorizer(), // No auth needed for schema
+      routeKey: HttpRouteKey.with(`/api/${this.API_VERSION}/schema/{PROXY+}`, HttpMethod.GET),
+    });
 
     new HttpRoute(this, 'GetHttpRoute', {
       httpApi: apiGW.httpApi,

--- a/lib/workload/stateless/stacks/metadata-manager/deploy/construct/lambda-api/index.ts
+++ b/lib/workload/stateless/stacks/metadata-manager/deploy/construct/lambda-api/index.ts
@@ -65,11 +65,12 @@ export class LambdaAPIConstruct extends Construct {
     // add some integration to the http api gw
     const apiIntegration = new HttpLambdaIntegration('ApiLambdaIntegration', this.lambda);
 
+    // Routes for API schemas
     new HttpRoute(this, 'GetSchemaHttpRoute', {
       httpApi: apiGW.httpApi,
       integration: apiIntegration,
       authorizer: new HttpNoneAuthorizer(), // No auth needed for schema
-      routeKey: HttpRouteKey.with(`/api/${this.API_VERSION}/schema/{PROXY+}`, HttpMethod.GET),
+      routeKey: HttpRouteKey.with(`/schema/{PROXY+}`, HttpMethod.GET),
     });
 
     new HttpRoute(this, 'GetHttpRoute', {

--- a/lib/workload/stateless/stacks/sequence-run-manager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/sequence-run-manager/deploy/stack.ts
@@ -7,7 +7,12 @@ import { EventBus, IEventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
 import { PythonFunction, PythonLayerVersion } from '@aws-cdk/aws-lambda-python-alpha';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
-import { HttpMethod, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv2';
+import {
+  HttpMethod,
+  HttpNoneAuthorizer,
+  HttpRoute,
+  HttpRouteKey,
+} from 'aws-cdk-lib/aws-apigatewayv2';
 import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { ApiGatewayConstruct, ApiGatewayConstructProps } from '../../../../components/api-gateway';
 import { Architecture } from 'aws-cdk-lib/aws-lambda';
@@ -117,6 +122,14 @@ export class SequenceRunManagerStack extends Stack {
     const httpApi = srmApi.httpApi;
 
     const apiIntegration = new HttpLambdaIntegration('ApiIntegration', apiFn);
+
+    // Routes for API schemas
+    new HttpRoute(this, 'GetSchemaHttpRoute', {
+      httpApi: srmApi.httpApi,
+      integration: apiIntegration,
+      authorizer: new HttpNoneAuthorizer(), // No auth needed for schema
+      routeKey: HttpRouteKey.with(`/schema/{PROXY+}`, HttpMethod.GET),
+    });
 
     new HttpRoute(this, 'GetHttpRoute', {
       httpApi: httpApi,

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/base.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/base.py
@@ -143,6 +143,9 @@ REST_FRAMEWORK = {
     "JSON_UNDERSCOREIZE": {
         'no_underscore_before_number': True,
     },
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+    ],
 }
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/base.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/base.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "sequence_run_manager",
     "aws_xray_sdk.ext.django",
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
@@ -164,3 +165,37 @@ XRAY_RECORDER = {
 
 # turn off xray more generally and, you can overwrite with env var AWS_XRAY_SDK_ENABLED=true at runtime
 aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+
+# --- drf-spectacular settings
+
+REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'UMCCR OrcaBus sequence_run_manager API',
+    'DESCRIPTION': 'UMCCR OrcaBus sequence_run_manager API',
+    'VERSION': API_VERSION,
+    'SERVE_INCLUDE_SCHEMA': False,
+    'SECURITY': [
+        {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
+    ],
+    'CONTACT': {
+        'name': 'UMCCR',
+        'email': 'services@umccr.org'
+    },
+    "LICENSE": {
+        "name": "MIT License",
+    },
+    "EXTERNAL_DOCS": {
+        "description": "Terms of service",
+        "url": "https://umccr.org/",
+    },
+    'CAMELIZE_NAMES': True,
+    'POSTPROCESSING_HOOKS': [
+        'drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields',
+        'drf_spectacular.hooks.postprocess_schema_enums'
+    ],
+}

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/local.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/settings/local.py
@@ -23,43 +23,9 @@ DATABASES = {
 
 INSTALLED_APPS += (
     "django_extensions",
-    "drf_spectacular",
 )
 
 ROOT_URLCONF = "sequence_run_manager.urls.local"
 
 RUNSERVER_PLUS_PRINT_SQL_TRUNCATE = sys.maxsize
 
-# --- drf-spectacular settings
-
-REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
-
-SPECTACULAR_SETTINGS = {
-    'TITLE': 'UMCCR OrcaBus sequence_run_manager API',
-    'DESCRIPTION': 'UMCCR OrcaBus sequence_run_manager API',
-    'VERSION': API_VERSION,
-    'SERVE_INCLUDE_SCHEMA': False,
-    'SECURITY': [
-        {
-            "type": "http",
-            "scheme": "bearer",
-            "bearerFormat": "JWT",
-        }
-    ],
-    'CONTACT': {
-        'name': 'UMCCR',
-        'email': 'services@umccr.org'
-    },
-    "LICENSE": {
-        "name": "MIT License",
-    },
-    "EXTERNAL_DOCS": {
-        "description": "Terms of service",
-        "url": "https://umccr.org/",
-    },
-    'CAMELIZE_NAMES': True,
-    'POSTPROCESSING_HOOKS': [
-        'drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields',
-        'drf_spectacular.hooks.postprocess_schema_enums'
-    ],
-}

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/base.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/base.py
@@ -1,4 +1,6 @@
 from django.urls import path, include
+from django.urls import path
+from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
 
 from sequence_run_manager.routers import OptionalSlashDefaultRouter
 from sequence_run_manager.viewsets.sequence import SequenceViewSet
@@ -18,6 +20,9 @@ router.register("sequence/(?P<orcabus_id>[^/]+)/state", StateViewSet, basename="
 
 urlpatterns = [
     path(f"{api_base}", include(router.urls)),
+    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
+    path('schema/swagger-ui/',
+         SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]
 
 handler500 = "rest_framework.exceptions.server_error"

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/local.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/urls/local.py
@@ -1,10 +1,5 @@
-from django.urls import path
-from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
-
 from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
-    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
-    path('swagger-ui/',
-         SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    # Some URL that only exists in the local environment
 ]

--- a/lib/workload/stateless/stacks/workflow-manager/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/workflow-manager/deploy/stack.ts
@@ -13,7 +13,12 @@ import {
 } from 'aws-cdk-lib';
 import { PythonFunction, PythonLayerVersion } from '@aws-cdk/aws-lambda-python-alpha';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
-import { HttpMethod, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv2';
+import {
+  HttpMethod,
+  HttpNoneAuthorizer,
+  HttpRoute,
+  HttpRouteKey,
+} from 'aws-cdk-lib/aws-apigatewayv2';
 import { PostgresManagerStack } from '../../../../stateful/stacks/postgres-manager/deploy/stack';
 import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { ApiGatewayConstruct, ApiGatewayConstructProps } from '../../../../components/api-gateway';
@@ -123,6 +128,14 @@ export class WorkflowManagerStack extends Stack {
     const httpApi = wfmApi.httpApi;
 
     const apiIntegration = new HttpLambdaIntegration('ApiIntegration', apiFn);
+
+    // Routes for API schemas
+    new HttpRoute(this, 'GetSchemaHttpRoute', {
+      httpApi: wfmApi.httpApi,
+      integration: apiIntegration,
+      authorizer: new HttpNoneAuthorizer(), // No auth needed for schema
+      routeKey: HttpRouteKey.with(`/schema/{PROXY+}`, HttpMethod.GET),
+    });
 
     new HttpRoute(this, 'GetHttpRoute', {
       httpApi: httpApi,

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/base.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/base.py
@@ -143,6 +143,9 @@ REST_FRAMEWORK = {
     "JSON_UNDERSCOREIZE": {
         'no_underscore_before_number': True,
     },
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+    ],
 }
 
 CORS_ORIGIN_ALLOW_ALL = True

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/base.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/base.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "workflow_manager",
     "aws_xray_sdk.ext.django",
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
@@ -164,3 +165,38 @@ XRAY_RECORDER = {
 
 # turn off xray more generally and, you can overwrite with env var AWS_XRAY_SDK_ENABLED=true at runtime
 aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+
+# --- drf-spectacular settings
+
+REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'UMCCR OrcaBus workflow_manager API',
+    'DESCRIPTION': 'UMCCR OrcaBus workflow_manager API',
+    'VERSION': API_VERSION,
+    'SERVE_INCLUDE_SCHEMA': False,
+    'SECURITY': [
+        {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
+    ],
+    'CONTACT': {
+        'name': 'UMCCR',
+        'email': 'services@umccr.org'
+    },
+    "LICENSE": {
+        "name": "MIT License",
+    },
+    "EXTERNAL_DOCS": {
+        "description": "Terms of service",
+        "url": "https://umccr.org/",
+    },
+    'CAMELIZE_NAMES': True,
+    'POSTPROCESSING_HOOKS': [
+        'drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields',
+        'drf_spectacular.hooks.postprocess_schema_enums'
+    ],
+    'SCHEMA_PATH_PREFIX': f'/api/{API_VERSION}/',
+}

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/local.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/settings/local.py
@@ -23,44 +23,9 @@ DATABASES = {
 
 INSTALLED_APPS += (
     "django_extensions",
-    "drf_spectacular",
 )
 
 ROOT_URLCONF = "workflow_manager.urls.local"
 
 RUNSERVER_PLUS_PRINT_SQL_TRUNCATE = sys.maxsize
 
-# --- drf-spectacular settings
-
-REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
-
-SPECTACULAR_SETTINGS = {
-    'TITLE': 'UMCCR OrcaBus workflow_manager API',
-    'DESCRIPTION': 'UMCCR OrcaBus workflow_manager API',
-    'VERSION': API_VERSION,
-    'SERVE_INCLUDE_SCHEMA': False,
-    'SECURITY': [
-        {
-            "type": "http",
-            "scheme": "bearer",
-            "bearerFormat": "JWT",
-        }
-    ],
-    'CONTACT': {
-        'name': 'UMCCR',
-        'email': 'services@umccr.org'
-    },
-    "LICENSE": {
-        "name": "MIT License",
-    },
-    "EXTERNAL_DOCS": {
-        "description": "Terms of service",
-        "url": "https://umccr.org/",
-    },
-    'CAMELIZE_NAMES': True,
-    'POSTPROCESSING_HOOKS': [
-        'drf_spectacular.contrib.djangorestframework_camel_case.camelize_serializer_fields',
-        'drf_spectacular.hooks.postprocess_schema_enums'
-    ],
-    'SCHEMA_PATH_PREFIX': f'/api/{API_VERSION}/',
-}

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/base.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/base.py
@@ -1,4 +1,6 @@
 from django.urls import path, include
+from django.urls import path
+from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
 
 from workflow_manager.routers import OptionalSlashDefaultRouter
 from workflow_manager.viewsets.analysis import AnalysisViewSet
@@ -49,6 +51,9 @@ router.register(
 
 urlpatterns = [
     path(f"{api_base}", include(router.urls)),
+    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
+    path('schema/swagger-ui/',
+         SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
 ]
 
 handler500 = "rest_framework.exceptions.server_error"

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/local.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/urls/local.py
@@ -1,10 +1,5 @@
-from django.urls import path
-from drf_spectacular.views import SpectacularJSONAPIView, SpectacularSwaggerView
-
 from .base import urlpatterns as base_urlpatterns
 
 urlpatterns = base_urlpatterns + [
-    path('schema/openapi.json', SpectacularJSONAPIView.as_view(), name='schema'),
-    path('swagger-ui/',
-         SpectacularSwaggerView.as_view(url_name='schema'), name='swagger-ui'),
+    # Some URL that only exists in the local environment
 ]

--- a/skel/django-api/deploy/stack.ts
+++ b/skel/django-api/deploy/stack.ts
@@ -8,7 +8,7 @@ import { EventBus, IEventBus, Rule } from 'aws-cdk-lib/aws-events';
 import { aws_events_targets, aws_lambda, aws_secretsmanager, Duration, Stack, StackProps } from 'aws-cdk-lib';
 import { PythonFunction, PythonLayerVersion } from '@aws-cdk/aws-lambda-python-alpha';
 import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
-import { HttpMethod, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpMethod, HttpNoneAuthorizer, HttpRoute, HttpRouteKey } from 'aws-cdk-lib/aws-apigatewayv2';
 import { PostgresManagerStack } from '../../../lib/workload/stateful/stacks/postgres-manager/deploy/stack';
 import { ManagedPolicy, Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
 import { ApiGatewayConstruct, ApiGatewayConstructProps } from '../../../lib/workload/components/api-gateway';
@@ -116,6 +116,14 @@ export class ProjectNameStack extends Stack {  // FIXME change construct name
     const httpApi = srmApi.httpApi;
 
     const apiIntegration = new HttpLambdaIntegration('ApiIntegration', apiFn);
+
+    // Routes for API schemas
+    new HttpRoute(this, 'GetSchemaHttpRoute', {
+      httpApi: srmApi.httpApi,
+      integration: apiIntegration,
+      authorizer: new HttpNoneAuthorizer(), // No auth needed for schema
+      routeKey: HttpRouteKey.with(`/schema/{PROXY+}`, HttpMethod.GET),
+    });
 
     new HttpRoute(this, 'GetHttpRoute', {
       httpApi: httpApi,

--- a/skel/django-api/project_name/settings/base.py
+++ b/skel/django-api/project_name/settings/base.py
@@ -143,6 +143,9 @@ REST_FRAMEWORK = {
     "JSON_UNDERSCOREIZE": {
         'no_underscore_before_number': True,
     },
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework.authentication.TokenAuthentication",
+    ],
 }
 
 CORS_ORIGIN_ALLOW_ALL = True
@@ -161,3 +164,33 @@ XRAY_RECORDER = {
 
 # turn off xray more generally and, you can overwrite with env var AWS_XRAY_SDK_ENABLED=true at runtime
 aws_xray_sdk.global_sdk_config.set_sdk_enabled(False)
+
+
+# --- drf-spectacular settings
+
+REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'UMCCR OrcaBus {{project_name}} API',
+    'DESCRIPTION': 'UMCCR OrcaBus {{project_name}} API',
+    'VERSION': API_VERSION,
+    'SERVE_INCLUDE_SCHEMA': False,
+    'SECURITY': [
+        {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT",
+        }
+    ],
+    'CONTACT': {
+        'name': 'UMCCR',
+        'email': 'services@umccr.org'
+    },
+    "LICENSE": {
+        "name": "MIT License",
+    },
+    "EXTERNAL_DOCS": {
+        "description": "Terms of service",
+        "url": "https://umccr.org/",
+    },
+}

--- a/skel/django-api/project_name/settings/base.py
+++ b/skel/django-api/project_name/settings/base.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "{{project_name}}",
     "aws_xray_sdk.ext.django",
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [

--- a/skel/django-api/project_name/settings/local.py
+++ b/skel/django-api/project_name/settings/local.py
@@ -23,7 +23,6 @@ DATABASES = {
 
 INSTALLED_APPS += (
     "django_extensions",
-    "drf_spectacular",
 )
 
 ROOT_URLCONF = "{{project_name}}.urls.local"

--- a/skel/django-api/project_name/settings/local.py
+++ b/skel/django-api/project_name/settings/local.py
@@ -30,31 +30,3 @@ ROOT_URLCONF = "{{project_name}}.urls.local"
 
 RUNSERVER_PLUS_PRINT_SQL_TRUNCATE = sys.maxsize
 
-# --- drf-spectacular settings
-
-REST_FRAMEWORK['DEFAULT_SCHEMA_CLASS'] = 'drf_spectacular.openapi.AutoSchema'
-
-SPECTACULAR_SETTINGS = {
-    'TITLE': 'UMCCR OrcaBus {{project_name}} API',
-    'DESCRIPTION': 'UMCCR OrcaBus {{project_name}} API',
-    'VERSION': API_VERSION,
-    'SERVE_INCLUDE_SCHEMA': False,
-    'SECURITY': [
-        {
-            "type": "http",
-            "scheme": "bearer",
-            "bearerFormat": "JWT",
-        }
-    ],
-    'CONTACT': {
-        'name': 'UMCCR',
-        'email': 'services@umccr.org'
-    },
-    "LICENSE": {
-        "name": "MIT License",
-    },
-    "EXTERNAL_DOCS": {
-        "description": "Terms of service",
-        "url": "https://umccr.org/",
-    },
-}


### PR DESCRIPTION
Only in Django Microservice

- Move swagger local to the deployable endpoint
- Change swagger path (from `/swagger-ui`) to `/schema/swagger-ui`
- Add NoneAuth for all path prefix with `/schema` endpoint in API-GW

cc: @raylrui @mmalenic 