### PR TITLE
Feat(WFM): Duplication rerun check

### DIFF
--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/errors.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/errors.py
@@ -1,0 +1,8 @@
+class RerunDuplicationError(Exception):
+    """
+    Exception raised when a rerun duplication is not allowed.
+    """
+
+    def __init__(self, message="Duplication rerun is not allowed."):
+        self.message = message
+        super().__init__(self.message)

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/serializers/workflow_run_action.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/serializers/workflow_run_action.py
@@ -15,6 +15,9 @@ class AllowedRerunWorkflowSerializer(serializers.Serializer):
 
 
 class BaseRerunInputSerializer(serializers.Serializer):
+    # Reruns with the same input (duplicate reruns) should not be allowed unless this flag is set to True
+    allow_duplication = serializers.BooleanField(default=False, required=False,
+                                                 help_text='Allow rerun with the same previous input (duplicate rerun)')
 
     def update(self, instance, validated_data):
         pass

--- a/lib/workload/stateless/stacks/workflow-manager/workflow_manager/viewsets/workflow_run_action.py
+++ b/lib/workload/stateless/stacks/workflow-manager/workflow_manager/viewsets/workflow_run_action.py
@@ -12,10 +12,12 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, PolymorphicProxySerializer
 
 from workflow_manager.aws_event_bridge.event import emit_wrsc_api_event
+from workflow_manager.errors import RerunDuplicationError
 from workflow_manager.models.utils import create_portal_run_id
 from workflow_manager.serializers.library import LibrarySerializer
 from workflow_manager.serializers.payload import PayloadSerializer
-from workflow_manager.serializers.workflow_run_action import AllowedRerunWorkflow, RERUN_INPUT_SERIALIZERS, AllowedRerunWorkflowSerializer
+from workflow_manager.serializers.workflow_run_action import AllowedRerunWorkflow, RERUN_INPUT_SERIALIZERS, \
+    AllowedRerunWorkflowSerializer
 from workflow_manager.models import (
     WorkflowRun,
     State,
@@ -31,20 +33,20 @@ class WorkflowRunActionViewSet(ViewSet):
     def validate_rerun_workflows(self, request, *args, **kwargs):
         wfl_run = get_object_or_404(self.queryset, pk=kwargs.get('pk'))
         is_valid = wfl_run.workflow.workflow_name in AllowedRerunWorkflow
-        
+
         # Get allowed dataset choice for the workflow
         wfl_name = wfl_run.workflow.workflow_name
         allowed_dataset_choice = []
         if wfl_name == AllowedRerunWorkflow.RNASUM.value:
             allowed_dataset_choice = RERUN_INPUT_SERIALIZERS[wfl_name].allowed_dataset_choice
-        
+
         response = {
             'is_valid': is_valid,
             'allowed_dataset_choice': allowed_dataset_choice,
             'valid_workflows': AllowedRerunWorkflow,
         }
         return Response(response, status=status.HTTP_200_OK)
-    
+
     @extend_schema(
         request=PolymorphicProxySerializer(
             component_name='WorkflowRunRerun',
@@ -77,8 +79,11 @@ class WorkflowRunActionViewSet(ViewSet):
         if not serializer.is_valid():
             return Response(serializer.errors,
                             status=status.HTTP_400_BAD_REQUEST)
+        try:
+            detail = construct_rerun_eb_detail(wfl_run, serializer.data)
+        except RerunDuplicationError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
-        detail = construct_rerun_eb_detail(wfl_run, serializer.data)
         emit_wrsc_api_event(detail)
 
         return Response(detail, status=status.HTTP_200_OK)
@@ -91,6 +96,8 @@ def construct_rerun_eb_detail(wfl_run: WorkflowRun, input_body: dict) -> dict:
     new_portal_run_id = create_portal_run_id()
     wfl_name = wfl_run.workflow.workflow_name
 
+    # Each rerun workflow type must implement its own rerun duplication logic and raise `RerunDuplicationError`
+    # if it is considered a duplication, unless `allow_duplication` is set to True in the input body.
     new_payload: dict
     if wfl_name == AllowedRerunWorkflow.RNASUM.value:
         new_payload = construct_rnasum_rerun_payload(wfl_run, input_body)
@@ -100,14 +107,14 @@ def construct_rerun_eb_detail(wfl_run: WorkflowRun, input_body: dict) -> dict:
     # Replace old portal_run_id with new_portal_run_id in any part of the string
     new_eb_detail = json.loads(
         json.dumps({
-                "status": 'READY',
-                "payload": new_payload,
-                "portalRunId": new_portal_run_id,
-                "linkedLibraries": LibrarySerializer(wfl_run.libraries.all(), many=True, camel_case_data=True).data,
-                "workflowName": wfl_run.workflow.workflow_name,
-                "workflowRunName": wfl_run.workflow_run_name,
-                "workflowVersion": wfl_run.workflow.workflow_version,
-                "timestamp": datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
+            "status": 'READY',
+            "payload": new_payload,
+            "portalRunId": new_portal_run_id,
+            "linkedLibraries": LibrarySerializer(wfl_run.libraries.all(), many=True, camel_case_data=True).data,
+            "workflowName": wfl_run.workflow.workflow_name,
+            "workflowRunName": wfl_run.workflow_run_name,
+            "workflowVersion": wfl_run.workflow.workflow_version,
+            "timestamp": datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
         }).replace(f"{wfl_run.portal_run_id}", f"{new_portal_run_id}"))
 
     return new_eb_detail
@@ -117,6 +124,28 @@ def construct_rnasum_rerun_payload(wfl_run: WorkflowRun, input_body: dict) -> di
     """
     Construct payload for rerun for 'rnasum' workflow based on the request body payload
     """
+    allow_rerun_duplication = input_body.get("allow_duplication", False)
+
+    if not allow_rerun_duplication:
+        # The duplication check is based on the dataset input at the READY state of the workflow run that has the same
+        # linked libraries and Workflow entity. If the dataset has been run in the past, it will raise an error.
+
+        # Find all workflowrun that has the same linked libraries and Workflow entity
+        wfl_runs = WorkflowRun.objects.filter(
+            libraries__in=wfl_run.libraries.all(),
+            workflow=wfl_run.workflow
+        )
+
+        past_dataset = set()
+        for run in wfl_runs:
+            # Get the payload where the state is 'READY'
+            ready_state: State = run.states.get(status='READY')
+            ready_data_payload = PayloadSerializer(ready_state.payload).data
+            past_dataset.add(ready_data_payload.get('data', {}).get("inputs", {}).get("dataset", ''))
+
+        if input_body["dataset"] in past_dataset:
+            raise RerunDuplicationError(f"Dataset '{input_body['dataset']}' has been run in the past. "
+                                        f"Set 'allow_duplication' manually to True to proceed.")
 
     # Get the payload where the state is 'READY'
     ready_state: State = wfl_run.states.get(status='READY')


### PR DESCRIPTION
Add duplication input check before executing emitting rerun events to EB. The check is based on the `READY` state payload, where the workflow entity and linked library are the same as the given wfl_run. The payload check will depend on each wfl type, whereas RNAsum is only based on dataset input.

This will throw an error on UI as the bad request is returned.
<img width="340" alt="Screenshot 2025-02-04 at 11 17 48" src="https://github.com/user-attachments/assets/d0d0ffbe-147a-441b-94ce-b22406bee5b0" />

closes #815 