### PR TITLE
fix(filemanager): ignore transient secret errors

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
+++ b/lib/workload/stateless/stacks/filemanager/deploy/constructs/functions/api.ts
@@ -36,7 +36,7 @@ export class ApiFunction extends fn.Function {
     // Allow access to the access key secret.
     this.role.addToPolicy(
       new PolicyStatement({
-        actions: ['secretsmanager:GetSecretValue'],
+        actions: ['secretsmanager:GetSecretValue', 'secretsmanager:DescribeSecret'],
         resources: [`${props.accessKeySecretArn}-*`],
       })
     );


### PR DESCRIPTION
Related to https://github.com/umccr/orca-ui/issues/173

### Changes
* Add flag to ignore transient errors in the secrets manager cache.
* Print the error with full context if it does occur.

Hopefully this should reduce the amount of times this occur. I'll have to look into the issue more to determine if it really is a transient error or something else. If it is a transient error and it keeps occuring, I can add a retry mechanism.