### PR TITLE
Enable corepack before all yarn --install commands

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,6 +7,7 @@ tasks:
     init: |
       pre-commit install
       pre-commit run
+      corepack enable
       yarn install
       find ./lib -name 'requirements.txt' -exec pip install -r {} \;
       pip install -r requirements-dev.txt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: test deep scan
 
 install:
+	@corepack enable
 	@yarn install
 	@pre-commit install
 

--- a/lib/pipeline/statefulPipelineStack.ts
+++ b/lib/pipeline/statefulPipelineStack.ts
@@ -26,6 +26,7 @@ export class StatefulPipelineStack extends cdk.Stack {
 
     const unitTest = new pipelines.CodeBuildStep('UnitTest', {
       commands: [
+        'corepack enable',
         'yarn install --immutable',
         'make test-stateful-iac',
         'make test-stateful-app-suite',
@@ -61,7 +62,7 @@ export class StatefulPipelineStack extends cdk.Stack {
     });
 
     const synthAction = new pipelines.CodeBuildStep('Synth', {
-      commands: ['yarn install --immutable', 'yarn run cdk-stateful synth'],
+      commands: ['corepack enable', 'yarn install --immutable', 'yarn run cdk-stateful synth'],
       input: unitTest,
       primaryOutputDirectory: 'cdk.out',
       rolePolicyStatements: [

--- a/lib/pipeline/statelessPipelineStack.ts
+++ b/lib/pipeline/statelessPipelineStack.ts
@@ -77,6 +77,7 @@ export class StatelessPipelineStack extends cdk.Stack {
         `pip3 install cargo-lambda`,
       ],
       commands: [
+        'corepack enable',
         'yarn install --immutable',
         'make test-stateless-iac',
         'make test-stateless-app-suite',
@@ -125,7 +126,7 @@ export class StatelessPipelineStack extends cdk.Stack {
         'rustup component add rustfmt',
         `pip3 install cargo-lambda`,
       ],
-      commands: ['yarn install --immutable', 'yarn run cdk-stateless synth'],
+      commands: ['corepack enable', 'yarn install --immutable', 'yarn run cdk-stateless synth'],
       input: unitTest,
       primaryOutputDirectory: 'cdk.out',
       rolePolicyStatements: [

--- a/lib/workload/stateful/stacks/postgres-manager/Makefile
+++ b/lib/workload/stateful/stacks/postgres-manager/Makefile
@@ -1,6 +1,7 @@
 .PHONY: test
 
 install:
+	@corepack enable
 	@yarn install --immutable
 
 up:


### PR DESCRIPTION
By removing the .yarn/yarn--version.cjs file I think corepack enable is needed order for the build commands to work - see 
https://umccr.slack.com/archives/C070B52CHT9/p1743493591199569?thread_ts=1743387409.116639&cid=C070B52CHT9