### PR TITLE
fix(token-service): generated password should contain required characters

### DIFF
--- a/lib/workload/stateful/stacks/token-service/token_service/rotate_service_jwt.py
+++ b/lib/workload/stateful/stacks/token-service/token_service/rotate_service_jwt.py
@@ -49,7 +49,7 @@ def lambda_handler(event, context):
         event (dict): Lambda dictionary of event parameters. These keys must include the following:
             - SecretId: The secret ARN or identifier
             - ClientRequestToken: The ClientRequestToken of the secret version
-            - Step: The rotation step (one of createSecret, setSecret, testSecret, or finishSecret)
+            - Step: The rotation step (one of createSecret, setSecret, testSecret, finishSecret or resetPendingSecret)
 
         context (LambdaContext): The Lambda runtime information
 
@@ -96,6 +96,9 @@ def lambda_handler(event, context):
 
     elif step == "finishSecret":
         finish_secret(service_client, arn, token)
+
+    elif step == "resetPendingSecret":
+        reset_pending_secret(service_client, arn, token)
 
     else:
         logger.error("lambda_handler: Invalid step parameter %s for secret %s" % (step, arn))
@@ -258,6 +261,31 @@ def finish_secret(service_client, arn, token):
     # Finalize by staging the secret version current
     service_client.update_secret_version_stage(SecretId=arn, VersionStage="AWSCURRENT", MoveToVersionId=token, RemoveFromVersionId=current_version)
     logger.info("finishSecret: Successfully set AWSCURRENT stage to version %s for secret %s." % (token, arn))
+
+
+def reset_pending_secret(service_client, arn, token):
+    """Clears the pending secret so that a new one can be generated.
+
+    Args:
+        service_client (client): The secrets manager service client
+
+        arn (string): The secret ARN or other identifier
+
+        token (string): The ClientRequestToken associated with the secret version
+
+    """
+    secret = service_client.get_secret_value(
+        SecretId=arn, VersionId=token, VersionStage="AWSPENDING"
+    )
+    version_id = secret["VersionId"]
+
+    service_client.update_secret_version_stage(
+        SecretId=arn, VersionStage="AWSPENDING", RemoveFromVersionId=version_id
+    )
+    logger.info(
+        "resetPendingSecret: Successfully removed AWSPENDING stage from version %s for secret %s."
+        % (token, arn)
+    )
 
 
 # --- module internal functions

--- a/lib/workload/stateful/stacks/token-service/token_service/rotate_service_user.py
+++ b/lib/workload/stateful/stacks/token-service/token_service/rotate_service_user.py
@@ -124,7 +124,7 @@ def create_secret(service_client, arn, token):
         logger.info("createSecret: Successfully retrieved secret for %s." % arn)
     except service_client.exceptions.ResourceNotFoundException:
         # Generate a random password
-        current_dict['password'] = CognitoTokenService.generate_password()
+        current_dict['password'] = token_srv.generate_password()
         # Put the secret
         service_client.put_secret_value(SecretId=arn, ClientRequestToken=token, SecretString=json.dumps(current_dict), VersionStages=['AWSPENDING'])
         logger.info("createSecret: Successfully put secret for ARN %s and version %s." % (arn, token))


### PR DESCRIPTION
Closes #811 

### Changes
* Ensure that the required characters are always present in generated password to prevent the secret rotation from failing.
    * Cognito allows defining password requirements, in this case the password should have at least 1 uppercase, lowercase, numeric, and special characters: https://docs.aws.amazon.com/cognito/latest/developerguide/managing-users-passwords.html