### PR TITLE
feat(filemanager): allow updating ingest id even if already set

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
+++ b/lib/workload/stateless/stacks/filemanager/docs/API_GUIDE.md
@@ -199,8 +199,8 @@ curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/js
 "https://file.dev.umccr.org/api/v1/s3?key=*202405212aecb782*" | jq
 ```
 
-In addition to updating attributes, the PATCH request can also be used to update the `ingestId` for records with a null
-`ingestId`. For example, update the `ingestId` on a single record:
+In addition to updating attributes, the PATCH request can also be used to update the `ingestId`.
+For example, update the `ingestId` on a single record:
 
 ```sh
 curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
@@ -216,7 +216,8 @@ curl -X PATCH -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/js
 "https://file.dev.umccr.org/api/v1/s3?key=*202405212aecb782*" | jq
 ```
 
-Note the extra `ingestId` key in the JSON body. The operation must be `add`, and the path must be `/`.
+Note the extra `ingestId` key in the JSON body. The operation must be `add`, `replace`, or `remove`, and the path must
+be `/`.
 
 ## Count objects
 

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/mod.rs
@@ -30,7 +30,7 @@ pub mod list;
 pub mod update;
 
 /// Container for generating database entries.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Entries {
     pub s3_objects: Vec<S3Object>,
     pub s3_crawl: Vec<S3Crawl>,


### PR DESCRIPTION
Closes #881 

### Changes
* Allows updating ingest id even if already set, or removing an existing ingest id.