### PR TITLE
fix(filemanager): order nulls last desc and first asc to preserve correct current state

### DIFF
--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/reset_current_state.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/reset_current_state.sql
@@ -26,7 +26,7 @@ to_update as (
             -- This finds the first value in the set which represents the most up-to-date state.
             -- If ordered by the sequencer, the first row is the one that needs to have `is_current_state`
             -- set to 'true' only for `Created` events, as `Deleted` events are always non-current state.
-            case when row_number() over (order by s3_object.sequencer desc) = 1 then
+            case when row_number() over (order by s3_object.sequencer desc nulls last) = 1 then
                 event_type = 'Created'
             -- Set `is_current_state` to 'false' for all other rows, as this is now historical data.
             else

--- a/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
+++ b/lib/workload/stateless/stacks/filemanager/database/queries/api/select_existing_by_bucket_key.sql
@@ -51,7 +51,7 @@ cross join lateral (
         input.key = s3_object.key and
         input.version_id = s3_object.version_id and
         s3_object.is_current_state = true
-    order by s3_object.sequencer desc
+    order by s3_object.sequencer desc nulls last
     limit 1
 )
 as s3_object

--- a/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
+++ b/lib/workload/stateless/stacks/filemanager/filemanager/src/queries/list.rs
@@ -4,12 +4,12 @@
 use sea_orm::prelude::Expr;
 use sea_orm::sea_query::extension::postgres::PgExpr;
 use sea_orm::sea_query::{
-    Alias, BinOper, ColumnRef, ConditionExpression, IntoColumnRef, IntoCondition,
+    Alias, BinOper, ColumnRef, ConditionExpression, IntoColumnRef, IntoCondition, NullOrdering,
     PostgresQueryBuilder, SimpleExpr,
 };
 use sea_orm::{
     ColumnTrait, Condition, ConnectionTrait, EntityTrait, FromQueryResult, IntoSimpleExpr,
-    JsonValue, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait, Select,
+    JsonValue, Order, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect, QueryTrait, Select,
 };
 use tracing::trace;
 use url::Url;
@@ -47,7 +47,11 @@ where
 
     /// Define a select query for finding values from s3 objects.
     pub fn for_s3() -> Select<s3_object::Entity> {
-        s3_object::Entity::find().order_by_asc(s3_object::Column::Sequencer)
+        s3_object::Entity::find().order_by_with_nulls(
+            s3_object::Column::Sequencer,
+            Order::Asc,
+            NullOrdering::First,
+        )
     }
 
     /// Filter records by all fields in the filter variable.


### PR DESCRIPTION
Closes #989

### Changes
 * Order nulls last when descending and first when ascending to fix null sequencers being preferred over real sequencers.