### PR TITLE
add srm library id filter

### DIFF
--- a/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/viewsets/sequence.py
+++ b/lib/workload/stateless/stacks/sequence-run-manager/sequence_run_manager/viewsets/sequence.py
@@ -1,20 +1,27 @@
 from drf_spectacular.utils import extend_schema
 from sequence_run_manager.viewsets.base import BaseViewSet
 from django.db.models import Q
-from sequence_run_manager.models import Sequence
-from sequence_run_manager.serializers.sequence import SequenceSerializer, SequenceListParamSerializer, \
-    SequenceMinSerializer
+from sequence_run_manager.models import Sequence, LibraryAssociation
+from sequence_run_manager.serializers.sequence import SequenceSerializer, SequenceListParamSerializer, SequenceMinSerializer
 
 
 class SequenceViewSet(BaseViewSet):
     serializer_class = SequenceSerializer
     search_fields = Sequence.get_base_fields()
+    lookup_value_regex = "[^/]+" # to allow id prefix
 
     def get_queryset(self):
-        """Pick up the start_time and end_time from the query params and exclude them from the rest of the query params"""
+        """
+        custom query params:
+        start_time: start time of the sequence run
+        end_time: end time of the sequence run
+        
+        library_id: library id of the sequence run
+        """
         
         start_time = self.request.query_params.get('start_time', 0)
         end_time = self.request.query_params.get('end_time', 0)
+        library_id = self.request.query_params.get('library_id', 0)
         
         # exclude the custom query params from the rest of the query params
         def exclude_params(params):
@@ -24,13 +31,17 @@ class SequenceViewSet(BaseViewSet):
         exclude_params([
             'start_time',
             'end_time',
+            'library_id',
         ])
         result_set = Sequence.objects.get_by_keyword(**self.request.query_params)
 
         if start_time and end_time:
             result_set = result_set.filter(Q(start_time__range=[start_time, end_time]) | Q(end_time__range=[start_time, end_time]))
+        if library_id:
+            sequence_ids = LibraryAssociation.objects.filter(library_id=library_id).values_list('sequence_id', flat=True)
+            result_set = result_set.filter(orcabus_id__in=sequence_ids)
 
-        return result_set
+        return result_set.distinct()
     
 
     @extend_schema(parameters=[


### PR DESCRIPTION
Add new filter params for sequence run manager:
Example
`/api/v1/sequence?library_id=L123456`
it will return all sequence run which carry this library.
```
{
    "links": {
        "next": null,
        "previous": null
    },
    "pagination": {
        "count": 1,
        "page": 1,
        "rowsPerPage": 10
    },
    "results": [
        {
            "orcabusId": "string",
            "instrumentRunId": "string",
            "experimentName": "string",
            "startTime": "string",
            "endTime": "string",
            "status": "string"
        }
    ]
}
```