### PR TITLE
bump: cdk from 2.187.0 to 2.189.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "cdk-stateful": "cdk --app 'yarn run -B ts-node --prefer-ts-exts bin/statefulPipeline.ts'"
   },
   "dependencies": {
-    "@aws-cdk/aws-lambda-go-alpha": "2.187.0-alpha.0",
-    "@aws-cdk/aws-lambda-python-alpha": "2.187.0-alpha.0",
-    "@aws-cdk/aws-pipes-alpha": "2.187.0-alpha.0",
-    "@aws-cdk/aws-pipes-sources-alpha": "2.187.0-alpha.0",
-    "aws-cdk-lib": "2.187.0",
+    "@aws-cdk/aws-lambda-go-alpha": "2.189.0-alpha.0",
+    "@aws-cdk/aws-lambda-python-alpha": "2.189.0-alpha.0",
+    "@aws-cdk/aws-pipes-alpha": "2.189.0-alpha.0",
+    "@aws-cdk/aws-pipes-sources-alpha": "2.189.0-alpha.0",
+    "aws-cdk-lib": "2.189.0",
     "cargo-lambda-cdk": "^0.0.31",
     "cdk-nag": "^2.35.3",
     "constructs": "^10.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,44 +29,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-lambda-go-alpha@npm:2.187.0-alpha.0":
-  version: 2.187.0-alpha.0
-  resolution: "@aws-cdk/aws-lambda-go-alpha@npm:2.187.0-alpha.0"
+"@aws-cdk/aws-lambda-go-alpha@npm:2.189.0-alpha.0":
+  version: 2.189.0-alpha.0
+  resolution: "@aws-cdk/aws-lambda-go-alpha@npm:2.189.0-alpha.0"
   peerDependencies:
-    aws-cdk-lib: ^2.187.0
+    aws-cdk-lib: ^2.189.0
     constructs: ^10.0.0
-  checksum: 10c0/5228c590a4a815016a6a382d4d13c217643ee76e626a5bac26365da6434703c634186f4a9771e17cd814c8c9cb463a5751fa8619acdec0bb6a10b7cd80d266d6
+  checksum: 10c0/53a61e4037cf092ba20c828b00f160d76ecd305114c643cb78ce1d8224a6c6a5e57964e8aab50d1c86ca5c677a1a578b90deb97189787d57d6756530a9b4e3a1
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-lambda-python-alpha@npm:2.187.0-alpha.0":
-  version: 2.187.0-alpha.0
-  resolution: "@aws-cdk/aws-lambda-python-alpha@npm:2.187.0-alpha.0"
+"@aws-cdk/aws-lambda-python-alpha@npm:2.189.0-alpha.0":
+  version: 2.189.0-alpha.0
+  resolution: "@aws-cdk/aws-lambda-python-alpha@npm:2.189.0-alpha.0"
   peerDependencies:
-    aws-cdk-lib: ^2.187.0
+    aws-cdk-lib: ^2.189.0
     constructs: ^10.0.0
-  checksum: 10c0/e0e09181bede2755e02629e07e19a104e4b9f39ea79f428d04e677b876c440c683e26bf83f44a82d50cf9303aa704ae09013ebb7bf981e95281f1e042e29f320
+  checksum: 10c0/5f79790a350bf6ece17984b59e49a4a7c6b276c4ad79e0216abdb535a12541a855865a849ee72a8fc2f22eec9db200024b555b9694facc53018932c166bca55c
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-pipes-alpha@npm:2.187.0-alpha.0":
-  version: 2.187.0-alpha.0
-  resolution: "@aws-cdk/aws-pipes-alpha@npm:2.187.0-alpha.0"
+"@aws-cdk/aws-pipes-alpha@npm:2.189.0-alpha.0":
+  version: 2.189.0-alpha.0
+  resolution: "@aws-cdk/aws-pipes-alpha@npm:2.189.0-alpha.0"
   peerDependencies:
-    aws-cdk-lib: ^2.187.0
+    aws-cdk-lib: ^2.189.0
     constructs: ^10.0.0
-  checksum: 10c0/da05ae8f02fa7936cb78baea40d144c457de323ace1abb4f437fcad7a8b29579d357b20682ef8f991b19a39155ec5fdaa2da1bb2da9f853a59bca7c587cdfde7
+  checksum: 10c0/f5a61cc6f0fd24f1f47b576a504c81c93f6512bcf08134e6cc2c5ab7f2a270507e924c999c291680c521333f8078f54a53954c52044448b1d527468269224e12
   languageName: node
   linkType: hard
 
-"@aws-cdk/aws-pipes-sources-alpha@npm:2.187.0-alpha.0":
-  version: 2.187.0-alpha.0
-  resolution: "@aws-cdk/aws-pipes-sources-alpha@npm:2.187.0-alpha.0"
+"@aws-cdk/aws-pipes-sources-alpha@npm:2.189.0-alpha.0":
+  version: 2.189.0-alpha.0
+  resolution: "@aws-cdk/aws-pipes-sources-alpha@npm:2.189.0-alpha.0"
   peerDependencies:
-    "@aws-cdk/aws-pipes-alpha": 2.187.0-alpha.0
-    aws-cdk-lib: ^2.187.0
+    "@aws-cdk/aws-pipes-alpha": 2.189.0-alpha.0
+    aws-cdk-lib: ^2.189.0
     constructs: ^10.0.0
-  checksum: 10c0/f5c14a80737378fa2b4fbc734973548a077bee7e2727d9b442f6a6f61802d3690c7d204011460c5ea0d68e4404eb6a57255543f5a30ea3f47f2ad75a37dda773
+  checksum: 10c0/ae9ca1007c637b7821ff5c11d813217ed271591ec8f5e729a588d8f6dc5f221d3242a2e32493dc2270405e20d910fe32a9eb99f6ca4f3c5332dbb94050e2219a
   languageName: node
   linkType: hard
 
@@ -2477,9 +2477,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk-lib@npm:2.187.0":
-  version: 2.187.0
-  resolution: "aws-cdk-lib@npm:2.187.0"
+"aws-cdk-lib@npm:2.189.0":
+  version: 2.189.0
+  resolution: "aws-cdk-lib@npm:2.189.0"
   dependencies:
     "@aws-cdk/asset-awscli-v1": "npm:^2.2.229"
     "@aws-cdk/asset-node-proxy-agent-v6": "npm:^2.1.0"
@@ -2497,7 +2497,7 @@ __metadata:
     yaml: "npm:1.10.2"
   peerDependencies:
     constructs: ^10.0.0
-  checksum: 10c0/9b2d97e3e21d296ccf73d099512d380bbc9fd464acd5c02e521b869af82a2c74eef7dd70695012759911bf02eb0e77267b4283b2b7b10643b740c59dea727398
+  checksum: 10c0/842d24cf7c25f3ce5b89bb7d2a6a648f9db2a0de6da8331e192a5ad5e60278be3a8941b1d6a6b8da45123ec9254c861f713ad28603c56988659ad807d4610706
   languageName: node
   linkType: hard
 
@@ -5063,17 +5063,17 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "orcabus@workspace:."
   dependencies:
-    "@aws-cdk/aws-lambda-go-alpha": "npm:2.187.0-alpha.0"
-    "@aws-cdk/aws-lambda-python-alpha": "npm:2.187.0-alpha.0"
-    "@aws-cdk/aws-pipes-alpha": "npm:2.187.0-alpha.0"
-    "@aws-cdk/aws-pipes-sources-alpha": "npm:2.187.0-alpha.0"
+    "@aws-cdk/aws-lambda-go-alpha": "npm:2.189.0-alpha.0"
+    "@aws-cdk/aws-lambda-python-alpha": "npm:2.189.0-alpha.0"
+    "@aws-cdk/aws-pipes-alpha": "npm:2.189.0-alpha.0"
+    "@aws-cdk/aws-pipes-sources-alpha": "npm:2.189.0-alpha.0"
     "@aws-sdk/client-eventbridge": "npm:^3.758.0"
     "@eslint/js": "npm:^9.19.0"
     "@types/eslint__js": "npm:^8.42.3"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.13.10"
     aws-cdk: "npm:^2.1006.0"
-    aws-cdk-lib: "npm:2.187.0"
+    aws-cdk-lib: "npm:2.189.0"
     cargo-lambda-cdk: "npm:^0.0.31"
     cdk-nag: "npm:^2.35.3"
     constructs: "npm:^10.4.2"


### PR DESCRIPTION
Fixes pre-commit-lint-security step and issues with duplicate sfn outputs. With 2.187.0 a `cdk synth` would fail with:

```
ValidationError: Stage Assets.2 already contains an action with name 'sfn_configure_outputs_json_DefinitionBody2'
    at path [OrcaBusStatelessPipeline/Pipeline/Pipeline/Assets.2] in constructs.Construct     
```

Related issue https://github.com/aws/aws-cdk/issues/34027