### PR TITLE
Added Fastq Sync Service

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -72,6 +72,10 @@ import {
   getFastqUnarchivingManagerStackProps,
   getFastqUnarchivingManagerTableStackProps,
 } from './stacks/fastqUnarchivingManager';
+import {
+  getFastqSyncManagerStackProps,
+  getFastqSyncManagerTableStackProps,
+} from './stacks/fastqSyncManager';
 
 interface EnvironmentConfig {
   name: string;
@@ -115,6 +119,7 @@ export const getEnvironmentConfig = (stage: AppStage): EnvironmentConfig | null 
       accessKeySecretStackProps: getAccessKeySecretStackProps(stage),
       fastqManagerTableStackProps: getFastqManagerTableStackProps(stage),
       fastqUnarchivingManagerTableStackProps: getFastqUnarchivingManagerTableStackProps(),
+      fastqSyncManagerTableStackProps: getFastqSyncManagerTableStackProps(),
     },
     statelessConfig: {
       metadataManagerStackProps: getMetadataManagerStackProps(stage),
@@ -147,6 +152,7 @@ export const getEnvironmentConfig = (stage: AppStage): EnvironmentConfig | null 
       pgDDProps: getPgDDProps(stage),
       fastqManagerStackProps: getFastqManagerStackProps(stage),
       fastqUnarchivingManagerStackProps: getFastqUnarchivingManagerStackProps(stage),
+      fastqSyncManagerStackProps: getFastqSyncManagerStackProps(stage),
     },
   };
 

--- a/config/constants.ts
+++ b/config/constants.ts
@@ -961,3 +961,8 @@ export const fastqUnarchivingEventDetailType = {
   updateJob: 'FastqUnarchivingJobUpdated',
 };
 export const fastqUnarchivingManagerEventSource = 'orcabus.fastqunarchivingmanager';
+
+/*
+Fastq sync service
+*/
+export const fastqSyncEventDetailType = 'fastqSync';

--- a/config/stacks/fastqSyncManager.ts
+++ b/config/stacks/fastqSyncManager.ts
@@ -1,0 +1,91 @@
+import {
+  AppStage,
+  /* Events */
+  eventBusName,
+  fastqManagerEventDetails,
+  fastqManagerEventSource,
+  fastqSyncEventDetailType,
+  fastqUnarchivingEventDetailType,
+  fastqUnarchivingManagerEventSource,
+  hostedZoneNameParameterPath,
+  icav2PipelineCacheBucket,
+  icav2PipelineCachePrefix,
+  jwtSecretName,
+} from '../constants';
+
+import { FastqSyncManagerStackConfig } from '../../lib/workload/stateless/stacks/fastq-sync/deploy/interfaces';
+import { FastqSyncTableConfig } from '../../lib/workload/stateful/stacks/fastq-sync-dynamodb/deploy/stack';
+
+/*
+export interface FastqSyncManagerStackConfig {
+  /*
+  Orcabus token and zone name for external lambda functions
+  */
+//orcabusTokenSecretsManagerPath: string;
+//hostedZoneNameSsmParameterPath: string;
+
+/*
+  Data tables
+  */
+//fastqSyncDynamodbTableName: string;
+/*
+  Event bus stuff
+  */
+//eventBusName: string;
+// eventTriggers: FastqSyncEventTriggers
+//}
+//*/
+
+const fastqSyncDynamodbTableName = 'fastqSyncTokenTable';
+
+// Stateful
+export const getFastqSyncManagerTableStackProps = (): FastqSyncTableConfig => {
+  return {
+    /* DynamoDB table for fastq list rows */
+    dynamodbTableName: fastqSyncDynamodbTableName,
+  };
+};
+
+// Stateless
+export const getFastqSyncManagerStackProps = (stage: AppStage): FastqSyncManagerStackConfig => {
+  return {
+    /*
+    Table stuff
+    */
+    fastqSyncDynamodbTableName: fastqSyncDynamodbTableName,
+
+    /*
+    Events stuff
+    */
+    eventBusName: eventBusName,
+    eventTriggers: {
+      fastqSetUpdated: {
+        eventSource: fastqManagerEventSource,
+        eventDetailType: fastqManagerEventDetails.updateFastqSet,
+      },
+      fastqListRowUpdated: {
+        eventSource: fastqManagerEventSource,
+        eventDetailType: fastqManagerEventDetails.updateFastqListRow,
+      },
+      fastqUnarchiving: {
+        eventSource: fastqUnarchivingManagerEventSource,
+        eventDetailType: fastqUnarchivingEventDetailType.updateJob,
+      },
+      fastqSync: {
+        eventDetailType: fastqSyncEventDetailType,
+      },
+    },
+
+    /*
+    Orcabus token and zone name for external lambda functions
+    */
+    orcabusTokenSecretsManagerPath: jwtSecretName,
+    hostedZoneNameSsmParameterPath: hostedZoneNameParameterPath,
+
+    /*
+    S3 Stuff
+    */
+    pipelineCacheBucketName: icav2PipelineCacheBucket[stage],
+    pipelineCachePrefix: icav2PipelineCachePrefix[stage],
+  };
+};

--- a/lib/workload/stateful/stacks/fastq-sync-dynamodb/Readme.md
+++ b/lib/workload/stateful/stacks/fastq-sync-dynamodb/Readme.md
@@ -1,0 +1,6 @@
+# Fastq Sync dynamodb
+
+Simple database with dynamodb to store task tokens and link them to fastq set ids (And vice versa)
+
+A task token can only map to one fastq set id, but a fastq set id can map to multiple task tokens.
+

--- a/lib/workload/stateful/stacks/fastq-sync-dynamodb/deploy/stack.ts
+++ b/lib/workload/stateful/stacks/fastq-sync-dynamodb/deploy/stack.ts
@@ -1,0 +1,22 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { DynamodbPartitionedPipelineConstruct } from '../../../../components/dynamodb-partitioned-table';
+
+export interface FastqSyncTableConfig {
+  dynamodbTableName: string;
+}
+
+export type FastqSyncManagerTableStackProps = FastqSyncTableConfig & cdk.StackProps;
+
+export class FastqSyncManagerTable extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: FastqSyncManagerTableStackProps) {
+    super(scope, id, props);
+
+    /*
+    Initialise dynamodb table, where id_type is the primary sort key
+    */
+    const dynamodbTable = new DynamodbPartitionedPipelineConstruct(this, 'fastq_sync_table', {
+      tableName: props.dynamodbTableName,
+    });
+  }
+}

--- a/lib/workload/stateful/statefulStackCollectionClass.ts
+++ b/lib/workload/stateful/statefulStackCollectionClass.ts
@@ -74,6 +74,10 @@ import {
   FastqUnarchivingManagerTable,
   FastqUnarchivingManagerTableStackProps,
 } from './stacks/fastq-unarchiving-dynamodb/deploy';
+import {
+  FastqSyncManagerTable,
+  FastqSyncManagerTableStackProps,
+} from './stacks/fastq-sync-dynamodb/deploy/stack';
 
 export interface StatefulStackCollectionProps {
   dataBucketStackProps: DataBucketStackProps;
@@ -98,6 +102,7 @@ export interface StatefulStackCollectionProps {
   accessKeySecretStackProps: AccessKeySecretStackProps;
   fastqManagerTableStackProps: FastqManagerTableStackProps;
   fastqUnarchivingManagerTableStackProps: FastqUnarchivingManagerTableStackProps;
+  fastqSyncManagerTableStackProps: FastqSyncManagerTableStackProps;
 }
 
 export class StatefulStackCollection {
@@ -125,6 +130,7 @@ export class StatefulStackCollection {
   readonly accessKeySecretStack: Stack;
   readonly fastqManagerTableStack: Stack;
   readonly fastqUnarchivingManagerTableStack: Stack;
+  readonly fastqSyncManagerTableStack: Stack;
 
   constructor(
     scope: Construct,
@@ -290,6 +296,15 @@ export class StatefulStackCollection {
       {
         ...this.createTemplateProps(env, 'FastqUnarchivingManagerTableStack'),
         ...statefulConfiguration.fastqUnarchivingManagerTableStackProps,
+      }
+    );
+
+    this.fastqSyncManagerTableStack = new FastqSyncManagerTable(
+      scope,
+      'FastqSyncManagerTableStack',
+      {
+        ...this.createTemplateProps(env, 'FastqSyncManagerTableStack'),
+        ...statefulConfiguration.fastqSyncManagerTableStackProps,
       }
     );
   }

--- a/lib/workload/stateless/stacks/fastq-sync/Readme.md
+++ b/lib/workload/stateless/stacks/fastq-sync/Readme.md
@@ -1,0 +1,62 @@
+# Fastq Sync Service
+
+The fastq sync service is a simple service that allows step functions with fastq set ids as inputs to 'hang' 
+until the requirements of the fastq set have been met. 
+
+This is useful for workflow-glue services that have fastq set ids but need to wait for either
+
+1. The fastq set readsets to be created
+2. The fastq set to have been qc'd AND have a fingerprint file and compression information
+3. This is also useful for data sharing services that require the fastqs to be unarchived before they can be shared
+
+The step function will then hang at that step until the task token has been 'unlocked' by the fastq sync service.
+
+## Registering task tokens
+
+Workflow glue services can use the fastq sync service by generating the following event
+
+```json5
+{
+  "EventBusName": "OrcaBusMain",
+  "Source": "doesnt matter",
+  "DetailType": "FastqSync",
+  "Detail": {
+    "taskToken":  "uuid",
+    "fastqSetId": "fqs.123456",
+    // Then one or more of the following
+    // Requirements can be left out if not needed
+    "requirements": {
+      // Do all fastq list rows in the set contain readsets?
+      "hasActiveReadSet": true,  
+      // Do all fastq list rows in the set contain an ntsm uri?
+      "hasFingerprint": true,  
+      // Do all fastq list rows in the set contain compression information?
+      // Useful if the fastq list rows are in ora format. 
+      // Some pipelines require the gzip file size in bytes in order 
+      // to stream the gzip file from ora back into s3 
+      "hasFileCompressionInformation": true,  
+      // Do all fastq list rows in the set contain qc information?
+      // We don't use this for anything yet but we may use this in the future
+      // to ensure that a fastq set has met the ideal coverage levels
+      "hasQc": true,
+    },
+    "forceUnarchiving": true,  // Force unarchiving of a fastq file if necessary, will fail if not set and fastq is in archive
+  }
+}
+```
+
+The fastq sync service will also trigger the qc, fingerprint or compression information services if they do not exist. 
+
+If any of the fastq list rows are in archive, the fastq sync service will also trigger the fastq unarchiving service to thaw out these fastq list rows.
+And place them into the 'byob' bucket.  
+
+
+## Unlocking task tokens
+
+The fastq sync service will then also listen for the following event types:
+
+1. FastqListRowUpdated (from the fastq management service)
+2. UnarchivingJobUpdated (from the fastq unarchiving service, where the status is 'SUCCEEDED')
+
+Everytime one of the events is triggered, the fastq sync service will check if the fastq list row or fastq set has met the requirements.
+If all requirements are met for the fastq set, the fastq sync service will unlock the task token.

--- a/lib/workload/stateless/stacks/fastq-sync/deploy/index.ts
+++ b/lib/workload/stateless/stacks/fastq-sync/deploy/index.ts
@@ -1,0 +1,713 @@
+/*
+
+Generate the four step functions
+And add target (slightly modified) events to each https://stackoverflow.com/a/59528479/6946787
+
+Import the following layers
+* fastq manager tools
+* fastq unarchiving tools
+
+Both these layers are prerequisites for the fastq_sync_tools layer.
+For any lambda that uses the fastq sync tools layer, the fastq manager tools and fastq unarchiving tools layers are also required.
+
+
+Generate the following lambdas
+
+* check fastq set id against requirements
+  * Requires fastq tools, fastq sync tools, and so fastq unarchiving tools as well
+
+* check fastq id against requirements
+  * Requires fastq tools, fastq sync tools, and so fastq unarchiving tools as well
+
+* get fastq list row ids from fastq set id
+  * Requires fastq tools
+
+* get fastq set ids from fastq list row id
+  * Requires fastq tools
+
+* Launch requirement job
+  * Requires fastq tools, fastq sync tools, and so fastq unarchiving tools as well
+
+
+Generate the following step functions
+
+* Fastq id updated
+  * Converts to list of fastq set ids and launches the fastq set id updated step function
+
+* Fastq set updated
+  * Checks fastq set id against any task tokens and checks if requirements for each task token has been satisfied
+
+* Initialise task token for fastq set id sync
+  * Initialises task token row in database and appends the task token to the fastq set id in the database
+  * Does an immediate check against requirements to see if the fastq set id requirements is already satisfied
+
+* Launch fastq list row requirements
+  * Run QC, File Compression stats, ntsm / fingerprint or unarchiving on the fastq list row id if the requirements are not satisfied
+
+
+Listen to the following events:
+
+* FastqSync -> Synced Event with a taskToken
+* FastqSetUpdated -> Triggers the FastqSetUpdated step function
+* FastqListRowUpdated -> Triggers the fastq id step function
+* FastqUnarchivingComplete -> Triggers the fastq id step function
+
+*/
+
+import path from 'path';
+import { Construct } from 'constructs';
+import * as cdk from 'aws-cdk-lib';
+import { Duration, Stack, StackProps } from 'aws-cdk-lib';
+
+// Importing AWS Lambda related modules
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { PythonUvFunction } from '../../../../components/uv-python-lambda-image-builder';
+import { FastqToolsPythonLambdaLayer } from '../../../../components/python-fastq-tools-layer';
+import { FastqSyncToolsPythonLambdaLayer } from '../layers';
+import { FastqUnarchivingToolsPythonLambdaLayer } from '../../../../components/python-fastq-unarchiving-tools-layer';
+
+// Importing AWS DynamoDB related modules
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+
+// Importing AWS IAM related modules
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+// Importing AWS SSM and Secrets Manager related modules
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+
+// Importing AWS EventBridge related modules
+import * as events from 'aws-cdk-lib/aws-events';
+
+// Importing AWS Step Functions related modules
+import * as sfn from 'aws-cdk-lib/aws-stepfunctions';
+import { IStateMachine } from 'aws-cdk-lib/aws-stepfunctions';
+
+// Importing interfaces
+import {
+  FastqListRowIdUpdatedEventBridgeRuleProps,
+  FastqListRowIdUpdatedSfnProps,
+  FastqSetIdUpdatedEventBridgeRuleProps,
+  FastqSetIdUpdatedSfnProps,
+  FastqSyncEventBridgeRuleProps,
+  FastqSyncManagerStackConfig,
+  FastqUnarchivingCompleteEventBridgeRuleProps,
+  InitialiseTaskTokenForFastqSyncSfnProps,
+  LambdaBuildInputs,
+  Lambdas,
+  LaunchFastqListRowRequirementsSfnProps,
+} from './interfaces';
+import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
+import { EventField, RuleTargetInput } from 'aws-cdk-lib/aws-events';
+import { NagSuppressions } from 'cdk-nag';
+
+export type FastqSyncManagerStackProps = FastqSyncManagerStackConfig & cdk.StackProps;
+
+export class FastqSyncManagerStack extends Stack {
+  constructor(scope: Construct, id: string, props: StackProps & FastqSyncManagerStackProps) {
+    super(scope, id, props);
+
+    /* Set tables */
+    const fastqSyncDynamodbTable = dynamodb.TableV2.fromTableName(
+      this,
+      'fastq_sync_dynamodb_table',
+      props.fastqSyncDynamodbTableName
+    );
+
+    /* Get event bus */
+    const eventBus = events.EventBus.fromEventBusName(this, 'event_bus', props.eventBusName);
+
+    // Create the External Tool Layers
+    const fastqToolsLayer = new FastqToolsPythonLambdaLayer(this, 'fastq-tools-layer', {
+      layerPrefix: 'fastqsync',
+    });
+    const fastqUnarchivingToolsLayer = new FastqUnarchivingToolsPythonLambdaLayer(
+      this,
+      'fastq-unarchiving-tools-layer',
+      {
+        layerPrefix: 'fastqsync',
+      }
+    );
+
+    // Create the internal-use-only fastq sync tool layer
+    const fastqSyncToolsLayer = new FastqSyncToolsPythonLambdaLayer(
+      this,
+      'fastq-sync-tools-layer',
+      {
+        layerPrefix: 'fastqsync',
+      }
+    );
+
+    /*
+    Collect the required secret and ssm parameters for getting metadata
+    */
+    const hostnameSsmParameterObj = ssm.StringParameter.fromStringParameterName(
+      this,
+      'hostname_ssm_parameter',
+      props.hostedZoneNameSsmParameterPath
+    );
+    const orcabusTokenSecretObj = secretsmanager.Secret.fromSecretNameV2(
+      this,
+      'orcabus_token_secret',
+      props.orcabusTokenSecretsManagerPath
+    );
+
+    // Create the shared lambdas used in various step functions
+    const sharedLambdas = this.build_lambda_functions_in_sfns({
+      /* Layers Tools */
+      fastqToolsLayer: fastqToolsLayer.lambdaLayerVersionObj,
+      fastqUnarchivingToolsLayer: fastqUnarchivingToolsLayer.lambdaLayerVersionObj,
+      fastqSyncToolsLayer: fastqSyncToolsLayer.lambdaLayerVersionObj,
+      /* SSM and Secrets Manager */
+      hostnameSsmParameterObj: hostnameSsmParameterObj,
+      orcabusTokenSecretObj: orcabusTokenSecretObj,
+      /* S3 Stuff */
+      pipelineCacheBucketName: props.pipelineCacheBucketName,
+      pipelineCachePrefix: props.pipelineCachePrefix,
+    });
+
+    // Create the step functions
+    const launchFastqListRowRequirementsSfn = this.build_launch_fastq_list_row_requirements_sfn({
+      // Lambdas
+      getFastqListRowAndRequirementsLambdaFunction:
+        sharedLambdas.getFastqListRowAndRequirementsLambdaFunction,
+      launchRequirementJobLambdaFunctionArn: sharedLambdas.launchRequirementJobLambdaFunction,
+    });
+
+    // Task token intiialiser step function
+    // Triggered by a service generating a Fastq Sync event
+    const initialiseTaskTokenSfn = this.build_initialise_task_token_for_fastq_sync_sfn({
+      // Table
+      fastqSyncDynamoDbTable: fastqSyncDynamodbTable,
+      // Lambdas
+      checkFastqSetIdAgainstRequirementsLambdaFunction:
+        sharedLambdas.checkFastqSetIdAgainstRequirementsLambdaFunction,
+      getFastqListRowFromFastqSetIdLambdaFunction:
+        sharedLambdas.getFastqListRowIdsFromFastqSetIdLambdaFunction,
+      // Child step functions
+      launchRequirementsSfn: launchFastqListRowRequirementsSfn,
+    });
+
+    const fastqSetIdUpdatedSfn = this.build_fastq_set_id_updated_sfn({
+      // Table
+      fastqSyncDynamoDbTable: fastqSyncDynamodbTable,
+      // Lambdas
+      checkFastqSetIdAgainstRequirementsLambdaFunction:
+        sharedLambdas.checkFastqSetIdAgainstRequirementsLambdaFunction,
+      getFastqListRowFromFastqSetIdLambdaFunction:
+        sharedLambdas.getFastqListRowIdsFromFastqSetIdLambdaFunction,
+      // Child step functions
+      launchRequirementsSfn: launchFastqListRowRequirementsSfn,
+    });
+    const fastqListRowIdUpdatedSfn = this.build_fastq_list_row_id_updated_sfn({
+      // Lambdas
+      getFastqSetIdsFromFastqListRowIdsLambdaFunction:
+        sharedLambdas.getFastqSetIdsFromFastqListRowIdsLambdaFunction,
+      // Child step functions
+      fastqSetIdUpdatedSfn: fastqSetIdUpdatedSfn,
+    });
+
+    // Build up event rules
+    this.build_task_token_initialiser_event_rule({
+      eventBus: eventBus,
+      eventTriggers: props.eventTriggers.fastqSync,
+      taskTokenInitialiserSfn: initialiseTaskTokenSfn,
+    });
+
+    this.build_fastq_list_row_id_updated_event_rule({
+      eventBus: eventBus,
+      eventTriggers: props.eventTriggers.fastqListRowUpdated,
+      fastqListRowIdUpdatedSfn: fastqListRowIdUpdatedSfn,
+    });
+    // this.build_fastq_set_id_updated_event_rule({
+    //   eventBus: eventBus,
+    //   eventTriggers: props.eventTriggers.fastqSetUpdated,
+    //   fastqSetIdUpdatedSfn: fastqSetIdUpdatedSfn,
+    // });
+    this.build_fastq_unarchiving_complete_event_rule({
+      eventBus: eventBus,
+      eventTriggers: props.eventTriggers.fastqUnarchiving,
+      fastqListRowIdUpdatedSfn: fastqListRowIdUpdatedSfn,
+    });
+  }
+
+  private build_lambda_functions_in_sfns(props: LambdaBuildInputs): Lambdas {
+    const checkFastqSetIdAgainstRequirementsLambdaFunction = new PythonUvFunction(
+      this,
+      'checkFastqSetIdAgainstRequirementsLambdaFunction',
+      {
+        entry: path.join(__dirname, '../lambdas/check_fastq_set_id_against_requirements_py'),
+        runtime: lambda.Runtime.PYTHON_3_12,
+        architecture: lambda.Architecture.ARM_64,
+        index: 'check_fastq_set_id_against_requirements.py',
+        handler: 'handler',
+        timeout: Duration.seconds(60),
+        memorySize: 2048,
+        environment: {
+          /* SSM and Secrets Manager env vars */
+          HOSTNAME_SSM_PARAMETER: props.hostnameSsmParameterObj.parameterName,
+          ORCABUS_TOKEN_SECRET_ID: props.orcabusTokenSecretObj.secretName,
+          BYOB_BUCKET_PREFIX: `s3://${props.pipelineCacheBucketName}/${props.pipelineCachePrefix}`,
+        },
+        layers: [
+          props.fastqToolsLayer,
+          props.fastqSyncToolsLayer,
+          props.fastqUnarchivingToolsLayer,
+        ],
+      }
+    );
+    // Give lambda function permissions to secrets and ssm parameters
+    props.orcabusTokenSecretObj.grantRead(
+      checkFastqSetIdAgainstRequirementsLambdaFunction.currentVersion
+    );
+    props.hostnameSsmParameterObj.grantRead(
+      checkFastqSetIdAgainstRequirementsLambdaFunction.currentVersion
+    );
+
+    const getFastqListRowAndRequirementsLambdaFunction = new PythonUvFunction(
+      this,
+      'getFastqListRowAndRequirementsLambdaFunction',
+      {
+        entry: path.join(__dirname, '../lambdas/get_fastq_list_row_and_requirements_py'),
+        runtime: lambda.Runtime.PYTHON_3_12,
+        architecture: lambda.Architecture.ARM_64,
+        index: 'get_fastq_list_row_and_requirements.py',
+        handler: 'handler',
+        timeout: Duration.seconds(60),
+        memorySize: 2048,
+        environment: {
+          /* SSM and Secrets Manager env vars */
+          HOSTNAME_SSM_PARAMETER: props.hostnameSsmParameterObj.parameterName,
+          ORCABUS_TOKEN_SECRET_ID: props.orcabusTokenSecretObj.secretName,
+          BYOB_BUCKET_PREFIX: `s3://${props.pipelineCacheBucketName}/${props.pipelineCachePrefix}`,
+        },
+        layers: [
+          props.fastqToolsLayer,
+          props.fastqSyncToolsLayer,
+          props.fastqUnarchivingToolsLayer,
+        ],
+      }
+    );
+    // Give lambda function permissions to secrets and ssm parameters
+    props.orcabusTokenSecretObj.grantRead(
+      getFastqListRowAndRequirementsLambdaFunction.currentVersion
+    );
+    props.hostnameSsmParameterObj.grantRead(
+      getFastqListRowAndRequirementsLambdaFunction.currentVersion
+    );
+
+    const getFastqListRowIdsFromFastqSetIdLambdaFunction = new PythonUvFunction(
+      this,
+      'getFastqListRowIdsFromFastqSetIdLambdaFunction',
+      {
+        entry: path.join(__dirname, '../lambdas/get_fastq_list_row_ids_from_fastq_set_id_py'),
+        runtime: lambda.Runtime.PYTHON_3_12,
+        architecture: lambda.Architecture.ARM_64,
+        index: 'get_fastq_list_row_ids_from_fastq_set_id.py',
+        handler: 'handler',
+        timeout: Duration.seconds(60),
+        memorySize: 2048,
+        environment: {
+          /* SSM and Secrets Manager env vars */
+          HOSTNAME_SSM_PARAMETER: props.hostnameSsmParameterObj.parameterName,
+          ORCABUS_TOKEN_SECRET_ID: props.orcabusTokenSecretObj.secretName,
+        },
+        layers: [props.fastqToolsLayer],
+      }
+    );
+    // Give lambda function permissions to secrets and ssm parameters
+    props.orcabusTokenSecretObj.grantRead(
+      getFastqListRowIdsFromFastqSetIdLambdaFunction.currentVersion
+    );
+    props.hostnameSsmParameterObj.grantRead(
+      getFastqListRowIdsFromFastqSetIdLambdaFunction.currentVersion
+    );
+
+    const getFastqSetIdsFromFastqListRowIdsLambdaFunction = new PythonUvFunction(
+      this,
+      'getFastqSetIdsFromFastqListRowIdsLambdaFunction',
+      {
+        entry: path.join(__dirname, '../lambdas/get_fastq_set_ids_from_fastq_list_row_ids_py'),
+        runtime: lambda.Runtime.PYTHON_3_12,
+        architecture: lambda.Architecture.ARM_64,
+        index: 'get_fastq_set_ids_from_fastq_list_row_ids.py',
+        handler: 'handler',
+        timeout: Duration.seconds(60),
+        memorySize: 2048,
+        environment: {
+          /* SSM and Secrets Manager env vars */
+          HOSTNAME_SSM_PARAMETER: props.hostnameSsmParameterObj.parameterName,
+          ORCABUS_TOKEN_SECRET_ID: props.orcabusTokenSecretObj.secretName,
+        },
+        layers: [props.fastqToolsLayer],
+      }
+    );
+    // Give lambda function permissions to secrets and ssm parameters
+    props.orcabusTokenSecretObj.grantRead(
+      getFastqSetIdsFromFastqListRowIdsLambdaFunction.currentVersion
+    );
+    props.hostnameSsmParameterObj.grantRead(
+      getFastqSetIdsFromFastqListRowIdsLambdaFunction.currentVersion
+    );
+
+    const launchRequirementJobLambdaFunction = new PythonUvFunction(
+      this,
+      'launchRequirementJobLambdaFunction',
+      {
+        entry: path.join(__dirname, '../lambdas/launch_requirement_job_py'),
+        runtime: lambda.Runtime.PYTHON_3_12,
+        architecture: lambda.Architecture.ARM_64,
+        index: 'launch_requirement_job.py',
+        handler: 'handler',
+        timeout: Duration.seconds(60),
+        memorySize: 2048,
+        environment: {
+          /* SSM and Secrets Manager env vars */
+          HOSTNAME_SSM_PARAMETER: props.hostnameSsmParameterObj.parameterName,
+          ORCABUS_TOKEN_SECRET_ID: props.orcabusTokenSecretObj.secretName,
+          BYOB_BUCKET_PREFIX: `s3://${props.pipelineCacheBucketName}/${props.pipelineCachePrefix}`,
+        },
+        layers: [
+          props.fastqToolsLayer,
+          props.fastqSyncToolsLayer,
+          props.fastqUnarchivingToolsLayer,
+        ],
+      }
+    );
+    // Give lambda function permissions to secrets and ssm parameters
+    props.orcabusTokenSecretObj.grantRead(launchRequirementJobLambdaFunction.currentVersion);
+    props.hostnameSsmParameterObj.grantRead(launchRequirementJobLambdaFunction.currentVersion);
+
+    return {
+      checkFastqSetIdAgainstRequirementsLambdaFunction:
+        checkFastqSetIdAgainstRequirementsLambdaFunction,
+      getFastqListRowAndRequirementsLambdaFunction: getFastqListRowAndRequirementsLambdaFunction,
+      getFastqListRowIdsFromFastqSetIdLambdaFunction:
+        getFastqListRowIdsFromFastqSetIdLambdaFunction,
+      getFastqSetIdsFromFastqListRowIdsLambdaFunction:
+        getFastqSetIdsFromFastqListRowIdsLambdaFunction,
+      launchRequirementJobLambdaFunction: launchRequirementJobLambdaFunction,
+    };
+  }
+
+  private build_launch_fastq_list_row_requirements_sfn(
+    props: LaunchFastqListRowRequirementsSfnProps
+  ): IStateMachine {
+    // Set up the step function
+    const fqlrRequirementsLauncherStateMachine = new sfn.StateMachine(this, 'fqlrRequirementsSfn', {
+      stateMachineName: `fastq-sync-launch-fqlr-requirements-sfn`,
+      definitionBody: sfn.DefinitionBody.fromFile(
+        path.join(
+          __dirname,
+          '../step_functions_templates/launch_fastq_list_row_requirements.asl.json'
+        )
+      ),
+      definitionSubstitutions: {
+        __get_fastq_list_row_and_requirements_lambda_function_arn__:
+          props.getFastqListRowAndRequirementsLambdaFunction.currentVersion.functionArn,
+        __launch_requirement_job_lambda_function_arn__:
+          props.launchRequirementJobLambdaFunctionArn.currentVersion.functionArn,
+      },
+    });
+
+    // Give the state machine permissions to invoke the lambdas
+    [
+      props.getFastqListRowAndRequirementsLambdaFunction,
+      props.launchRequirementJobLambdaFunctionArn,
+    ].forEach((lambdaFunction) => {
+      lambdaFunction.currentVersion.grantInvoke(fqlrRequirementsLauncherStateMachine);
+    });
+
+    return fqlrRequirementsLauncherStateMachine;
+  }
+
+  private build_initialise_task_token_for_fastq_sync_sfn(
+    props: InitialiseTaskTokenForFastqSyncSfnProps
+  ): IStateMachine {
+    // Set up the step function
+    const initialiseTaskTokenForFastqSyncStateMachine = new sfn.StateMachine(
+      this,
+      'initialiseTaskTokenForFastqSyncSfn',
+      {
+        stateMachineName: `fastq-sync-initialise-task-token-sfn`,
+        definitionBody: sfn.DefinitionBody.fromFile(
+          path.join(
+            __dirname,
+            '../step_functions_templates/initialise_task_token_for_fastq_set_id_sync.asl.json'
+          )
+        ),
+        definitionSubstitutions: {
+          // Tables
+          __dynamodb_table_name__: props.fastqSyncDynamoDbTable.tableName,
+          // Lambdas
+          __check_fastq_set_id_against_requirements_lambda_function_arn__:
+            props.checkFastqSetIdAgainstRequirementsLambdaFunction.currentVersion.functionArn,
+          __get_fastq_list_row_from_fastq_set_id_lambda_function_arn__:
+            props.getFastqListRowFromFastqSetIdLambdaFunction.currentVersion.functionArn,
+          // Child Step functions
+          __launch_requirements_sfn_arn__: props.launchRequirementsSfn.stateMachineArn,
+        },
+      }
+    );
+
+    // Give the state machine permissions to read and write to the dynamodb table
+    props.fastqSyncDynamoDbTable.grantReadWriteData(initialiseTaskTokenForFastqSyncStateMachine);
+
+    // Give the state machine permissions to invoke the lambdas
+    [
+      props.checkFastqSetIdAgainstRequirementsLambdaFunction,
+      props.getFastqListRowFromFastqSetIdLambdaFunction,
+    ].forEach((lambdaFunction) => {
+      lambdaFunction.currentVersion.grantInvoke(initialiseTaskTokenForFastqSyncStateMachine);
+    });
+
+    // Give the state machine permissions to start the launch requirements step function
+    props.launchRequirementsSfn.grantStartExecution(initialiseTaskTokenForFastqSyncStateMachine);
+
+    // Because we run a nested state machine, we need to add the permissions to the parent state machine role
+    // See https://stackoverflow.com/questions/60612853/nested-step-function-in-a-step-function-unknown-error-not-authorized-to-cr
+    initialiseTaskTokenForFastqSyncStateMachine.addToRolePolicy(
+      new iam.PolicyStatement({
+        resources: [
+          `arn:aws:events:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule`,
+        ],
+        actions: ['events:PutTargets', 'events:PutRule', 'events:DescribeRule'],
+      })
+    );
+
+    // Allow initialiser to perform SendTaskSuccess and SendTaskFailure
+    // To any step function
+    initialiseTaskTokenForFastqSyncStateMachine.addToRolePolicy(
+      new iam.PolicyStatement({
+        resources: [`arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:*`],
+        actions: ['states:SendTaskSuccess', 'states:SendTaskFailure'],
+      })
+    );
+
+    NagSuppressions.addResourceSuppressions(
+      initialiseTaskTokenForFastqSyncStateMachine,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason:
+            'Send task status permissions are required for the step function to work, this obviously needs a wildcard',
+        },
+      ],
+      true
+    );
+
+    return initialiseTaskTokenForFastqSyncStateMachine;
+  }
+
+  private build_fastq_set_id_updated_sfn(props: FastqSetIdUpdatedSfnProps): IStateMachine {
+    // Set up the step function
+    const fastqSetIdUpdatedStateMachine = new sfn.StateMachine(this, 'fastqSetIdUpdatedSfn', {
+      stateMachineName: `fastq-sync-fastq-set-id-updated-sfn`,
+      definitionBody: sfn.DefinitionBody.fromFile(
+        path.join(__dirname, '../step_functions_templates/fastq_set_updated.asl.json')
+      ),
+      definitionSubstitutions: {
+        // Tables
+        __dynamodb_table_name__: props.fastqSyncDynamoDbTable.tableName,
+        // Lambdas
+        __check_fastq_set_id_against_requirements_lambda_function_arn__:
+          props.checkFastqSetIdAgainstRequirementsLambdaFunction.currentVersion.functionArn,
+        __get_fastq_list_row_from_fastq_set_id_lambda_function_arn__:
+          props.getFastqListRowFromFastqSetIdLambdaFunction.currentVersion.functionArn,
+        // Child Step functions
+        __launch_requirements_sfn_arn__: props.launchRequirementsSfn.stateMachineArn,
+      },
+    });
+
+    // Give the state machine permissions to read and write to the dynamodb table
+    props.fastqSyncDynamoDbTable.grantReadWriteData(fastqSetIdUpdatedStateMachine);
+
+    // Give the state machine permissions to invoke the lambdas
+    [
+      props.checkFastqSetIdAgainstRequirementsLambdaFunction,
+      props.getFastqListRowFromFastqSetIdLambdaFunction,
+    ].forEach((lambdaFunction) => {
+      lambdaFunction.currentVersion.grantInvoke(fastqSetIdUpdatedStateMachine);
+    });
+
+    // Give the state machine permissions to start the launch requirements step function
+    props.launchRequirementsSfn.grantStartExecution(fastqSetIdUpdatedStateMachine);
+
+    // Because we run a nested state machine, we need to add the permissions to the parent state machine role
+    // See https://stackoverflow.com/questions/60612853/nested-step-function-in-a-step-function-unknown-error-not-authorized-to-cr
+    fastqSetIdUpdatedStateMachine.addToRolePolicy(
+      new iam.PolicyStatement({
+        resources: [
+          `arn:aws:events:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule`,
+        ],
+        actions: ['events:PutTargets', 'events:PutRule', 'events:DescribeRule'],
+      })
+    );
+
+    // Allow fastq set id updated sfn to send SendTaskSuccess and SendTaskFailure
+    // To any step function
+    fastqSetIdUpdatedStateMachine.addToRolePolicy(
+      new iam.PolicyStatement({
+        resources: [`arn:aws:states:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:stateMachine:*`],
+        actions: ['states:SendTaskSuccess', 'states:SendTaskFailure'],
+      })
+    );
+
+    NagSuppressions.addResourceSuppressions(
+      fastqSetIdUpdatedStateMachine,
+      [
+        {
+          id: 'AwsSolutions-IAM5',
+          reason:
+            'Send task status permissions are required for the step function to work, this obviously needs a wildcard',
+        },
+      ],
+      true
+    );
+
+    return fastqSetIdUpdatedStateMachine;
+  }
+
+  private build_fastq_list_row_id_updated_sfn(props: FastqListRowIdUpdatedSfnProps): IStateMachine {
+    // Set up the step function
+    const fastqListRowIdUpdatedStateMachine = new sfn.StateMachine(
+      this,
+      'fastqListRowIdUpdatedSfn',
+      {
+        stateMachineName: `fastq-sync-fastq-list-row-id-updated-sfn`,
+        definitionBody: sfn.DefinitionBody.fromFile(
+          path.join(__dirname, '../step_functions_templates/fastq_id_updated.asl.json')
+        ),
+        definitionSubstitutions: {
+          // Lambdas
+          __get_fastq_set_ids_from_fastq_list_row_ids_lambda_function_arn__:
+            props.getFastqSetIdsFromFastqListRowIdsLambdaFunction.currentVersion.functionArn,
+          // Child Step functions
+          __run_fastq_set_id_updated_sfn_arn__: props.fastqSetIdUpdatedSfn.stateMachineArn,
+        },
+      }
+    );
+
+    // Give the state machine permissions to invoke the lambdas
+    [props.getFastqSetIdsFromFastqListRowIdsLambdaFunction].forEach((lambdaFunction) => {
+      lambdaFunction.currentVersion.grantInvoke(fastqListRowIdUpdatedStateMachine);
+    });
+
+    // Give the state machine permissions to start the launch requirements step function
+    props.fastqSetIdUpdatedSfn.grantStartExecution(fastqListRowIdUpdatedStateMachine);
+
+    // Because we run a nested state machine, we need to add the permissions to the parent state machine role
+    // See https://stackoverflow.com/questions/60612853/nested-step-function-in-a-step-function-unknown-error-not-authorized-to-cr
+    fastqListRowIdUpdatedStateMachine.addToRolePolicy(
+      new iam.PolicyStatement({
+        resources: [
+          `arn:aws:events:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule`,
+        ],
+        actions: ['events:PutTargets', 'events:PutRule', 'events:DescribeRule'],
+      })
+    );
+
+    return fastqListRowIdUpdatedStateMachine;
+  }
+
+  private build_task_token_initialiser_event_rule(props: FastqSyncEventBridgeRuleProps) {
+    const eventRule = new events.Rule(this, 'fastqSyncTaskTokenInitialiserRule', {
+      ruleName: `fastq-sync-task-token-initialiser-rule`,
+      eventBus: props.eventBus,
+      eventPattern: {
+        detailType: [props.eventTriggers.eventDetailType],
+      },
+    });
+
+    // Add target to event rule
+    eventRule.addTarget(
+      new eventsTargets.SfnStateMachine(props.taskTokenInitialiserSfn, {
+        input: events.RuleTargetInput.fromEventPath('$.detail'),
+      })
+    );
+  }
+
+  private build_fastq_list_row_id_updated_event_rule(
+    props: FastqListRowIdUpdatedEventBridgeRuleProps
+  ) {
+    const eventRule = new events.Rule(this, 'fastqListRowUpdatedFastqSync', {
+      ruleName: `fastq-sync-fastq-list-row-updated-event-rule`,
+      eventBus: props.eventBus,
+      eventPattern: {
+        source: [<string>props.eventTriggers.eventSource],
+        detailType: [props.eventTriggers.eventDetailType],
+        detail: {
+          status: [
+            { 'equals-ignore-case': 'READ_SET_ADDED' },
+            { 'equals-ignore-case': 'FILE_COMPRESSION_UPDATED' },
+            { 'equals-ignore-case': 'QC_UPDATED' },
+            { 'equals-ignore-case': 'NTSM_UPDATED' },
+          ],
+        },
+      },
+    });
+
+    // Add target to event rule
+    // Note that we expect fastqListRowIdList as our only input, since the fastqListRowUpdated event detail body
+    // Just contains the fastq list row object as is, we need to extract the id from the object and pass it to the target
+    // In list format - we use this same step function for the fastq unarchiving which is why we expect our input to be a list
+    eventRule.addTarget(
+      new eventsTargets.SfnStateMachine(props.fastqListRowIdUpdatedSfn, {
+        input: RuleTargetInput.fromObject({
+          fastqListRowIdList: [EventField.fromPath('$.detail.id')],
+        }),
+      })
+    );
+  }
+
+  private build_fastq_set_id_updated_event_rule(props: FastqSetIdUpdatedEventBridgeRuleProps) {
+    const eventRule = new events.Rule(this, 'fastqSetUpdatedFastqSync', {
+      ruleName: `fastq-sync-fastq-set-updated-event-rule`,
+      eventBus: props.eventBus,
+      eventPattern: {
+        source: [<string>props.eventTriggers.eventSource],
+        detailType: [props.eventTriggers.eventDetailType],
+      },
+    });
+
+    // Add target to event rule
+    // Note that we expect fastqListRowId as our only input, since the fastqSetId event detail body
+    // Just contains the fastq list row object as is,
+    // we need to extract the id from the object and pass it to the target
+    eventRule.addTarget(
+      new eventsTargets.SfnStateMachine(props.fastqSetIdUpdatedSfn, {
+        input: RuleTargetInput.fromObject({
+          fastqSetId: EventField.fromPath('$.detail.id'),
+        }),
+      })
+    );
+  }
+
+  private build_fastq_unarchiving_complete_event_rule(
+    props: FastqUnarchivingCompleteEventBridgeRuleProps
+  ) {
+    const eventRule = new events.Rule(this, 'fastqUnarchivingComplete', {
+      ruleName: `fastq-sync-fastq-unarchiving-complete-event-rule`,
+      eventBus: props.eventBus,
+      eventPattern: {
+        source: [<string>props.eventTriggers.eventSource],
+        detailType: [props.eventTriggers.eventDetailType],
+        detail: {
+          status: [{ 'equals-ignore-case': 'SUCCEEDED' }],
+        },
+      },
+    });
+
+    // Add target to event rule
+    // Note that we expect fastqListRowIdList as our only input
+    // While the fastqUnarchivingComplete event detail body contains the fastq list row objects we need to
+    // rename the list to match the input requirements of the step function
+    eventRule.addTarget(
+      new eventsTargets.SfnStateMachine(props.fastqListRowIdUpdatedSfn, {
+        input: RuleTargetInput.fromObject({
+          fastqListRowIdList: EventField.fromPath('$.detail.fastqIds'),
+        }),
+      })
+    );
+  }
+}

--- a/lib/workload/stateless/stacks/fastq-sync/deploy/interfaces.ts
+++ b/lib/workload/stateless/stacks/fastq-sync/deploy/interfaces.ts
@@ -1,0 +1,113 @@
+import { PythonLayerVersion } from '@aws-cdk/aws-lambda-python-alpha';
+import { IStringParameter } from 'aws-cdk-lib/aws-ssm';
+import { ISecret } from 'aws-cdk-lib/aws-secretsmanager';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { IStateMachine } from 'aws-cdk-lib/aws-stepfunctions';
+import { ITableV2 } from 'aws-cdk-lib/aws-dynamodb';
+import { IEventBus } from 'aws-cdk-lib/aws-events';
+
+export interface EventTrigger {
+  eventDetailType: string;
+  eventSource?: string;
+}
+
+export interface FastqSyncEventTriggers {
+  fastqSetUpdated: EventTrigger;
+  fastqListRowUpdated: EventTrigger;
+  fastqUnarchiving: EventTrigger;
+  fastqSync: EventTrigger;
+}
+
+export interface LambdaBuildInputs {
+  /* Python layers */
+  fastqToolsLayer: PythonLayerVersion;
+  fastqUnarchivingToolsLayer: PythonLayerVersion;
+  fastqSyncToolsLayer: PythonLayerVersion;
+  /* SSM and Secrets */
+  hostnameSsmParameterObj: IStringParameter;
+  orcabusTokenSecretObj: ISecret;
+  /* S3 Stuff */
+  pipelineCacheBucketName: string;
+  pipelineCachePrefix: string;
+}
+
+export interface Lambdas {
+  checkFastqSetIdAgainstRequirementsLambdaFunction: lambda.Function;
+  getFastqListRowAndRequirementsLambdaFunction: lambda.Function;
+  getFastqListRowIdsFromFastqSetIdLambdaFunction: lambda.Function;
+  getFastqSetIdsFromFastqListRowIdsLambdaFunction: lambda.Function;
+  launchRequirementJobLambdaFunction: lambda.Function;
+}
+
+export interface LaunchFastqListRowRequirementsSfnProps {
+  getFastqListRowAndRequirementsLambdaFunction: lambda.Function;
+  launchRequirementJobLambdaFunctionArn: lambda.Function;
+}
+
+export interface InitialiseTaskTokenForFastqSyncSfnProps {
+  fastqSyncDynamoDbTable: ITableV2;
+  checkFastqSetIdAgainstRequirementsLambdaFunction: lambda.Function;
+  getFastqListRowFromFastqSetIdLambdaFunction: lambda.Function;
+  launchRequirementsSfn: IStateMachine;
+}
+
+export interface FastqSetIdUpdatedSfnProps {
+  fastqSyncDynamoDbTable: ITableV2;
+  checkFastqSetIdAgainstRequirementsLambdaFunction: lambda.Function;
+  getFastqListRowFromFastqSetIdLambdaFunction: lambda.Function;
+  launchRequirementsSfn: IStateMachine;
+}
+
+export interface FastqListRowIdUpdatedSfnProps {
+  getFastqSetIdsFromFastqListRowIdsLambdaFunction: lambda.Function;
+  fastqSetIdUpdatedSfn: IStateMachine;
+}
+
+export interface FastqListRowIdUpdatedEventBridgeRuleProps {
+  fastqListRowIdUpdatedSfn: IStateMachine;
+  eventBus: IEventBus;
+  eventTriggers: EventTrigger;
+}
+
+export interface FastqSetIdUpdatedEventBridgeRuleProps {
+  fastqSetIdUpdatedSfn: IStateMachine;
+  eventBus: IEventBus;
+  eventTriggers: EventTrigger;
+}
+
+export interface FastqUnarchivingCompleteEventBridgeRuleProps {
+  fastqListRowIdUpdatedSfn: IStateMachine;
+  eventBus: IEventBus;
+  eventTriggers: EventTrigger;
+}
+
+export interface FastqSyncEventBridgeRuleProps {
+  taskTokenInitialiserSfn: IStateMachine;
+  eventBus: IEventBus;
+  eventTriggers: EventTrigger;
+}
+
+export interface FastqSyncManagerStackConfig {
+  /*
+  Orcabus token and zone name for external lambda functions
+  */
+  orcabusTokenSecretsManagerPath: string;
+  hostedZoneNameSsmParameterPath: string;
+
+  /*
+  Data tables
+  */
+  fastqSyncDynamodbTableName: string;
+
+  /*
+  Event bus stuff
+  */
+  eventBusName: string;
+  eventTriggers: FastqSyncEventTriggers;
+
+  /*
+  S3 Stuff
+  */
+  pipelineCacheBucketName: string;
+  pipelineCachePrefix: string;
+}

--- a/lib/workload/stateless/stacks/fastq-sync/lambdas/check_fastq_set_id_against_requirements_py/check_fastq_set_id_against_requirements.py
+++ b/lib/workload/stateless/stacks/fastq-sync/lambdas/check_fastq_set_id_against_requirements_py/check_fastq_set_id_against_requirements.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+"""
+Given a fastq set id and a set of requirements, check if the fastq set id meets the requirements.
+
+We need to get all fastq list rows in the fastq set and from there, check if all fastq list row ids meet all requirements.
+
+An example input is as follows:
+
+{
+    "fastqSetId": "fqs.12345",
+    "requirements": [
+        "activeReadSet",
+        "hasQc",
+        "hasFingerprint",
+        "hasFileCompressionInformation"
+    ]
+}
+
+An example output is as follows:
+
+{
+    "hasAllRequirements": true
+}
+
+We assume compression metadata is only required for readsets with ORA compression format
+
+"""
+from typing import Dict
+
+from fastq_tools import get_fastq_set
+from fastq_sync_tools import check_fastq_set_against_requirements_bool, Requirements
+
+
+def handler(event, context) -> Dict[str, bool]:
+    """
+    Check if the fastq set id meets the requirements
+    :param event:
+    :param context:
+    :return:
+    """
+
+    # Get the fastq set object
+    fastq_set_obj = get_fastq_set(event["fastqSetId"], includeS3Details=True)
+
+    # Get requirements
+    requirements = list(map(lambda req_iter_: Requirements(req_iter_), event["requirements"]))
+
+    is_unarchiving_allowed = event.get("isUnarchivingAllowed", False)
+
+    return {
+        "hasAllRequirements": check_fastq_set_against_requirements_bool(
+            fastq_set_obj, requirements, is_unarchiving_allowed
+        )
+    }
+
+
+# if __name__ == "__main__":
+#     import json
+#     from os import environ
+#     environ['AWS_PROFILE'] = 'umccr-development'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     environ['HOSTNAME_SSM_PARAMETER'] = '/hosted_zone/umccr/name'
+#     environ['ORCABUS_TOKEN_SECRET_ID'] = 'orcabus/token-service-jwt'
+#     environ['BYOB_BUCKET_PREFIX'] = 's3://pipeline-dev-cache-503977275616-ap-southeast-2/byob-icav2/development/'
+#     print(json.dumps(
+#         handler(
+#             {
+#                 "fastqSetId": "fqs.01JQ3BEV01G92NWSWD4S59TSE4",
+#                 "requirements": [
+#                     "hasActiveReadSet",
+#                     "hasQc",
+#                     "hasFingerprint",
+#                     "hasFileCompressionInformation"
+#                 ]
+#             },
+#             None
+#         ),
+#         indent=4
+#     ))
+#
+#     # {
+#     #     "hasAllRequirements": false
+#     # }

--- a/lib/workload/stateless/stacks/fastq-sync/lambdas/get_fastq_list_row_and_requirements_py/get_fastq_list_row_and_requirements.py
+++ b/lib/workload/stateless/stacks/fastq-sync/lambdas/get_fastq_list_row_and_requirements_py/get_fastq_list_row_and_requirements.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+"""
+Given a fastq list row and remaining requirements dict, determine which requirements are met by the object and which ones are not.
+
+Given a dictionary as follows
+
+{
+    "fastqListRowId": "fqr.1234",
+    "requirements": [
+        "activeReadSet",
+        "hasQc",
+        "hasFingerprint"
+    ]
+}
+
+We return a dictionary like the following
+{
+    "fastqListRowId": "fqr.1234",
+    "satisfiedRequirements": [
+        "activeReadSet",
+        "hasQc"
+    ],
+    "unsatisfiedRequirements": [
+        "hasFingerprint"
+    ]
+}
+"""
+
+
+from fastq_tools import get_fastq
+from fastq_sync_tools import check_fastq_list_row_against_requirements_list
+
+
+def handler(event, context):
+    """
+    Given a fastq list row and a list of requirements,
+    determine which requirements are met by the object and which ones are not.
+    :param event:
+    :param context:
+    :return:
+    """
+    fastq_obj = get_fastq(event['fastqListRowId'], includeS3Details=True)
+
+    satisfied_requirements, unsatisfied_requirements = check_fastq_list_row_against_requirements_list(fastq_obj, event['requirements'])
+
+    return {
+        "fastqListRowObj": fastq_obj,
+        "satisfiedRequirements": list(map(lambda req_iter_: req_iter_.value, satisfied_requirements)),
+        "unsatisfiedRequirements": list(map(lambda req_iter_: req_iter_.value, unsatisfied_requirements))
+    }
+
+
+# if __name__ == "__main__":
+#     import json
+#     from os import environ
+#     environ['AWS_PROFILE'] = 'umccr-development'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     environ['HOSTNAME_SSM_PARAMETER'] = '/hosted_zone/umccr/name'
+#     environ['ORCABUS_TOKEN_SECRET_ID'] = 'orcabus/token-service-jwt'
+#     environ['BYOB_BUCKET_PREFIX'] = 's3://pipeline-dev-cache-503977275616-ap-southeast-2/byob-icav2/development/'
+#     print(json.dumps(
+#         handler(
+#             {
+#                 "fastqListRowId": "fqr.01JQ3BETTR9JPV33S3ZXB18HBN",
+#                 "requirements": [
+#                     "hasActiveReadSet",
+#                     "hasQc",
+#                     "hasFingerprint",
+#                     "hasFileCompressionInformation"
+#                 ]
+#             },
+#             None
+#         ),
+#         indent=4
+#     ))
+#
+#     # {
+#     #     "fastqListRowObj": {
+#     #         "id": "fqr.01JQ3BETTR9JPV33S3ZXB18HBN",
+#     #         "fastqSetId": "fqs.01JQ3BETXHQP3FEENYNFJAD7F1",
+#     #         "index": "TCTCTACT+GAACCGCG",
+#     #         "lane": 4,
+#     #         "instrumentRunId": "241024_A00130_0336_BHW7MVDSXC",
+#     #         "library": {
+#     #             "orcabusId": "lib.01JBB5Y44ZSWKBXJJFHRHJ94CK",
+#     #             "libraryId": "L2401548"
+#     #         },
+#     #         "platform": "Illumina",
+#     #         "center": "UMCCR",
+#     #         "date": "2024-10-24T00:00:00",
+#     #         "readSet": {
+#     #             "r1": {
+#     #                 "ingestId": "0195c5fb-8352-7a60-b45f-a93989c559a1",
+#     #                 "s3Uri": "s3://pipeline-dev-cache-503977275616-ap-southeast-2/byob-icav2/development/primary/241024_A00130_0336_BHW7MVDSXC/20250324abcd1234/Samples/Lane_4/L2401548/L2401548_S24_L004_R1_001.fastq.ora",
+#     #                 "storageClass": "Standard",
+#     #                 "gzipCompressionSizeInBytes": null,
+#     #                 "rawMd5sum": null
+#     #             },
+#     #             "r2": {
+#     #                 "ingestId": "0195c5fb-8ab5-7f71-8a7d-23fa5bdf3f2d",
+#     #                 "s3Uri": "s3://pipeline-dev-cache-503977275616-ap-southeast-2/byob-icav2/development/primary/241024_A00130_0336_BHW7MVDSXC/20250324abcd1234/Samples/Lane_4/L2401548/L2401548_S24_L004_R2_001.fastq.ora",
+#     #                 "storageClass": "Standard",
+#     #                 "gzipCompressionSizeInBytes": null,
+#     #                 "rawMd5sum": null
+#     #             },
+#     #             "compressionFormat": "ORA"
+#     #         },
+#     #         "qc": null,
+#     #         "ntsm": null,
+#     #         "readCount": 517512667,
+#     #         "baseCountEst": 1035025334,
+#     #         "isValid": true
+#     #     },
+#     #     "satisfiedRequirements": [
+#     #         "hasActiveReadSet"
+#     #     ],
+#     #     "unsatisfiedRequirements": [
+#     #         "hasQc",
+#     #         "hasFingerprint",
+#     #         "hasFileCompressionInformation"
+#     #     ]
+#     # }

--- a/lib/workload/stateless/stacks/fastq-sync/lambdas/get_fastq_list_row_ids_from_fastq_set_id_py/get_fastq_list_row_ids_from_fastq_set_id.py
+++ b/lib/workload/stateless/stacks/fastq-sync/lambdas/get_fastq_list_row_ids_from_fastq_set_id_py/get_fastq_list_row_ids_from_fastq_set_id.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+"""
+Get the fastq list row from the fastq set id
+"""
+from typing import Dict, List
+
+from fastq_tools import get_fastq_set, FastqSet
+
+
+def handler(event, context) -> Dict[str, List[str]]:
+    fastq_set_obj: FastqSet = get_fastq_set(event['fastqSetId'])
+
+    return {
+        "fastqListRowIdList": list(map(
+            lambda fastq_list_row_iter_: fastq_list_row_iter_['id'],
+            fastq_set_obj['fastqSet']
+        ))
+    }
+
+
+# if __name__ == "__main__":
+#     import json
+#     from os import environ
+#     environ['AWS_PROFILE'] = 'umccr-development'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     environ['HOSTNAME_SSM_PARAMETER'] = '/hosted_zone/umccr/name'
+#     environ['ORCABUS_TOKEN_SECRET_ID'] = 'orcabus/token-service-jwt'
+#     environ['BYOB_BUCKET_PREFIX'] = 's3://pipeline-dev-cache-503977275616-ap-southeast-2/byob-icav2/development/'
+#     print(json.dumps(
+#         handler(
+#             {
+#                 "fastqSetId": "fqs.01JQ3BETXHQP3FEENYNFJAD7F1",
+#             },
+#             None
+#         ),
+#         indent=4
+#     ))
+#
+#     # {
+#     #     "fastqListRowIdList": [
+#     #         "fqr.01JQ3BETTR9JPV33S3ZXB18HBN"
+#     #     ]
+#     # }

--- a/lib/workload/stateless/stacks/fastq-sync/lambdas/get_fastq_set_ids_from_fastq_list_row_ids_py/get_fastq_set_ids_from_fastq_list_row_ids.py
+++ b/lib/workload/stateless/stacks/fastq-sync/lambdas/get_fastq_set_ids_from_fastq_list_row_ids_py/get_fastq_set_ids_from_fastq_list_row_ids.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+"""
+Used to handle job completions from the unarchiving manager.
+
+The unarchiving manager speaks in fastq list row ids but we need fastq set ids as our starting point.
+
+An example input of this may be:
+
+{
+    "fastqListRowIds": [
+        "fqr.1234",
+        "fqr.5678"
+    ]
+}
+
+While an example output might be
+
+{
+    "fastqSetIds": [
+        "fqs.1234",
+    ]
+}
+
+"""
+
+from typing import List, Dict
+
+from fastq_tools import get_fastq, FastqListRow
+
+
+def handler(event, context) -> Dict[str, List[str]]:
+    """
+    Get the fastq set id for each fastq object
+    :param event:
+    :param context:
+    :return:
+    """
+
+    fastq_objs: List[FastqListRow] = list(map(
+        lambda fastq_list_row_id_iter: get_fastq(fastq_list_row_id_iter),
+        event["fastqListRowIdList"]
+    ))
+
+    fastq_set_ids = list(set(list(map(
+        lambda fastq_obj_iter: fastq_obj_iter["fastqSetId"],
+        fastq_objs
+    ))))
+
+    return {
+        "fastqSetIds": fastq_set_ids
+    }
+
+
+# if __name__ == "__main__":
+#     import json
+#     from os import environ
+#     environ['AWS_PROFILE'] = 'umccr-development'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     environ['HOSTNAME_SSM_PARAMETER'] = '/hosted_zone/umccr/name'
+#     environ['ORCABUS_TOKEN_SECRET_ID'] = 'orcabus/token-service-jwt'
+#     environ['BYOB_BUCKET_PREFIX'] = 's3://pipeline-dev-cache-503977275616-ap-southeast-2/byob-icav2/development/'
+#     print(json.dumps(
+#         handler(
+#             {
+#                 "fastqListRowIdList": ["fqr.01JQ3BETTR9JPV33S3ZXB18HBN"],
+#             },
+#             None
+#         ),
+#         indent=4
+#     ))
+#
+#     # {
+#     #     "fastqSetIds": [
+#     #         "fqs.01JQ3BETXHQP3FEENYNFJAD7F1"
+#     #     ]
+#     # }

--- a/lib/workload/stateless/stacks/fastq-sync/lambdas/launch_requirement_job_py/launch_requirement_job.py
+++ b/lib/workload/stateless/stacks/fastq-sync/lambdas/launch_requirement_job_py/launch_requirement_job.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+"""
+Given a requirement item and a fastq list row id, launch a job against the requirement item
+
+For qc, fingerprint or compression, we use the fastq api endpoint,
+For unarchiving we use the fastq unarchiving endpoint
+
+The requirementType input will be one of the following:
+
+ACTIVE_READSET
+QC
+FINGERPRINT
+COMPRESSION_METADATA
+
+"""
+
+from fastq_tools import (
+    get_fastq, JobType,
+)
+
+from fastq_sync_tools import (
+    Requirements,
+    run_fastq_job,
+    run_fastq_unarchiving_job,
+    check_fastq_unarchiving_job,
+    check_fastq_job
+)
+
+
+def handler(event, context):
+    """
+    Get the requirement type and launch the job
+    :param event:
+    :param context:
+    :return:
+    """
+    # Get inputs
+    fastq_list_row_id = event['fastqListRowId']
+    requirement_type = Requirements(event['requirementType'])
+
+    # Get the fastq list row as an object
+    fastq_list_row_obj = get_fastq(fastq_list_row_id, includeS3Details=True)
+
+    # Launch unarchiving job
+    if check_fastq_unarchiving_job(fastq_list_row_id) and requirement_type == Requirements.HAS_ACTIVE_READ_SET:
+        run_fastq_unarchiving_job(
+            fastq_list_row_obj
+        )
+
+    # Run internal jobs
+    if check_fastq_job(fastq_list_row_id, JobType.QC) and requirement_type == Requirements.HAS_QC:
+        run_fastq_job(fastq_list_row_obj, JobType.QC)
+
+    if check_fastq_job(fastq_list_row_id, JobType.NTSM) and requirement_type == Requirements.HAS_FINGERPRINT:
+        run_fastq_job(fastq_list_row_obj, JobType.NTSM)
+
+    if check_fastq_job(fastq_list_row_id, JobType.FILE_COMPRESSION) and requirement_type == Requirements.HAS_FILE_COMPRESSION_INFORMATION:
+        run_fastq_job(fastq_list_row_obj, JobType.FILE_COMPRESSION)
+
+
+# if __name__ == "__main__":
+#     import json
+#     from os import environ
+#     environ['AWS_PROFILE'] = 'umccr-development'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     environ['HOSTNAME_SSM_PARAMETER'] = '/hosted_zone/umccr/name'
+#     environ['ORCABUS_TOKEN_SECRET_ID'] = 'orcabus/token-service-jwt'
+#     environ['BYOB_BUCKET_PREFIX'] = 's3://pipeline-dev-cache-503977275616-ap-southeast-2/byob-icav2/development/'
+#     print(json.dumps(
+#         handler(
+#             {
+#                 "fastqListRowId": "fqr.01JQ3BEM14JA78EQBGBMB9MHE4",
+#                 "requirementType": "hasQc"
+#             },
+#             None
+#         ),
+#         indent=4
+#     ))
+
+# if __name__ == "__main__":
+#     import json
+#     from os import environ
+#     environ['AWS_PROFILE'] = 'umccr-production'
+#     environ['AWS_REGION'] = 'ap-southeast-2'
+#     environ['HOSTNAME_SSM_PARAMETER'] = '/hosted_zone/umccr/name'
+#     environ['ORCABUS_TOKEN_SECRET_ID'] = 'orcabus/token-service-jwt'
+#     environ['BYOB_BUCKET_PREFIX'] = 's3://pipeline-prod-cache-503977275616-ap-southeast-2/byob-icav2/production/'
+#     print(json.dumps(
+#         handler(
+#             {
+#                 "fastqListRowId": "fqr.01JN25XG75K54W8YF0J9MXVZKA",
+#                 "requirementType": "hasActiveReadSet"
+#             },
+#             None
+#         ),
+#         indent=4
+#     ))

--- a/lib/workload/stateless/stacks/fastq-sync/layers/fastq_sync_tools_layer/pyproject.toml
+++ b/lib/workload/stateless/stacks/fastq-sync/layers/fastq_sync_tools_layer/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "fastq_sync_tools"
+version = "0.0.1"
+description = "Workflow Manager Lambda Layers"
+license = "GPL-3.0-or-later"
+authors = [
+    "Alexis Lucattini"
+]
+homepage = "https://github.com/umccr/orcabus"
+repository = "https://github.com/umccr/orcabus"
+
+[tool.poetry.dependencies]
+python = "^3.12, <3.13"
+requests = "^2.32.3"
+
+[tool.poetry.group.dev]
+optional = true
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.0.0"  # For testing only
+# For typehinting only, not required at runtime
+mypy-boto3-ssm = "^1.34"
+mypy-boto3-secretsmanager = "^1.34"

--- a/lib/workload/stateless/stacks/fastq-sync/layers/fastq_sync_tools_layer/src/fastq_sync_tools/__init__.py
+++ b/lib/workload/stateless/stacks/fastq-sync/layers/fastq_sync_tools_layer/src/fastq_sync_tools/__init__.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+"""
+Fastq tools to be used by various lambdas as needed
+"""
+from .utils.globals import Requirements
+from .utils.utils import (
+    has_active_readset,
+    has_qc,
+    has_fingerprint,
+    has_compression_metadata,
+    check_fastq_job,
+    check_fastq_unarchiving_job,
+    run_fastq_job,
+    run_fastq_unarchiving_job,
+    check_fastq_set_against_requirements_bool,
+    check_fastq_list_row_against_requirements_list,
+)
+
+
+__all__ = [
+    # Requirements enum
+    "Requirements",
+    # All helpers
+    "has_active_readset",
+    "has_qc",
+    "has_fingerprint",
+    "has_compression_metadata",
+    "check_fastq_job",
+    "check_fastq_unarchiving_job",
+    "run_fastq_job",
+    "run_fastq_unarchiving_job",
+    "check_fastq_set_against_requirements_bool",
+    "check_fastq_list_row_against_requirements_list"
+]

--- a/lib/workload/stateless/stacks/fastq-sync/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/globals.py
+++ b/lib/workload/stateless/stacks/fastq-sync/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/globals.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from enum import Enum
+
+ACTIVE_STORAGE_CLASSES = [
+    "Standard",
+    "StandardIa",
+    "IntelligentTiering",
+    "GlacierIr",
+    "Glacier",
+    "DeepArchive",
+]
+
+BYOB_BUCKET_PREFIX_ENV_VAR = "BYOB_BUCKET_PREFIX"
+
+
+class Requirements(Enum):
+  HAS_ACTIVE_READ_SET = "hasActiveReadSet"
+  HAS_QC = "hasQc"
+  HAS_FINGERPRINT = "hasFingerprint"
+  HAS_FILE_COMPRESSION_INFORMATION = "hasFileCompressionInformation"
+

--- a/lib/workload/stateless/stacks/fastq-sync/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
+++ b/lib/workload/stateless/stacks/fastq-sync/layers/fastq_sync_tools_layer/src/fastq_sync_tools/utils/utils.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+
+"""
+Bunch of useful helper functions for lambdas in the fastq sync service
+"""
+
+
+from os import environ
+from typing import Optional, List, Tuple
+
+from fastq_tools import (
+    JobStatus, Job, JobType,
+    FastqListRow,
+    get_fastq_jobs,
+    run_qc_stats,
+    run_file_compression_stats,
+    run_ntsm, FastqSet
+)
+from fastq_unarchiving_tools import (
+    Job as UnarchivingJob,
+    JobType as UnarchivingJobType,
+    create_job as create_unarchiving_job, get_job_list_for_fastq,
+    JobStatus as UnarchivingJobStatus
+)
+from .globals import (
+    ACTIVE_STORAGE_CLASSES, BYOB_BUCKET_PREFIX_ENV_VAR,
+    Requirements
+)
+
+
+def has_active_readset(fastq_list_row_obj: 'FastqListRow') -> bool:
+    if fastq_list_row_obj['readSet'] is None:
+        return False
+
+    readset_objects = list(filter(
+        lambda readset_iter_: readset_iter_ is not None,
+        [fastq_list_row_obj['readSet']['r1'], fastq_list_row_obj['readSet']['r2']]
+    ))
+
+    for readset_object in readset_objects:
+        # If the storage class is not in the active storage classes or
+        # the s3 uri does not start with the bucket prefix
+        # then return False
+        if (
+                (readset_object['storageClass'] not in ACTIVE_STORAGE_CLASSES)
+                or
+                (not readset_object['s3Uri'].startswith(environ[BYOB_BUCKET_PREFIX_ENV_VAR]))
+        ):
+            return False
+
+    return True
+
+
+def has_qc(fastq_list_row_obj: FastqListRow) -> bool:
+    return fastq_list_row_obj['qc'] is not None
+
+
+def has_fingerprint(fastq_list_row_obj: FastqListRow) -> bool:
+    return fastq_list_row_obj['ntsm'] is not None
+
+
+def has_compression_metadata(fastq_list_row_obj: FastqListRow) -> bool:
+    # Check active readset
+    if not has_active_readset(fastq_list_row_obj):
+        return False
+
+    # Can assert we have an active readset and that the readset is not None
+
+    # Let's check if the compression format is ORA, if not, we can assume that the compression metadata
+    # Condition is satisfied
+    if fastq_list_row_obj['readSet']['compressionFormat'] != 'ORA':
+        return True
+
+    # If the compression format is ORA, then we need to check if the compression metadata is present
+    readset_objects = list(filter(
+        lambda readset_iter_: readset_iter_ is not None,
+        [fastq_list_row_obj['readSet']['r1'], fastq_list_row_obj['readSet']['r2']]
+    ))
+
+    for readset_object in readset_objects:
+        if readset_object['gzipCompressionSizeInBytes'] is None or readset_object['rawMd5sum'] is None:
+            return False
+
+    # If we got to here then the compression metadata is present in all readsets for this fastq list row
+    return True
+
+
+def check_fastq_job(fastq_id: str, job_type: JobType) -> bool:
+    """
+    Check the fastq doesn't already have jobs running for this particular type
+    :param fastq_id:
+    :param job_type:
+    :return:
+    """
+    return (
+            len(
+                list(filter(
+                    lambda job_iter_: (
+                            (
+                                    JobType(job_iter_['jobType']) == job_type
+                            ) and
+                            (
+                                    JobStatus(job_iter_['status']) in [JobStatus.PENDING, JobStatus.RUNNING]
+                            )
+                    ),
+                    get_fastq_jobs(fastq_id)
+                ))
+            ) == 0
+    )
+
+
+def check_fastq_unarchiving_job(fastq_id: str) -> bool:
+    """
+    Check that the fastq doesn't already have an unarchiving job running
+    Return True if there is no unarchiving jobs running for this fastq list row id
+    Return False if there are unarchiving jobs running for this fastq list row id
+    :param fastq_id:
+    :return:
+    """
+    return (
+            (
+                len(get_job_list_for_fastq(fastq_id, UnarchivingJobStatus.PENDING)) == 0
+            ) and
+            (
+                len(get_job_list_for_fastq(fastq_id, UnarchivingJobStatus.RUNNING)) == 0
+            )
+    )
+
+
+
+def run_fastq_job(fastq_list_row: FastqListRow, job_type: JobType) -> Optional[Job]:
+    """
+    Run a job for a fastq
+    :param fastq_id:
+    :param job_type:
+    :return:
+    """
+    # Check that the fastq list row has an active read set
+    if not has_active_readset(fastq_list_row):
+        return None
+
+    # Check if the job is already running
+    if not check_fastq_job(fastq_list_row['id'], job_type):
+        return None
+
+    # Create the job
+    if job_type == JobType.QC:
+        return run_qc_stats(fastq_id=fastq_list_row['id'])
+
+    if job_type == JobType.NTSM:
+        return run_ntsm(fastq_id=fastq_list_row['id'])
+
+    if job_type == JobType.FILE_COMPRESSION:
+        return run_file_compression_stats(fastq_id=fastq_list_row['id'])
+
+
+def run_fastq_unarchiving_job(fastq_list_row: FastqListRow) -> Optional[UnarchivingJob]:
+    create_unarchiving_job(
+        fastq_ids=[
+            fastq_list_row['id']
+        ],
+        job_type=UnarchivingJobType.S3_UNARCHIVING
+    )
+
+
+def check_fastq_list_row_against_requirements_list(
+        fastq_list_row_obj: FastqListRow,
+        requirements: List[Requirements]
+) -> Tuple[List[Requirements], List[Requirements]]:
+    """
+    Given a fastq list row and the requirements, split requirements into two lists, one that is satisfied and one that is not
+    """
+
+    satisfied_requirements = []
+    unsatisfied_requirements = []
+
+    # Just a large if else block to check the requirements
+    for requirement_iter_ in requirements:
+        requirement_iter_ = Requirements(requirement_iter_)
+        # Check read set
+        if requirement_iter_ == Requirements.HAS_ACTIVE_READ_SET:
+            if has_active_readset(fastq_list_row_obj):
+                satisfied_requirements.append(requirement_iter_)
+            else:
+                unsatisfied_requirements.append(requirement_iter_)
+
+        # Check qc
+        if requirement_iter_ == Requirements.HAS_QC:
+            if has_qc(fastq_list_row_obj):
+                satisfied_requirements.append(requirement_iter_)
+            else:
+                unsatisfied_requirements.append(requirement_iter_)
+
+        # Check fingerprint
+        if requirement_iter_ == Requirements.HAS_FINGERPRINT:
+            if has_fingerprint(fastq_list_row_obj):
+                satisfied_requirements.append(requirement_iter_)
+            else:
+                unsatisfied_requirements.append(requirement_iter_)
+
+        # Check compression metadata
+        if requirement_iter_ == Requirements.HAS_FILE_COMPRESSION_INFORMATION:
+            if has_compression_metadata(fastq_list_row_obj):
+                satisfied_requirements.append(requirement_iter_)
+            else:
+                unsatisfied_requirements.append(requirement_iter_)
+
+    return satisfied_requirements, unsatisfied_requirements
+
+
+def check_fastq_set_against_requirements_bool(
+        fastq_set_obj: FastqSet,
+        requirements: List[Requirements],
+        is_unarchiving_allowed: bool
+) -> bool:
+    """
+    This is used by the lambda that initially checks if all requirements have been met
+    We only need a yes or no answer if we're okay to proceed
+    :param fastq_set_obj:
+    :param requirements:
+    :return:
+    """
+    fastq_list_row_obj: FastqListRow
+    for fastq_list_row_obj in fastq_set_obj['fastqSet']:
+        if (
+                not is_unarchiving_allowed
+                and Requirements.HAS_ACTIVE_READ_SET in list(map(lambda x: Requirements(x), requirements))
+                and ( not has_active_readset(fastq_list_row_obj) )
+                and fastq_list_row_obj['readSet'] is not None
+        ):
+            raise ValueError("Fastq object is archived but unarchiving is not specified in the fastq sync service")
+
+        s_true, s_false = check_fastq_list_row_against_requirements_list(fastq_list_row_obj, requirements)
+
+        if len(s_false) > 0:
+            return False
+
+    return True

--- a/lib/workload/stateless/stacks/fastq-sync/layers/index.ts
+++ b/lib/workload/stateless/stacks/fastq-sync/layers/index.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import { Construct } from 'constructs';
+import { PythonLayerVersion } from '@aws-cdk/aws-lambda-python-alpha';
+import path from 'path';
+import { PythonLambdaLayerConstruct } from '../../../../components/python-lambda-layer';
+
+export interface PythonFastqSyncLambdaLayerConstructProps {
+  layerPrefix: string;
+}
+
+export class FastqSyncToolsPythonLambdaLayer extends Construct {
+  public readonly lambdaLayerVersionObj: PythonLayerVersion;
+
+  constructor(scope: Construct, id: string, props: PythonFastqSyncLambdaLayerConstructProps) {
+    super(scope, id);
+
+    // Generate lambda Fastq python layer
+    // Get lambda layer object
+    this.lambdaLayerVersionObj = new PythonLambdaLayerConstruct(this, 'lambda_layer', {
+      layerName: `${props.layerPrefix}-Fastq-Sync-py-layer`,
+      layerDescription: 'Lambda Layer for handling the Fastq sync via Python',
+      layerDirectory: path.join(__dirname, 'fastq_sync_tools_layer'),
+    }).lambdaLayerVersionObj;
+  }
+}

--- a/lib/workload/stateless/stacks/fastq-sync/step_functions_templates/fastq_id_updated.asl.json
+++ b/lib/workload/stateless/stacks/fastq-sync/step_functions_templates/fastq_id_updated.asl.json
@@ -1,0 +1,62 @@
+{
+  "Comment": "A description of my state machine",
+  "StartAt": "Get fastq set ids from fastq list row ids",
+  "States": {
+    "Get fastq set ids from fastq list row ids": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Arguments": {
+        "FunctionName": "${__get_fastq_set_ids_from_fastq_list_row_ids_lambda_function_arn__}",
+        "Payload": {
+          "fastqListRowIdList": "{% $states.input.fastqListRowIdList %}"
+        }
+      },
+      "Output": {
+        "fastqSetIds": "{% $states.result.Payload.fastqSetIds %}"
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "For each fastq set id"
+    },
+    "For each fastq set id": {
+      "Type": "Map",
+      "Items": "{% $states.input.fastqSetIds %}",
+      "ItemSelector": {
+        "fastqSetId": "{% $states.context.Map.Item.Value %}"
+      },
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "Run fastq set updated sfn",
+        "States": {
+          "Run fastq set updated sfn": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::states:startExecution.sync:2",
+            "Arguments": {
+              "StateMachineArn": "${__run_fastq_set_id_updated_sfn_arn__}",
+              "Input": {
+                "fastqSetId": "{% $states.input.fastqSetId %}"
+              }
+            },
+            "End": true
+          }
+        }
+      },
+      "End": true
+    }
+  },
+  "QueryLanguage": "JSONata"
+}

--- a/lib/workload/stateless/stacks/fastq-sync/step_functions_templates/fastq_set_updated.asl.json
+++ b/lib/workload/stateless/stacks/fastq-sync/step_functions_templates/fastq_set_updated.asl.json
@@ -1,0 +1,313 @@
+{
+  "Comment": "A description of my state machine",
+  "StartAt": "Set input and global vars",
+  "States": {
+    "Set input and global vars": {
+      "Type": "Pass",
+      "Next": "Get Fastq Set Id Item",
+      "Assign": {
+        "fastqSetId": "{% $states.input.fastqSetId %}",
+        "dynamoDbTableName": "${__dynamodb_table_name__}",
+        "dynamoDbIdTypeKeys": {
+          "fastqSetId": "FASTQ_SET_ID",
+          "taskToken": "TASK_TOKEN"
+        }
+      }
+    },
+    "Get Fastq Set Id Item": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Arguments": {
+        "TableName": "{% $dynamoDbTableName %}",
+        "Key": {
+          "id": {
+            "S": "{% $fastqSetId %}"
+          },
+          "id_type": {
+            "S": "{% $dynamoDbIdTypeKeys.fastqSetId %}"
+          }
+        }
+      },
+      "Next": "Has Task Tokens"
+    },
+    "Has Task Tokens": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Next": "Get all task token objects in fastq set id",
+          "Comment": "Fastq Set has task tokens",
+          "Condition": "{% $states.input.Item ? true : false %}",
+          "Output": {
+            "taskTokens": "{% $states.input.Item.task_token_set.SS %}"
+          }
+        }
+      ],
+      "Default": "Success"
+    },
+    "Get all task token objects in fastq set id": {
+      "Type": "Map",
+      "Items": "{% $states.input.taskTokens %}",
+      "ItemSelector": {
+        "taskTokenMapIter": "{% $states.context.Map.Item.Value %}"
+      },
+      "MaxConcurrency": 1,
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "Set map vars",
+        "States": {
+          "Set map vars": {
+            "Type": "Pass",
+            "Next": "Get task token requirements",
+            "Assign": {
+              "taskTokenMapIter": "{% $states.input.taskTokenMapIter %}"
+            }
+          },
+          "Get task token requirements": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::dynamodb:getItem",
+            "Arguments": {
+              "TableName": "{% $dynamoDbTableName %}",
+              "Key": {
+                "id": {
+                  "S": "{% $taskTokenMapIter %}"
+                },
+                "id_type": {
+                  "S": "{% $dynamoDbIdTypeKeys.taskToken %}"
+                }
+              }
+            },
+            "Next": "Check task token requirements against fastq set id",
+            "Assign": {
+              "requirementsSetMapIter": "{% $states.result.Item.requirements_set.SS %}"
+            }
+          },
+          "Check task token requirements against fastq set id": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "Output": {
+              "hasAllRequirements": "{% $states.result.Payload.hasAllRequirements %}"
+            },
+            "Arguments": {
+              "FunctionName": "${__check_fastq_set_id_against_requirements_lambda_function_arn__}",
+              "Payload": {
+                "fastqSetId": "{% $fastqSetId %}",
+                "requirements": "{% $requirementsSetMapIter %}"
+              }
+            },
+            "Retry": [
+              {
+                "ErrorEquals": [
+                  "Lambda.ServiceException",
+                  "Lambda.AWSLambdaException",
+                  "Lambda.SdkClientException",
+                  "Lambda.TooManyRequestsException"
+                ],
+                "IntervalSeconds": 1,
+                "MaxAttempts": 3,
+                "BackoffRate": 2,
+                "JitterStrategy": "FULL"
+              }
+            ],
+            "Next": "Matches requirements"
+          },
+          "Matches requirements": {
+            "Type": "Choice",
+            "Choices": [
+              {
+                "Next": "Meets all requirements",
+                "Condition": "{% $states.input.hasAllRequirements %}",
+                "Comment": "All requirements satisfied"
+              }
+            ],
+            "Default": "Task token requirement outputs"
+          },
+          "Meets all requirements": {
+            "Type": "Task",
+            "Arguments": {
+              "Output": {},
+              "TaskToken": "{% $taskTokenMapIter %}"
+            },
+            "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskSuccess",
+            "Next": "Clean up"
+          },
+          "Clean up": {
+            "Type": "Parallel",
+            "Branches": [
+              {
+                "StartAt": "Delete task token",
+                "States": {
+                  "Delete task token": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::dynamodb:deleteItem",
+                    "Arguments": {
+                      "TableName": "{% $dynamoDbTableName %}",
+                      "Key": {
+                        "id": {
+                          "S": "{% $taskTokenMapIter %}"
+                        },
+                        "id_type": {
+                          "S": "{% $dynamoDbIdTypeKeys.taskToken %}"
+                        }
+                      }
+                    },
+                    "End": true
+                  }
+                }
+              },
+              {
+                "StartAt": "Get fastq set item (map iter)",
+                "States": {
+                  "Get fastq set item (map iter)": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::dynamodb:getItem",
+                    "Arguments": {
+                      "TableName": "{% $dynamoDbTableName %}",
+                      "Key": {
+                        "id": {
+                          "S": "{% $fastqSetId %}"
+                        },
+                        "id_type": {
+                          "S": "{% $dynamoDbIdTypeKeys.fastqSetId %}"
+                        }
+                      }
+                    },
+                    "Next": "Only one token in fastq set"
+                  },
+                  "Only one token in fastq set": {
+                    "Type": "Choice",
+                    "Choices": [
+                      {
+                        "Next": "Delete fastq set id from db",
+                        "Condition": "{% $count($states.input.Item.task_token_set) = 1 %}"
+                      }
+                    ],
+                    "Default": "Pop task token from fastq set id"
+                  },
+                  "Delete fastq set id from db": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::dynamodb:deleteItem",
+                    "Arguments": {
+                      "TableName": "{% $dynamoDbTableName %}",
+                      "Key": {
+                        "id": {
+                          "S": "{% $fastqSetId %}"
+                        },
+                        "id_type": {
+                          "S": "{% $dynamoDbIdTypeKeys.fastqSetId %}"
+                        }
+                      }
+                    },
+                    "End": true
+                  },
+                  "Pop task token from fastq set id": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:states:::dynamodb:updateItem",
+                    "Arguments": {
+                      "TableName": "{% $dynamoDbTableName %}",
+                      "Key": {
+                        "id": {
+                          "S": "{% $fastqSetId %}"
+                        },
+                        "id_type": {
+                          "S": "{% $dynamoDbIdTypeKeys.fastqSetId %}"
+                        }
+                      },
+                      "UpdateExpression": "SET task_token_set = task_token_set - :removed_task_token",
+                      "ExpressionAttributeValues": {
+                        ":removed_task_token": {
+                          "SS": ["{% $taskTokenMapIter %}"]
+                        }
+                      }
+                    },
+                    "End": true
+                  }
+                }
+              }
+            ],
+            "Next": "Set output requirements (none)"
+          },
+          "Set output requirements (none)": {
+            "Type": "Pass",
+            "End": true,
+            "Output": {
+              "requirementsSetMapIter": []
+            }
+          },
+          "Task token requirement outputs": {
+            "Type": "Pass",
+            "End": true,
+            "Output": {
+              "requirementsSetMapIter": "{% $requirementsSetMapIter %}"
+            }
+          }
+        }
+      },
+      "Next": "Get fastq list row ids from fastq set id",
+      "Assign": {
+        "requirementsSet": "{% /* Flatten and get distinct list of requirements  -  https://try.jsonata.org/DJQepsa_K */\n(\n  $appendRequirements := function($i, $j){$distinct($append($i, $j))};\n  $reduce(\n    [\n      $map($states.result, function($resultIter){$resultIter.requirementsSetMapIter})      \n    ],\n    $appendRequirements\n  )\n)\n\n %}"
+      }
+    },
+    "Get fastq list row ids from fastq set id": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": {
+        "fastqListRowIdList": "{% $states.result.Payload.fastqListRowIdList %}"
+      },
+      "Arguments": {
+        "FunctionName": "${__get_fastq_list_row_from_fastq_set_id_lambda_function_arn__}",
+        "Payload": {
+          "fastqSetId": "{% $fastqSetId %}"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "For each fastq list row in fastq set"
+    },
+    "For each fastq list row in fastq set": {
+      "Type": "Map",
+      "Items": "{% $states.input.fastqListRowIdList %}",
+      "ItemSelector": {
+        "fastqListRowIdMapIter": "{% $states.context.Map.Item.Value %}"
+      },
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "Launch requirements for fastq list row",
+        "States": {
+          "Launch requirements for fastq list row": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::states:startExecution.sync:2",
+            "Arguments": {
+              "StateMachineArn": "${__launch_requirements_sfn_arn__}",
+              "Input": {
+                "fastqListRowId": "{% $states.input.fastqListRowIdMapIter %}",
+                "requirements": "{% $requirementsSet %}"
+              }
+            },
+            "End": true
+          }
+        }
+      },
+      "End": true
+    },
+    "Success": {
+      "Type": "Succeed"
+    }
+  },
+  "QueryLanguage": "JSONata"
+}

--- a/lib/workload/stateless/stacks/fastq-sync/step_functions_templates/initialise_task_token_for_fastq_set_id_sync.asl.json
+++ b/lib/workload/stateless/stacks/fastq-sync/step_functions_templates/initialise_task_token_for_fastq_set_id_sync.asl.json
@@ -1,0 +1,254 @@
+{
+  "Comment": "A description of my state machine",
+  "StartAt": "Save input vars",
+  "States": {
+    "Save input vars": {
+      "Type": "Pass",
+      "Next": "Check fastq set id against requirements",
+      "Assign": {
+        "taskToken": "{% $states.input.taskToken %}",
+        "fastqSetId": "{% $states.input.fastqSetId %}",
+        "requirements": "{% $states.input.requirements %}",
+        "isUnarchivingAllowed": "{% $states.input.forceUnarchiving ? true : false %}",
+        "dynamoDbTableName": "${__dynamodb_table_name__}",
+        "dynamoDbIdTypeKeys": {
+          "fastqSetId": "FASTQ_SET_ID",
+          "taskToken": "TASK_TOKEN"
+        }
+      }
+    },
+    "Check fastq set id against requirements": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Arguments": {
+        "FunctionName": "${__check_fastq_set_id_against_requirements_lambda_function_arn__}",
+        "Payload": {
+          "fastqSetId": "{% $fastqSetId %}",
+          "requirements": "{% $requirements %}",
+          "isUnarchivingAllowed": "{% $isUnarchivingAllowed %}"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "Meets requirements",
+      "Output": {
+        "hasAllRequirements": "{% $states.result.Payload.hasAllRequirements %}"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Send Immediate Task Failure",
+          "Output": {
+            "error": "{% $states.errorOutput %}"
+          }
+        }
+      ]
+    },
+    "Send Immediate Task Failure": {
+      "Type": "Task",
+      "Arguments": {
+        "TaskToken": "{% $taskToken %}",
+        "Error": "FastqArchivedError",
+        "Cause": "{% $parse($states.input.error.Cause).errorMessage %}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskFailure",
+      "End": true
+    },
+    "Meets requirements": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Next": "Send Immediate Task Success",
+          "Condition": "{% $states.input.hasAllRequirements  %}",
+          "Comment": "Fastq Set Id already satisfies all requirements"
+        }
+      ],
+      "Default": "Register Task Token in Database"
+    },
+    "Register Task Token in Database": {
+      "Type": "Parallel",
+      "Next": "Get fastq list rows from fastq set id",
+      "Branches": [
+        {
+          "StartAt": "Register Fastq Sync Event (token)",
+          "States": {
+            "Register Fastq Sync Event (token)": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::dynamodb:putItem",
+              "Arguments": {
+                "TableName": "{% $dynamoDbTableName %}",
+                "Item": {
+                  "id": {
+                    "S": "{% $taskToken %}"
+                  },
+                  "id_type": {
+                    "S": "{% $dynamoDbIdTypeKeys.taskToken %}"
+                  },
+                  "fastq_set_id": {
+                    "S": "{% $fastqSetId %}"
+                  },
+                  "requirements_set": {
+                    "SS": "{% /* https://try.jsonata.org/slAM0Vym- */ [$keys($sift($requirements, function($v){$v = true}))] %}"
+                  }
+                }
+              },
+              "End": true
+            }
+          }
+        },
+        {
+          "StartAt": "Get fastq set id in db",
+          "States": {
+            "Get fastq set id in db": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::dynamodb:getItem",
+              "Arguments": {
+                "TableName": "{% $dynamoDbTableName %}",
+                "Key": {
+                  "id": {
+                    "S": "{% $fastqSetId %}"
+                  },
+                  "id_type": {
+                    "S": "{% $dynamoDbIdTypeKeys.fastqSetId %}"
+                  }
+                }
+              },
+              "Next": "Fastq Set Id in Sync DB"
+            },
+            "Fastq Set Id in Sync DB": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Next": "Add task token to fastq set id",
+                  "Condition": "{% $states.input.Item ? true : false %}",
+                  "Comment": "Fastq Set ID in DB"
+                }
+              ],
+              "Default": "Register Fastq Sync Event (fastq id)"
+            },
+            "Add task token to fastq set id": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::dynamodb:updateItem",
+              "Arguments": {
+                "TableName": "{% $dynamoDbTableName %}",
+                "Key": {
+                  "id": {
+                    "S": "{% $fastqSetId %}"
+                  },
+                  "id_type": {
+                    "S": "{% $dynamoDbIdTypeKeys.fastqSetId %}"
+                  }
+                },
+                "UpdateExpression": "ADD task_token_set :task_token",
+                "ExpressionAttributeValues": {
+                  ":task_token": {
+                    "SS": "{% [ $taskToken ] %}"
+                  }
+                }
+              },
+              "End": true
+            },
+            "Register Fastq Sync Event (fastq id)": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::dynamodb:putItem",
+              "Arguments": {
+                "TableName": "{% $dynamoDbTableName %}",
+                "Item": {
+                  "id": {
+                    "S": "{% $fastqSetId %}"
+                  },
+                  "id_type": {
+                    "S": "{% $dynamoDbIdTypeKeys.fastqSetId %}"
+                  },
+                  "task_token_set": {
+                    "SS": "{% [ $taskToken ] %}"
+                  }
+                }
+              },
+              "End": true
+            }
+          }
+        }
+      ]
+    },
+    "Get fastq list rows from fastq set id": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Arguments": {
+        "FunctionName": "${__get_fastq_list_row_from_fastq_set_id_lambda_function_arn__}",
+        "Payload": {
+          "fastqSetId": "{% $fastqSetId %}"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "For each fastq list row id",
+      "Output": {
+        "fastqListRowIdList": "{% $states.result.Payload.fastqListRowIdList %}"
+      }
+    },
+    "Send Immediate Task Success": {
+      "Type": "Task",
+      "Arguments": {
+        "Output": {},
+        "TaskToken": "{% $taskToken %}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:sendTaskSuccess",
+      "End": true
+    },
+    "For each fastq list row id": {
+      "Type": "Map",
+      "Items": "{% $states.input.fastqListRowIdList %}",
+      "ItemSelector": {
+        "fastqListRowIdMapIter": "{% $states.context.Map.Item.Value %}",
+        "requirementsListMapIter": "{% /* https://try.jsonata.org/slAM0Vym- */ [$keys($sift($requirements, function($v){$v = true}))] %}"
+      },
+      "ItemProcessor": {
+        "ProcessorConfig": {
+          "Mode": "INLINE"
+        },
+        "StartAt": "Launch Requirements for fastq list row id",
+        "States": {
+          "Launch Requirements for fastq list row id": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::states:startExecution.sync:2",
+            "Arguments": {
+              "StateMachineArn": "${__launch_requirements_sfn_arn__}",
+              "Input": {
+                "fastqListRowId": "{% $states.input.fastqListRowIdMapIter %}",
+                "requirements": "{% $states.input.requirementsListMapIter %}"
+              }
+            },
+            "End": true
+          }
+        }
+      },
+      "End": true
+    }
+  },
+  "QueryLanguage": "JSONata"
+}

--- a/lib/workload/stateless/stacks/fastq-sync/step_functions_templates/launch_fastq_list_row_requirements.asl.json
+++ b/lib/workload/stateless/stacks/fastq-sync/step_functions_templates/launch_fastq_list_row_requirements.asl.json
@@ -1,0 +1,243 @@
+{
+  "Comment": "A description of my state machine",
+  "StartAt": "Save vars",
+  "States": {
+    "Save vars": {
+      "Type": "Pass",
+      "Next": "Get fastq list row and remaining requirements",
+      "Assign": {
+        "fastqListRowId": "{% $states.input.fastqListRowId %}",
+        "requirements": "{% $states.input.requirements %}"
+      }
+    },
+    "Get fastq list row and remaining requirements": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Arguments": {
+        "FunctionName": "${__get_fastq_list_row_and_requirements_lambda_function_arn__}",
+        "Payload": {
+          "fastqListRowId": "{% $fastqListRowId %}",
+          "requirements": "{% $requirements %}"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "Next": "Has readset",
+      "Assign": {
+        "fastqListRowObj": "{% $states.result.Payload.fastqListRowObj %}",
+        "satisfiedRequirements": "{% $states.result.Payload.satisfiedRequirements %}",
+        "unsatisfiedRequirements": "{% $states.result.Payload.unsatisfiedRequirements %}"
+      }
+    },
+    "Has readset": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Next": "fastq needs unarchiving",
+          "Condition": "{% $fastqListRowObj.readSet ? true : false %}",
+          "Comment": "Run jobs"
+        }
+      ],
+      "Default": "No readset to add jobs to"
+    },
+    "No readset to add jobs to": {
+      "Type": "Pass",
+      "End": true
+    },
+    "fastq needs unarchiving": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Next": "Launch unarchiving",
+          "Condition": "{% \"hasActiveReadSet\" in $unsatisfiedRequirements %}",
+          "Comment": "Is Active Readset in unsatisfied requirements"
+        }
+      ],
+      "Default": "Launch requirements"
+    },
+    "Launch requirements": {
+      "Type": "Parallel",
+      "Branches": [
+        {
+          "StartAt": "Needs QC",
+          "States": {
+            "Needs QC": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Next": "Launch QC",
+                  "Condition": "{% \"hasQc\" in $unsatisfiedRequirements %}"
+                }
+              ],
+              "Default": "Pass"
+            },
+            "Launch QC": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Output": "{% $states.result.Payload %}",
+              "Arguments": {
+                "FunctionName": "${__launch_requirement_job_lambda_function_arn__}",
+                "Payload": {
+                  "fastqListRowId": "{% $fastqListRowId %}",
+                  "requirementType": "hasQc"
+                }
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 1,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ],
+              "End": true
+            },
+            "Pass": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        },
+        {
+          "StartAt": "Needs Fingerprint",
+          "States": {
+            "Needs Fingerprint": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Next": "Launch Fingerprint",
+                  "Condition": "{% \"hasFingerprint\" in $unsatisfiedRequirements %}"
+                }
+              ],
+              "Default": "Pass (2)"
+            },
+            "Launch Fingerprint": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Output": "{% $states.result.Payload %}",
+              "Arguments": {
+                "FunctionName": "${__launch_requirement_job_lambda_function_arn__}",
+                "Payload": {
+                  "fastqListRowId": "{% $fastqListRowId %}",
+                  "requirementType": "hasFingerprint"
+                }
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 1,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ],
+              "End": true
+            },
+            "Pass (2)": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        },
+        {
+          "StartAt": "Needs Compression Information",
+          "States": {
+            "Needs Compression Information": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Next": "Launch Compression Information",
+                  "Condition": "{% \"hasFileCompressionInformation\" in $unsatisfiedRequirements %}"
+                }
+              ],
+              "Default": "Pass (1)"
+            },
+            "Launch Compression Information": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Output": "{% $states.result.Payload %}",
+              "Arguments": {
+                "FunctionName": "${__launch_requirement_job_lambda_function_arn__}",
+                "Payload": {
+                  "fastqListRowId": "{% $fastqListRowId %}",
+                  "requirementType": "hasFileCompressionInformation"
+                }
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 1,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ],
+              "End": true
+            },
+            "Pass (1)": {
+              "Type": "Pass",
+              "End": true
+            }
+          }
+        }
+      ],
+      "End": true
+    },
+    "Launch unarchiving": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Output": "{% $states.result.Payload %}",
+      "Arguments": {
+        "FunctionName": "${__launch_requirement_job_lambda_function_arn__}",
+        "Payload": {
+          "fastqListRowId": "{% $fastqListRowId %}",
+          "requirementType": "hasActiveReadSet"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2,
+          "JitterStrategy": "FULL"
+        }
+      ],
+      "End": true
+    }
+  },
+  "QueryLanguage": "JSONata"
+}

--- a/lib/workload/stateless/statelessStackCollectionClass.ts
+++ b/lib/workload/stateless/statelessStackCollectionClass.ts
@@ -84,6 +84,7 @@ import {
   FastqUnarchivingManagerStack,
   FastqUnarchivingManagerStackProps,
 } from './stacks/fastq-unarchiving/deploy';
+import { FastqSyncManagerStack, FastqSyncManagerStackProps } from './stacks/fastq-sync/deploy';
 
 export interface StatelessStackCollectionProps {
   metadataManagerStackProps: MetadataManagerStackProps;
@@ -114,6 +115,7 @@ export interface StatelessStackCollectionProps {
   pgDDProps?: PgDDStackProps;
   fastqManagerStackProps: FastqManagerStackProps;
   fastqUnarchivingManagerStackProps: FastqUnarchivingManagerStackProps;
+  fastqSyncManagerStackProps: FastqSyncManagerStackProps;
 }
 
 export class StatelessStackCollection {
@@ -146,6 +148,7 @@ export class StatelessStackCollection {
   readonly sampleSheetCheckerStack: Stack;
   readonly fastqManagerStack: Stack;
   readonly fastqUnarchivingManagerStack: Stack;
+  readonly fastqSyncManagerStack: Stack;
 
   constructor(
     scope: Construct,
@@ -354,6 +357,11 @@ export class StatelessStackCollection {
         ...statelessConfiguration.fastqUnarchivingManagerStackProps,
       }
     );
+
+    this.fastqSyncManagerStack = new FastqSyncManagerStack(scope, 'FastqSyncManagerStack', {
+      ...this.createTemplateProps(env, 'FastqSyncManagerStack'),
+      ...statelessConfiguration.fastqSyncManagerStackProps,
+    });
   }
 
   /**


### PR DESCRIPTION
Just added the readme for now

# Fastq Sync Service

The fastq sync service is a simple service that allows step functions with task tokens to 'hang' 
until the requirements of either a fastq list row or fastq set have been met. 

This is useful for workflow-glue services that have fastq set ids but need to wait for either

1. The fastq set readsets to be created
2. The fastq set to have been qc'd AND have a fingerprint file and compression information
3. This is also useful for data sharing services that require the fastqs to be unarchived before they can be shared

The step function will then hang at that step until the task token has been 'unlocked'

## Registering task tokens

Workflow glue services can use the fastq sync service by generating the following event

```json5
{
  "EventBusName": "OrcaBusMain",
  "Source": "doesnt matter",
  "DetailType": "FastqSync",
  "Detail": {
    "taskToken":  "uuid",
    "fastqSetId": "fqs.123456",
    // Then one or more of the following
    // Requirements can be left out if not needed
    // Do all fastq list rows in the set contain readsets?
    "hasReadsets": true,  
    // Are the fastqs required to be in active storage
    "inActiveStorage": true,
    // Do all fastq list rows in the set contain an ntsm uri?
    "hasFingerprints": true,  
    // Do all fastq list rows in the set contain compression information?
    // Useful if the fastq list rows are in ora format. 
    // Some pipelines require the gzip file size in bytes in order 
    // to stream the gzip file from ora back into s3 
    "hasCompressionInformation": true,  
    // Do all fastq list rows in the set contain qc information?
    // We don't use this for anything yet but we may use this in the future
    // to ensure that a fastq set has met the ideal coverage levels
    "hasQc": true,
  }
}
```

The fastq sync service will also trigger the qc, fingerprint or compression information services on the fastq manager if they do not exist but are required (note that the fastq sync service is aware that archived files are not able to have fastq manager internal services run on them, and as such will trigger the unarchiving of these fastqs). 

![image](https://github.com/user-attachments/assets/2eb0d403-317e-48eb-aadb-30fe12c24e75)

## Unlocking task tokens

The fastq sync service will listen for the following events:

1. FastqSetUpdated (from the fastq management service)

2. UnarchivingCompleted (from the fastq unarchiving service)

![image](https://github.com/user-attachments/assets/943940a6-4746-4a47-9aa5-a60ceafb85d2)

The fastq sync service will then check against the requirements of the fastq set or fastq list row for each task token and if so, unlock the task token.

## Launching requirements sfn

Both step functions above call the launch requirements step function on each fastq list row in the set. 

The launch requirements step function looks like this:

![image](https://github.com/user-attachments/assets/c2c7566a-a794-47e7-b468-46c4ba88c8d2)


Resolves #871 

## TODO

- [ ] #896
- [ ] #897
- [ ] #898 
