### PR TITLE
Chore(sscheck): Re-enable logging and detailed error message

### DIFF
--- a/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/handler.py
+++ b/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/handler.py
@@ -29,7 +29,7 @@ def lambda_handler(event, context):
     event_copy['headers'].pop('Authorization', None)
     event_copy['headers'].pop('authorization', None)
 
-    logger.info(f"Processing (event, context): {event_copy}, {context}")
+    print(f"Processing (event, context): {event_copy}, {context}")
 
     # Parse header
     headers = event.get("headers", {})

--- a/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/handler.py
+++ b/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/handler.py
@@ -75,7 +75,10 @@ def lambda_handler(event, context):
         v2_sample_sheet_str = v1_to_v2_samplesheet(sample_sheet)
 
     except Exception as e:
-        body = construct_body(check_status="FAIL", error_message=str(e), log_path=LOG_PATH,
+        error_message = str(e)
+        if not error_message:
+            error_message = type(e).__name__
+        body = construct_body(check_status="FAIL", error_message=error_message, log_path=LOG_PATH,
                               v2_sample_sheet='')
         response = construct_response(status_code=200, body=body, origin=origin)
         return response

--- a/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/src/checker.py
+++ b/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/src/checker.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from src.errors import FileContentError
-from src.logger import get_logger, set_basic_logger, set_logger
+from src.logger import set_basic_logger, set_logger
 from src.samplesheet import SampleSheet, check_sample_sheet_for_index_clashes, check_samplesheet_header_metadata, \
     get_years_from_samplesheet, check_metadata_correspondence, check_global_override_cycles, \
     check_internal_override_cycles

--- a/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/src/logger.py
+++ b/lib/workload/stateless/stacks/sample-sheet-check/sample-sheet-check-lambda/src/logger.py
@@ -62,6 +62,7 @@ def set_logger(log_path, log_level=logging.DEBUG):
         f.write("")
 
     new_logger = logging.getLogger()
+    new_logger.handlers.clear()
     new_logger.setLevel(log_level)
 
     # create a logging format

--- a/lib/workload/stateless/stacks/sample-sheet-check/stack.ts
+++ b/lib/workload/stateless/stacks/sample-sheet-check/stack.ts
@@ -42,14 +42,6 @@ export class SampleSheetCheckerStack extends Stack {
       environment: {
         METADATA_DOMAIN_NAME: props.metadataDomainName,
       },
-      initialPolicy: [
-        // Not enabling logs
-        new PolicyStatement({
-          effect: Effect.DENY,
-          actions: ['logs:CreateLogGroup', 'logs:CreateLogStream', 'logs:PutLogEvents'],
-          resources: ['arn:aws:logs:*:*:*'],
-        }),
-      ],
     });
 
     // add some integration to the http api gw


### PR DESCRIPTION
- Enable back AWS lambda logging to CloudWatch
- On failed validation, return the error name to clarify the problem from the sample sheet