### PR TITLE
fix(sscheck): change metadata reference domain name

### DIFF
--- a/config/stacks/sampleSheetChecker.ts
+++ b/config/stacks/sampleSheetChecker.ts
@@ -7,6 +7,12 @@ import {
 } from '../constants';
 
 export const getSampleSheetCheckerProps = (stage: AppStage): SampleSheetCheckerStackProps => {
+  const metadataDomainNameDict = {
+    [AppStage.BETA]: 'metadata.dev.umccr.org',
+    [AppStage.GAMMA]: 'metadata.stg.umccr.org',
+    [AppStage.PROD]: 'metadata.prod.umccr.org',
+  };
+
   return {
     apiGatewayConstructProps: {
       ...cognitoApiGatewayConfig,
@@ -15,5 +21,6 @@ export const getSampleSheetCheckerProps = (stage: AppStage): SampleSheetCheckerS
       apiName: 'SSCheck',
       customDomainNamePrefix: 'sscheck-orcabus',
     },
+    metadataDomainName: metadataDomainNameDict[stage],
   };
 };

--- a/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/src/metadata.py
+++ b/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/src/metadata.py
@@ -4,9 +4,8 @@ from typing import List
 import json
 
 # Grab api constant from environment variable
-DOMAIN_NAME = os.environ.get("DATA_PORTAL_DOMAIN_NAME", "dev.umccr.org")
+METADATA_DOMAIN_NAME = os.environ.get("METADATA_DOMAIN_NAME", "metadata.dev.umccr.org")
 METADATA_API_PATH = 'api/v1/library'
-METADATA_SUBDOMAIN = 'metadata'
 
 
 def get_metadata_record_from_array_of_field_name(auth_header: str, field_name: str,
@@ -37,7 +36,7 @@ def get_metadata_record_from_array_of_field_name(auth_header: str, field_name: s
 
         query_param_string = query_param_string + f'&rowsPerPage=1000'  # Add Rows per page (1000 is the maximum rows)
 
-        url = f"https://{METADATA_SUBDOMAIN.strip('.')}.{DOMAIN_NAME.strip('.')}/{METADATA_API_PATH.strip('/')}/{query_param_string}"
+        url = f"https://{METADATA_DOMAIN_NAME.strip('.')}/{METADATA_API_PATH.strip('/')}/{query_param_string}"
         # Make sure no data is left, looping data until the end
         while url is not None:
             req = urllib.request.Request(url, headers=headers)

--- a/lib/workload/stateless/stacks/sample-sheet-check/stack.ts
+++ b/lib/workload/stateless/stacks/sample-sheet-check/stack.ts
@@ -15,6 +15,10 @@ export interface SampleSheetCheckerStackProps {
    * The props for api-gateway
    */
   apiGatewayConstructProps: ApiGatewayConstructProps;
+  /**
+   * The domain name of the metadata service
+   */
+  metadataDomainName: string;
 }
 
 export class SampleSheetCheckerStack extends Stack {
@@ -27,8 +31,6 @@ export class SampleSheetCheckerStack extends Stack {
       props.apiGatewayConstructProps
     );
 
-    const domainName = StringParameter.valueForStringParameter(this, 'umccr_domain');
-
     const sscheckLambda = new DockerImageFunction(this, 'SSCheckLambda', {
       code: DockerImageCode.fromImageAsset(path.join(__dirname, 'sample-sheet-check-lambda'), {
         file: 'lambda.Dockerfile',
@@ -38,7 +40,7 @@ export class SampleSheetCheckerStack extends Stack {
       timeout: Duration.seconds(28),
       memorySize: 1024,
       environment: {
-        DATA_PORTAL_DOMAIN_NAME: domainName,
+        METADATA_DOMAIN_NAME: props.metadataDomainName,
       },
       initialPolicy: [
         // Not enabling logs


### PR DESCRIPTION
`umccr_domain` parameter name does not exist in every stage account. Will put the metadata domain name as a config stack.