### PR TITLE
fix: avoid cross compiling on same architecture

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/function.ts
@@ -107,6 +107,7 @@ export class Function extends Construct {
         environment: {
           ...props.buildEnvironment,
         },
+        ...(process.arch == 'arm64' && { cargoLambdaFlags: ['--compiler', 'cargo'] }),
         dockerOptions: {
           network: 'host',
         },


### PR DESCRIPTION
This is related to failing filemanager builds on CodeBuild: https://github.com/umccr/orcabus/actions/runs/13912874550/job/38930505126?pr=912

I think this is an upstream issue - the `RustFunction` uses zig underneath to cross compile because the native cross compilation using `cargo` is not as convenient. This only occurs on some targets and I think this issue is related: https://github.com/ziglang/zig/issues/23052

Either way, this is only affecting compilation with zig to `aarch64` from an arm64 machine. For that case, it's better to just use cargo directly as there is no cross compilation.

### Changes 
* Fixes the arm64 filemanager builds by avoiding `cargo-zigbuild` and just using cargo directly.

