### PR TITLE
Fix/srm duplicate events

### DIFF
--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager_proc/lambdas/bssh_event.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager_proc/lambdas/bssh_event.py
@@ -114,7 +114,6 @@ def event_handler(event, context):
     if sequence_domain.status_has_changed:
         try:
             SequenceRule(sequence_domain.sequence).must_not_emergency_stop()
-            sequence_state_srv.create_sequence_state_from_bssh_event(event_details)
             entry = sequence_domain.to_put_events_request_entry(
                     event_bus_name=event_bus_name,
             )

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager_proc/tests/test_sequence_domain.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager_proc/tests/test_sequence_domain.py
@@ -21,7 +21,7 @@ class SequenceDomainUnitTests(SequenceRunProcUnitTestCase):
         """
         mock_sequence = SequenceFactory()
         mock_sequence_domain = SequenceDomain(
-            sequence=mock_sequence, state_has_changed=True
+            sequence=mock_sequence, state_has_changed=True, status_has_changed=True
         )
 
         marshalled_object = Marshaller.marshall(mock_sequence_domain.to_event())
@@ -39,7 +39,7 @@ class SequenceDomainUnitTests(SequenceRunProcUnitTestCase):
         """
         mock_sequence = SequenceFactory()
         mock_sequence_domain = SequenceDomain(
-            sequence=mock_sequence, state_has_changed=True
+            sequence=mock_sequence, state_has_changed=True, status_has_changed=True
         )
 
         marshalled_object = Marshaller.marshall(mock_sequence_domain.to_event())
@@ -60,7 +60,7 @@ class SequenceDomainUnitTests(SequenceRunProcUnitTestCase):
         """
         mock_sequence = SequenceFactory()
         mock_sequence_domain = SequenceDomain(
-            sequence=mock_sequence, state_has_changed=True
+            sequence=mock_sequence, state_has_changed=True, status_has_changed=True
         )
 
         aws_event = mock_sequence_domain.to_event_with_envelope()
@@ -76,7 +76,7 @@ class SequenceDomainUnitTests(SequenceRunProcUnitTestCase):
         """
         mock_sequence = SequenceFactory()
         mock_sequence_domain = SequenceDomain(
-            sequence=mock_sequence, state_has_changed=True
+            sequence=mock_sequence, state_has_changed=True, status_has_changed=True
         )
 
         mock_entry = mock_sequence_domain.to_put_events_request_entry(

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager_proc/tests/test_sequence_srv.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager_proc/tests/test_sequence_srv.py
@@ -37,6 +37,9 @@ class SequenceRunSrvUnitTests(SequenceRunProcUnitTestCase):
             seq_domain.sequence.instrument_run_id, seq_in_db.instrument_run_id
         )
         self.assertTrue(
+            seq_domain.status_has_changed
+        )  # assert Sequence Run Status has changed True
+        self.assertTrue(
             seq_domain.state_has_changed
         )  # assert Sequence Run State has changed True
 
@@ -63,5 +66,5 @@ class SequenceRunSrvUnitTests(SequenceRunProcUnitTestCase):
         self.assertIsNotNone(seq_domain)
         self.assertEqual(1, Sequence.objects.count())
         self.assertFalse(
-            seq_domain.state_has_changed
-        )  # assert Sequence Run State has changed False
+            seq_domain.status_has_changed
+        )  # assert Sequence Run Status has changed False


### PR DESCRIPTION
resolve https://github.com/umccr/orcabus/issues/877

1. remove repeated events creation in [bssh_event.py](https://github.com/umccr/orcabus/compare/fix/srm-duplicate-events?expand=1#diff-7eced148fe010954063e5940e29df3ecf0abfeb14abc1843fcc2428a06cf8344)

3. There is a bit 'chaos' in the order of 'bssh event' from bssh service event pipeline (from [cloudwatch logs](https://472057503814-d5o6bw3m.ap-southeast-2.console.aws.amazon.com/cloudwatch/home?region=ap-southeast-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252FOrcaBusProd-SequenceRunManager-ProcHandler044B1AD2-8l74WOppn2Kn/log-events/2025$252F02$252F24$252F$255B$2524LATEST$255D26fc8d0fb62d46e2a7e1a522bb299d20) in prod env). Rather than check the latest state of state history, we will check if there is already state by 'status' and 'dateModified' from payload, and then decide if create a new state.