### PR TITLE
Fastq glue should listen to SRM succeeded events

### DIFF
--- a/lib/workload/stateless/stacks/fastq-glue/deploy/index.ts
+++ b/lib/workload/stateless/stacks/fastq-glue/deploy/index.ts
@@ -396,9 +396,11 @@ export class FastqGlueStack extends Stack {
       this.lambdaObjects[lambdaName] = this.createLambdaFunction({
         lambdaName: lambdaName,
         ...{
-          layerRequirements: lambdaToRequirementsMapping[lambdaName].needsFastqToolsLayer
-            ? props.layerRequirements
-            : undefined,
+          layerRequirements:
+            lambdaToRequirementsMapping[lambdaName].needsFastqToolsLayer ||
+            lambdaToRequirementsMapping[lambdaName].needsSequenceToolsLayer
+              ? props.layerRequirements
+              : undefined,
           fastqToolsLayer: lambdaToRequirementsMapping[lambdaName].needsFastqToolsLayer
             ? props.fastqToolsLayer
             : undefined,

--- a/lib/workload/stateless/stacks/fastq-glue/deploy/interfaces.ts
+++ b/lib/workload/stateless/stacks/fastq-glue/deploy/interfaces.ts
@@ -62,7 +62,7 @@ export const lambdaToRequirementsMapping: LambdaToRequirementsMappingType = {
   getSampleDemultiplexStats: {
     needsCacheBucketReadPermissions: true,
     needsFastqToolsLayer: false,
-    needsSequenceToolsLayer: false,
+    needsSequenceToolsLayer: true,
   },
 };
 

--- a/lib/workload/stateless/stacks/fastq-glue/step_functions_templates/fastq_set_add_read_set_template_sfn.asl.json
+++ b/lib/workload/stateless/stacks/fastq-glue/step_functions_templates/fastq_set_add_read_set_template_sfn.asl.json
@@ -15,7 +15,7 @@
       "Next": "Get Libraries in Instrument Run ID",
       "Assign": {
         "fastqListUri": "{% $outputUri & 'Reports/fastq_list.csv' %}",
-        "demuxStatsUri": "{% $outputUri & 'Reports/DemultiplexStats.csv' %}"
+        "demuxStatsUri": "{% $outputUri & 'Reports/Demultiplex_Stats.csv' %}"
       }
     },
     "Get Libraries in Instrument Run ID": {
@@ -50,7 +50,15 @@
       "Type": "Map",
       "Label": "Foreachlibrarybatched",
       "MaxConcurrency": 1000,
-      "Items": "{% $states.input.samplesList %}",
+      "Items": "{% $states.input.libraryIdList %}",
+      "ItemBatcher": {
+        "BatchInput": {
+          "fastqListUri": "{% $fastqListUri %}",
+          "demuxStatsUri": "{% $demuxStatsUri %}",
+          "instrumentRunId": "{% $instrumentRunId %}"
+        },
+        "MaxItemsPerBatch": 10
+      },
       "ItemProcessor": {
         "ProcessorConfig": {
           "Mode": "DISTRIBUTED",
@@ -150,7 +158,8 @@
                       "FunctionName": "${__get_sample_demultiplex_stats_lambda_function_arn__}",
                       "Payload": {
                         "sampleIdList": "{% $libraryIdListMapIter %}",
-                        "demuxStatsUri": "{% $demuxStatsUriMapIter %}"
+                        "demuxStatsUri": "{% $demuxStatsUriMapIter %}",
+                        "instrumentRunId": "{% $instrumentRunIdMapIter %}"
                       }
                     },
                     "Retry": [
@@ -230,14 +239,6 @@
         }
       },
       "Output": {},
-      "ItemBatcher": {
-        "BatchInput": {
-          "fastqListUri": "{% $fastqListUri %}",
-          "demuxStatsUri": "{% $demuxStatsUri %}",
-          "instrumentRunId": "{% $instrumentRunId %}"
-        },
-        "MaxItemsPerBatch": 10
-      },
       "End": true
     }
   },


### PR DESCRIPTION
Fastq glue now creates 'empty' fastq list rows when srm completes and then adds readsets once bsshfastqcopy completes. 