### PR TITLE
fix(WFM): Put Back `camelCase` Serializer

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/serializers/base.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/serializers/base.py
@@ -13,6 +13,14 @@ class SerializersBase(serializers.ModelSerializer):
         super().__init__(*args, **kwargs)
         self.use_camel_case = camel_case_data
 
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        if self.use_camel_case:
+            return {to_camel_case(key): value for key, value in representation.items()}
+        return representation
+
+
 
 class OptionalFieldsMixin:
     def make_fields_optional(self):


### PR DESCRIPTION
The removal in #784 is not intended. The re-run workflow depends on this to dispatch the correct JSON format to the EB.


Fix [slack-thread](https://umccr.slack.com/archives/C03ABJTSN7J/p1736120499759199?thread_ts=1734914138.553039&cid=C03ABJTSN7J)