### PR TITLE
upgrade orcabus to postgres 16

### DIFF
--- a/config/stacks/shared.ts
+++ b/config/stacks/shared.ts
@@ -176,8 +176,8 @@ const getDatabaseConstructProps = (stage: AppStage): ConfigurableDatabaseProps =
   const baseConfig = {
     clusterIdentifier: dbClusterIdentifier,
     defaultDatabaseName: 'orcabus',
-    version: AuroraPostgresEngineVersion.VER_15_4,
-    parameterGroupName: 'default.aurora-postgresql15',
+    version: AuroraPostgresEngineVersion.VER_16_6,
+    parameterGroupName: 'default.aurora-postgresql16',
     username: 'postgres',
     dbPort: databasePort,
     masterSecretName: rdsMasterSecretName,

--- a/lib/workload/stateful/stacks/shared/constructs/database/index.ts
+++ b/lib/workload/stateful/stacks/shared/constructs/database/index.ts
@@ -179,6 +179,7 @@ export class DatabaseConstruct extends Construct {
       backup: {
         retention: props.backupRetention,
       },
+      enableDataApi: true,
     });
 
     new sm.SecretRotation(this, 'MasterDbSecretRotation', {

--- a/lib/workload/stateless/stacks/filemanager/database/Dockerfile
+++ b/lib/workload/stateless/stacks/filemanager/database/Dockerfile
@@ -1,3 +1,3 @@
-FROM public.ecr.aws/docker/library/postgres:15.4
+FROM public.ecr.aws/docker/library/postgres:16
 
 COPY migrations/ /docker-entrypoint-initdb.d/

--- a/lib/workload/stateless/stacks/metadata-manager/Makefile
+++ b/lib/workload/stateless/stacks/metadata-manager/Makefile
@@ -32,7 +32,7 @@ db-dump:
 	-v $(shell pwd):/data \
 	-e PGPASSWORD=orcabus \
 	--network=metadata-manager_default \
-	postgres:15.4 \
+	postgres:16 \
 	pg_dump -h orcabus_db -U orcabus -d metadata_manager | gzip > data/mm_dump.sql.gz
 
 s3-dump-upload:

--- a/shared/mock-db.yml
+++ b/shared/mock-db.yml
@@ -3,7 +3,7 @@ services:
     # Use version that align with upper bound of AWS Aurora PostgreSQL LTS
     # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraPostgreSQL.Updates.LTS.html
     # See container image doc https://gallery.ecr.aws/docker/library/postgres for more settings
-    image: public.ecr.aws/docker/library/postgres:15.4
+    image: public.ecr.aws/docker/library/postgres:16
     container_name: orcabus_db
     restart: always
     environment:


### PR DESCRIPTION
As we discussed in security patrol, our orcabus version is bit lag behind.
"_Your database resources aren't running the latest minor DB engine version. The latest minor version contains the latest security fixes and other improvements._"

so it is time to upgrade postgres to latest version (include testing postgres images).

After testing in DEV, we can upgrade from 15.4 to 16.6 for orcabus databse engine. And it works fine for all ui api call.
As logs show, there will be around 11 mins downtime for this upgrade. ([log link](https://843407916570-ykjyha5d.ap-southeast-2.console.aws.amazon.com/rds/home?region=ap-southeast-2#database:id=orcabus-db;is-cluster=true;tab=logs-and-events))
![image](https://github.com/user-attachments/assets/ee2e0c36-fc88-4204-942a-e7b5c56dcce3)


But more testing still need to be done.

