### PR TITLE
fix(pipeline): enable logging on github action runner

### DIFF
--- a/lib/pipeline/statelessPipelineStack.ts
+++ b/lib/pipeline/statelessPipelineStack.ts
@@ -1,12 +1,10 @@
 import { Construct } from 'constructs';
 import * as cdk from 'aws-cdk-lib';
-import { ArnFormat, Stack } from 'aws-cdk-lib';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as pipelines from 'aws-cdk-lib/pipelines';
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import { ComputeType } from 'aws-cdk-lib/aws-codebuild';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import * as chatbot from 'aws-cdk-lib/aws-chatbot';
 import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as codestarnotifications from 'aws-cdk-lib/aws-codestarnotifications';


### PR DESCRIPTION
Closes #812 

### Changes
* Enables logging on the github action runner to address security hub control: https://docs.aws.amazon.com/securityhub/latest/userguide/codebuild-controls.html#codebuild-4

