### PR TITLE
build: update htsget-lambda dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "constructs": "^10.4.2",
     "core-js-pure": "^3.39.0",
     "dotenv": "^16.4.7",
-    "htsget-lambda": "^0.7.1",
+    "htsget-lambda": "^0.7.2",
     "source-map-support": "^0.5.21",
     "sqs-dlq-monitoring": "^1.2.18"
   },
@@ -42,7 +42,7 @@
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
-    "aws-cdk": "2.164.1",
+    "aws-cdk": "2.174.1",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,9 +1526,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk@npm:2.164.1":
-  version: 2.164.1
-  resolution: "aws-cdk@npm:2.164.1"
+"aws-cdk@npm:2.174.1":
+  version: 2.174.1
+  resolution: "aws-cdk@npm:2.174.1"
   dependencies:
     fsevents: "npm:2.3.2"
   dependenciesMeta:
@@ -1536,7 +1536,7 @@ __metadata:
       optional: true
   bin:
     cdk: bin/cdk
-  checksum: 10/76cb082aacd3dc00e57c9034fea3ea612d9b699376787262630974aabda167950a42f6702216c5824d4b8545028d94b8b69d905906c73c4d410471847aa9b023
+  checksum: 10/b790b6b8d70e2edd8f08b051bdb5925e0979388f44d47d898877abea7d7291aa8f17043741fa9f0bfdf86e7ee54a6ca4551bed1e036f03aa2464a1a61bcf787e
   languageName: node
   linkType: hard
 
@@ -1902,7 +1902,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"constructs@npm:10.4.2, constructs@npm:^10.4.2":
+"constructs@npm:^10.4.2":
   version: 10.4.2
   resolution: "constructs@npm:10.4.2"
   checksum: 10/0322de2ff7bca27dc71419b0437e2bcabc572bdce565b6cc0a34d12c74b32a27c69431975f2947503cbd31166f08ce3c98d1904fe469005b23c95fc2f5cef829
@@ -2599,22 +2599,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "glob@npm:11.0.0"
-  dependencies:
-    foreground-child: "npm:^3.1.0"
-    jackspeak: "npm:^4.0.1"
-    minimatch: "npm:^10.0.0"
-    minipass: "npm:^7.1.2"
-    package-json-from-dist: "npm:^1.0.0"
-    path-scurry: "npm:^2.0.0"
-  bin:
-    glob: dist/esm/bin.mjs
-  checksum: 10/e66939201d11ae30fe97e3364ac2be5c59d6c9bfce18ac633edfad473eb6b46a7553f6f73658f67caaf6cccc1df1ae336298a45e9021fa5695fd78754cc1603e
-  languageName: node
-  linkType: hard
-
 "glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -2687,19 +2671,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htsget-lambda@npm:^0.7.1":
-  version: 0.7.1
-  resolution: "htsget-lambda@npm:0.7.1"
+"htsget-lambda@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "htsget-lambda@npm:0.7.2"
   dependencies:
     "@iarna/toml": "npm:^3.0.0"
-    aws-cdk-lib: "npm:2.164.1"
     cargo-lambda-cdk: "npm:^0.0.31"
-    constructs: "npm:10.4.2"
-    glob: "npm:^11.0.0"
-    source-map-support: "npm:^0.5.21"
+  peerDependencies:
+    aws-cdk-lib: ^2.112.0
   bin:
     htsget_app: bin/htsget-lambda.js
-  checksum: 10/f68b0ad3175dde0d3168dc4d84fc1d0a8891fc15ce3cab184f514189f38b865cf52813edb70fd977deb9e2323bfbaccba7e91ac9e2df8263562a0d316df05bb5
+  checksum: 10/e313d4885be65b48a717d10b47389da2d850d4159a28e1ba4ca66ec009f1989ceec32f79e8f9f0957f7d541795dd02f252bc6c7d206b5a5df814f56f89864227
   languageName: node
   linkType: hard
 
@@ -2958,15 +2940,6 @@ __metadata:
     "@pkgjs/parseargs":
       optional: true
   checksum: 10/96f8786eaab98e4bf5b2a5d6d9588ea46c4d06bbc4f2eb861fdd7b6b182b16f71d8a70e79820f335d52653b16d4843b29dd9cdcf38ae80406756db9199497cf3
-  languageName: node
-  linkType: hard
-
-"jackspeak@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "jackspeak@npm:4.0.2"
-  dependencies:
-    "@isaacs/cliui": "npm:^8.0.2"
-  checksum: 10/d9722f0e55f6c322c57aedf094c405f4201b834204629817187953988075521cfddb23df83e2a7b845723ca7eb0555068c5ce1556732e9c275d32a531881efa8
   languageName: node
   linkType: hard
 
@@ -3648,13 +3621,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0":
-  version: 11.0.2
-  resolution: "lru-cache@npm:11.0.2"
-  checksum: 10/25fcb66e9d91eaf17227c6abfe526a7bed5903de74f93bfde380eb8a13410c5e8d3f14fe447293f3f322a7493adf6f9f015c6f1df7a235ff24ec30f366e1c058
-  languageName: node
-  linkType: hard
-
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -3752,15 +3718,6 @@ __metadata:
   version: 2.1.0
   resolution: "mimic-fn@npm:2.1.0"
   checksum: 10/d2421a3444848ce7f84bd49115ddacff29c15745db73f54041edc906c14b131a38d05298dae3081667627a59b2eb1ca4b436ff2e1b80f69679522410418b478a
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^10.0.0":
-  version: 10.0.1
-  resolution: "minimatch@npm:10.0.1"
-  dependencies:
-    brace-expansion: "npm:^2.0.1"
-  checksum: 10/082e7ccbc090d5f8c4e4e029255d5a1d1e3af37bda837da2b8b0085b1503a1210c91ac90d9ebfe741d8a5f286ece820a1abb4f61dc1f82ce602a055d461d93f3
   languageName: node
   linkType: hard
 
@@ -4012,7 +3969,7 @@ __metadata:
     "@types/eslint__js": "npm:^8.42.3"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.10.2"
-    aws-cdk: "npm:2.164.1"
+    aws-cdk: "npm:2.174.1"
     aws-cdk-lib: "npm:2.164.1"
     cargo-lambda-cdk: "npm:0.0.22"
     cdk-nag: "npm:^2.34.23"
@@ -4022,7 +3979,7 @@ __metadata:
     eslint: "npm:^9.17.0"
     eslint-config-prettier: "npm:^9.1.0"
     globals: "npm:^15.14.0"
-    htsget-lambda: "npm:^0.7.1"
+    htsget-lambda: "npm:^0.7.2"
     jest: "npm:^29.7.0"
     jest-junit: "npm:^16.0.0"
     prettier: "npm:^3.4.2"
@@ -4148,16 +4105,6 @@ __metadata:
     lru-cache: "npm:^10.2.0"
     minipass: "npm:^5.0.0 || ^6.0.2 || ^7.0.0"
   checksum: 10/5e8845c159261adda6f09814d7725683257fcc85a18f329880ab4d7cc1d12830967eae5d5894e453f341710d5484b8fdbbd4d75181b4d6e1eb2f4dc7aeadc434
-  languageName: node
-  linkType: hard
-
-"path-scurry@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "path-scurry@npm:2.0.0"
-  dependencies:
-    lru-cache: "npm:^11.0.0"
-    minipass: "npm:^7.1.2"
-  checksum: 10/285ae0c2d6c34ae91dc1d5378ede21981c9a2f6de1ea9ca5a88b5a270ce9763b83dbadc7a324d512211d8d36b0c540427d3d0817030849d97a60fa840a2c59ec
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related #758 
Related PR: https://github.com/umccr/htsget-deploy/pull/6

### Changes
* Update `htsget-lambda` with `aws-cdk-lib` peer dependency so that the `aws-cdk-lib` dependency can be updated in orcabus.