### PR TITLE
Add srm state operations and apis

### DIFF
--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/models/sequence.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/models/sequence.py
@@ -126,6 +126,11 @@ class Sequence(OrcaBusBaseModel):
         """
         return list(LibraryAssociation.objects.filter(sequence=self).values_list('library_id', flat=True))
 
+    def get_latest_state(self):
+        """
+        Get the latest state for the sequence
+        """
+        return self.states.order_by('-timestamp').first()
 
 
 class LibraryAssociationManager(OrcaBusBaseManager):

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/models/sequence.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/models/sequence.py
@@ -15,6 +15,9 @@ class SequenceStatus(models.TextChoices):
     FAILED = "FAILED"
     SUCCEEDED = "SUCCEEDED"
     ABORTED = "ABORTED"
+    
+    # custom status,  resolve issue: https://github.com/umccr/orcabus/issues/879
+    RESOLVED = "RESOLVED"
 
     @classmethod
     def from_value(cls, value):
@@ -24,6 +27,8 @@ class SequenceStatus(models.TextChoices):
             return cls.SUCCEEDED
         elif value == cls.FAILED.value:
             return cls.FAILED
+        elif value == cls.RESOLVED.value:
+            return cls.RESOLVED
         else:
             raise ValueError(f"No matching SequenceStatus found for value: {value}")
 

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/viewsets/sequence_run_stats.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/viewsets/sequence_run_stats.py
@@ -54,6 +54,7 @@ class SequenceStatsViewSet(GenericViewSet):
             'succeeded': 0,
             'aborted': 0,
             'failed': 0,
+            'resolved': 0,
         }
         
         for item in status_counts:

--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/viewsets/state.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/viewsets/state.py
@@ -1,16 +1,113 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema
 from rest_framework.viewsets import GenericViewSet
-from rest_framework import mixins
-
-from sequence_run_manager.models.state import State
+from rest_framework import mixins, status
+from rest_framework.response import Response
+from rest_framework.decorators import action
+from django.utils import timezone
+from sequence_run_manager.models import State, Sequence
 from sequence_run_manager.serializers.state import StateSerializer
 
 
-class StateViewSet(mixins.ListModelMixin, GenericViewSet):
+class StateViewSet(mixins.CreateModelMixin, mixins.UpdateModelMixin, mixins.ListModelMixin,  GenericViewSet):
     serializer_class = StateSerializer
     search_fields = State.get_base_fields()
+    http_method_names = ['get', 'post', 'patch']
     pagination_class = None
     lookup_value_regex = "[^/]+" # to allow id prefix
 
+    """
+    valid_states_map for state creation, update
+    refer: 
+        "Resolved" -- https://github.com/umccr/orcabus/issues/879
+    """
+    valid_states_map = {
+        'RESOLVED': ['FAILED']
+    }
+
     def get_queryset(self):
         return State.objects.filter(sequence=self.kwargs["orcabus_id"])
+    
+    @extend_schema(responses=OpenApiTypes.OBJECT, description="Valid states map for new state creation, update")
+    @action(detail=False, methods=['get'], url_name='valid_states_map', url_path='valid_states_map')
+    def get_valid_states_map(self, request, **kwargs):
+        return Response(self.valid_states_map)
 
+    
+    def create(self, request, *args, **kwargs):
+        """
+        Create a customed new state for a sequence run.
+        Currently we support "Resolved"
+        """
+        sequence_orcabus_id = self.kwargs.get("orcabus_id")
+        sequence = Sequence.objects.get(orcabus_id=sequence_orcabus_id)
+        
+        latest_state = sequence.get_latest_state()
+        if not latest_state:
+            return Response({"detail": "No state found for sequence run '{}'".format(sequence_orcabus_id)},
+                            status=status.HTTP_400_BAD_REQUEST)
+        latest_status = latest_state.status
+        request_status = request.data.get('status', '').upper()
+        
+        # check if the state status is valid
+        if not self.check_state_status(latest_status, request_status):
+            return Response({"detail": "Invalid state request. Can't add state '{}' to '{}'".format(request_status, latest_status)},
+                            status=status.HTTP_400_BAD_REQUEST)
+        
+        # comment is required when request change state
+        if not request.data.get('comment'):
+            return Response({"detail": "Comment is required when request status is '{}'".format(request_status)},
+                            status=status.HTTP_400_BAD_REQUEST)
+            
+        # create a new state
+        new_state = State.objects.create(
+            sequence=sequence,
+            status=request_status,
+            comment=request.data.get('comment'),
+            timestamp=timezone.now()
+        )
+        
+        # return the new state
+        serializer = self.get_serializer(new_state)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+        
+        
+    def update(self, request, *args, **kwargs):
+        """
+        Update a state for a sequence run.
+        Currently we support "Resolved"
+        """
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object()
+        
+        # Check if the state being updated is "Resolved"
+        if instance.status not in self.valid_states_map:
+            return Response({"detail": "Invalid state status."},
+                            status=status.HTTP_400_BAD_REQUEST)
+        
+        # Check if only the comment field is being updated
+        if set(request.data.keys()) != {'comment'}:
+            return Response({"detail": "Only the comment field can be updated."},
+                            status=status.HTTP_400_BAD_REQUEST)
+            
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        
+        if getattr(instance, '_prefetched_objects_cache', None):
+            # If 'prefetch_related' has been applied to a queryset, we need to
+            # forcibly invalidate the prefetch cache on the instance.
+            instance._prefetched_objects_cache = {}
+
+        return Response(serializer.data)
+
+    def check_state_status(self, current_status, request_status):
+        """
+        check if the state status is valid: 
+        valid_states_map[request_state] == current_state.status
+        """
+        return request_status in self.valid_states_map.get(current_status, [])
+        
+        
+        


### PR DESCRIPTION
solve: #879 

Add state operations in the SRM states.
State creation:
Post - `/api/v1/sequence/{orcabus_id}/state/`
update the comment
Patch - `/api/v1/sequence/{orcabus_id}/state/{id}` 

currently it only support 'RESOLVED' for failed sequence run.
```
valid_states_map = {
        'RESOLVED': ['FAILED']
    }
```
