### PR TITLE
refactor(stateless): detach direct dependency on the filemanager stack

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -159,6 +159,7 @@ export const fileManagerPresignUserSecret = 'orcabus/file-manager-presign-user';
 validateSecretName(fileManagerPresignUserSecret);
 
 export const fileManagerPresignUser = 'orcabus-file-manager-presign-user'; // pragma: allowlist secret
+export const fileManagerDomainPrefix = 'file';
 
 export const dataMoverRoleName = 'orcabus-data-mover-role';
 

--- a/config/stacks/fileManager.ts
+++ b/config/stacks/fileManager.ts
@@ -21,6 +21,7 @@ import {
   ntsmBucket,
   dataSharingCacheBucket,
   externalProjectBuckets,
+  fileManagerDomainPrefix,
 } from '../constants';
 
 export const fileManagerBuckets = (stage: AppStage): string[] => {
@@ -69,7 +70,7 @@ export const getFileManagerStackProps = (stage: AppStage): FilemanagerConfig => 
       corsAllowOrigins: corsAllowOrigins[stage],
       apiGwLogsConfig: logsApiGatewayConfig[stage],
       apiName: 'FileManager',
-      customDomainNamePrefix: 'file',
+      customDomainNamePrefix: fileManagerDomainPrefix,
     },
   };
 };

--- a/config/stacks/fmAnnotator.ts
+++ b/config/stacks/fmAnnotator.ts
@@ -1,11 +1,18 @@
-import { FMAnnotatorConfigurableProps } from '../../lib/workload/stateless/stacks/fmannotator/deploy/stack';
-import { eventBusName, eventDlqNameFMAnnotator, jwtSecretName, vpcProps } from '../constants';
+import { FMAnnotatorProps } from '../../lib/workload/stateless/stacks/fmannotator/deploy/stack';
+import {
+  eventBusName,
+  eventDlqNameFMAnnotator,
+  fileManagerDomainPrefix,
+  jwtSecretName,
+  vpcProps,
+} from '../constants';
 
-export const getFmAnnotatorProps = (): FMAnnotatorConfigurableProps => {
+export const getFmAnnotatorProps = (): FMAnnotatorProps => {
   return {
     vpcProps,
     eventBusName,
     jwtSecretName,
     eventDLQName: eventDlqNameFMAnnotator,
+    customDomainNamePrefix: fileManagerDomainPrefix,
   };
 };

--- a/config/stacks/htsget.ts
+++ b/config/stacks/htsget.ts
@@ -2,13 +2,14 @@ import {
   AppStage,
   cognitoApiGatewayConfig,
   corsAllowOrigins,
+  fileManagerIngestRoleName,
   logsApiGatewayConfig,
   vpcProps,
 } from '../constants';
-import { HtsgetStackConfigurableProps } from '../../lib/workload/stateless/stacks/htsget/stack';
+import { HtsgetStackProps } from '../../lib/workload/stateless/stacks/htsget/stack';
 import { fileManagerBuckets, fileManagerInventoryBuckets } from './fileManager';
 
-export const getHtsgetProps = (stage: AppStage): HtsgetStackConfigurableProps => {
+export const getHtsgetProps = (stage: AppStage): HtsgetStackProps => {
   const inventorySourceBuckets = fileManagerInventoryBuckets(stage);
   const eventSourceBuckets = fileManagerBuckets(stage);
 
@@ -22,5 +23,6 @@ export const getHtsgetProps = (stage: AppStage): HtsgetStackConfigurableProps =>
       customDomainNamePrefix: 'htsget-file',
     },
     buckets: [...inventorySourceBuckets, ...eventSourceBuckets],
+    roleName: fileManagerIngestRoleName,
   };
 };

--- a/lib/workload/components/api-gateway/index.ts
+++ b/lib/workload/components/api-gateway/index.ts
@@ -69,10 +69,7 @@ export class ApiGatewayConstruct extends Construct {
 
     // umccr acm arn
     const umccrAcmArn = StringParameter.valueForStringParameter(this, '/umccr/certificate_arn');
-    const hostedDomainName = StringParameter.valueForStringParameter(
-      this,
-      '/hosted_zone/umccr/name'
-    );
+    const hostedDomainName = ApiGatewayConstruct.hostedDomainName(this);
     const hostedZoneId = StringParameter.valueForStringParameter(this, '/hosted_zone/umccr/id');
 
     this._domainName = `${props.customDomainNamePrefix}.${hostedDomainName}`;
@@ -235,5 +232,12 @@ export class ApiGatewayConstruct extends Construct {
 
   get domainName(): string {
     return this._domainName;
+  }
+
+  /**
+   * Get the domain name for the UMCCR hosted zone.
+   */
+  static hostedDomainName(scope: Construct): string {
+    return StringParameter.valueForStringParameter(scope, '/hosted_zone/umccr/name');
   }
 }

--- a/lib/workload/stateless/stacks/fmannotator/deploy/stack.ts
+++ b/lib/workload/stateless/stacks/fmannotator/deploy/stack.ts
@@ -16,6 +16,7 @@ import { ISecret, Secret } from 'aws-cdk-lib/aws-secretsmanager';
 import { NamedLambdaRole } from '../../../../components/named-lambda-role';
 import { ManagedPolicy, PolicyStatement, Role } from 'aws-cdk-lib/aws-iam';
 import { IQueue, Queue } from 'aws-cdk-lib/aws-sqs';
+import { ApiGatewayConstruct } from '../../../../components/api-gateway';
 
 /**
  * Config for the FM annotator.
@@ -25,19 +26,13 @@ export type FMAnnotatorConfig = {
   eventBusName: string;
   eventDLQName: string;
   jwtSecretName: string;
+  customDomainNamePrefix: string;
 };
 
 /**
  * Props for the FM annotator stack which can be configured
  */
-export type FMAnnotatorConfigurableProps = StackProps & FMAnnotatorConfig;
-
-/**
- * Props for the FM annotator stack.
- */
-export type FMAnnotatorProps = FMAnnotatorConfigurableProps & {
-  domainName: string;
-};
+export type FMAnnotatorProps = StackProps & FMAnnotatorConfig;
 
 /**
  * Construct used to configure the FM annotator.
@@ -75,8 +70,9 @@ export class FMAnnotator extends Stack {
       )
     );
 
+    const domain = ApiGatewayConstruct.hostedDomainName(this);
     const env = {
-      FMANNOTATOR_FILE_MANAGER_ENDPOINT: `https://${props.domainName}`,
+      FMANNOTATOR_FILE_MANAGER_ENDPOINT: `https://${props.customDomainNamePrefix}.${domain}`,
       FMANNOTATOR_FILE_MANAGER_SECRET_NAME: tokenSecret.secretName,
       FMANNOTATOR_QUEUE_NAME: this.dlq.queueName,
       FMANNOTATOR_QUEUE_MAX_MESSAGES: '100',

--- a/lib/workload/stateless/stacks/htsget/stack.ts
+++ b/lib/workload/stateless/stacks/htsget/stack.ts
@@ -8,7 +8,7 @@ import { HtsgetLambda } from 'htsget-lambda';
 /**
  * Configurable props for the htsget stack.
  */
-export type HtsgetStackConfigurableProps = {
+export type HtsgetStackProps = {
   /**
    * Props to lookup vpc.
    */
@@ -21,16 +21,10 @@ export type HtsgetStackConfigurableProps = {
    * The buckets to configure for htsget access.
    */
   buckets: string[];
-};
-
-/**
- * Props for the data migrate stack.
- */
-export type HtsgetStackProps = HtsgetStackConfigurableProps & {
   /**
-   * The role to use.
+   * The role name to use.
    */
-  role: Role;
+  roleName: string;
 };
 
 /**
@@ -45,6 +39,7 @@ export class HtsgetStack extends Stack {
 
     this.vpc = Vpc.fromLookup(this, 'MainVpc', props.vpcProps);
     this.apiGateway = new ApiGatewayConstruct(this, 'ApiGateway', props.apiGatewayCognitoProps);
+    const role = Role.fromRoleName(this, 'Role', props.roleName);
 
     new HtsgetLambda(this, 'Htsget', {
       htsgetConfig: {
@@ -60,7 +55,7 @@ export class HtsgetStack extends Stack {
       },
       cargoLambdaFlags: ['--features', 'aws'],
       vpc: this.vpc,
-      role: props.role,
+      role,
       httpApi: this.apiGateway.httpApi,
       gitReference: 'htsget-lambda-v0.6.0',
       gitForceClone: false,

--- a/lib/workload/stateless/statelessStackCollectionClass.ts
+++ b/lib/workload/stateless/statelessStackCollectionClass.ts
@@ -48,7 +48,7 @@ import {
   OraCompressionIcav2PipelineManagerStackProps,
 } from './stacks/ora-compression-manager/deploy';
 
-import { FMAnnotator, FMAnnotatorConfigurableProps } from './stacks/fmannotator/deploy/stack';
+import { FMAnnotator, FMAnnotatorProps } from './stacks/fmannotator/deploy/stack';
 import {
   PieriandxPipelineManagerStack,
   PierianDxPipelineManagerStackProps,
@@ -67,7 +67,7 @@ import {
 } from './stacks/ora-decompression-manager/deploy';
 import { PgDDStack, PgDDStackProps } from './stacks/pg-dd/deploy/stack';
 import { DataMigrateStack, DataMigrateStackProps } from './stacks/data-migrate/deploy/stack';
-import { HtsgetStack, HtsgetStackConfigurableProps } from './stacks/htsget/stack';
+import { HtsgetStack, HtsgetStackProps } from './stacks/htsget/stack';
 import { SampleSheetCheckerStackProps } from './stacks/sample-sheet-check/stack';
 import { FastqManagerStack, FastqManagerStackProps } from './stacks/fastq-manager/deploy/stack';
 import {
@@ -105,9 +105,9 @@ export interface StatelessStackCollectionProps {
   dataSchemaStackProps: SchemaStackProps;
   bclConvertManagerStackProps: BclConvertManagerStackProps;
   stackyMcStackFaceProps: GlueStackProps;
-  fmAnnotatorProps: FMAnnotatorConfigurableProps;
+  fmAnnotatorProps: FMAnnotatorProps;
   dataMigrateProps: DataMigrateStackProps;
-  htsgetProps: HtsgetStackConfigurableProps;
+  htsgetProps: HtsgetStackProps;
   sampleSheetCheckerProps: SampleSheetCheckerStackProps;
   pgDDProps?: PgDDStackProps;
   fastqManagerStackProps: FastqManagerStackProps;
@@ -166,11 +166,10 @@ export class StatelessStackCollection {
       ...statelessConfiguration.dataSchemaStackProps,
     });
 
-    const fileManagerStack = new Filemanager(scope, 'FileManagerStack', {
+    new Filemanager(scope, 'FileManagerStack', {
       ...this.createTemplateProps(env, 'FileManagerStack'),
       ...statelessConfiguration.fileManagerStackProps,
     });
-    this.fileManagerStack = fileManagerStack;
 
     this.metadataManagerStack = new MetadataManagerStack(scope, 'MetadataManagerStack', {
       ...this.createTemplateProps(env, 'MetadataManagerStack'),
@@ -324,7 +323,6 @@ export class StatelessStackCollection {
     this.fmAnnotator = new FMAnnotator(scope, 'FMAnnotatorStack', {
       ...this.createTemplateProps(env, 'FMAnnotatorStack'),
       ...statelessConfiguration.fmAnnotatorProps,
-      domainName: fileManagerStack.domainName,
     });
     this.dataMigrate = new DataMigrateStack(scope, 'DataMigrateStack', {
       ...this.createTemplateProps(env, 'DataMigrateStack'),
@@ -333,7 +331,6 @@ export class StatelessStackCollection {
     this.htsgetStack = new HtsgetStack(scope, 'HtsgetStack', {
       ...this.createTemplateProps(env, 'HtsgetStack'),
       ...statelessConfiguration.htsgetProps,
-      role: fileManagerStack.ingestRole,
     });
 
     /**

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "constructs": "^10.4.2",
     "core-js-pure": "npm:3.41.0",
     "dotenv": "^16.4.7",
-    "htsget-lambda": "^0.8.7",
+    "htsget-lambda": "^0.9.0",
     "source-map-support": "^0.5.21",
     "sqs-dlq-monitoring": "^1.2.20"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2756,6 +2756,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cargo-lambda-cdk@npm:^0.0.33":
+  version: 0.0.33
+  resolution: "cargo-lambda-cdk@npm:0.0.33"
+  dependencies:
+    js-toml: "npm:^0.1.1"
+  peerDependencies:
+    aws-cdk-lib: ^2.63.0
+    constructs: ^10.0.5
+  checksum: 10c0/5e4835cb557009f10ea5b06c3af338fdb179c7f303c56061ae40255062feb599f1cde06b4870db1a0db77b8692afc8730221e281d0991e639b70702468f95929
+  languageName: node
+  linkType: hard
+
 "case@npm:1.6.3":
   version: 1.6.3
   resolution: "case@npm:1.6.3"
@@ -3761,16 +3773,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htsget-lambda@npm:^0.8.7":
-  version: 0.8.7
-  resolution: "htsget-lambda@npm:0.8.7"
+"htsget-lambda@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "htsget-lambda@npm:0.9.0"
   dependencies:
-    cargo-lambda-cdk: "npm:^0.0.31"
+    cargo-lambda-cdk: "npm:^0.0.33"
   peerDependencies:
     aws-cdk-lib: ^2.112.0
   bin:
     htsget_app: bin/htsget-lambda.js
-  checksum: 10c0/4b92b1e0416ef3f24b97f3b25613d5a17ce8fcc75576c43b8c0827a3ef165ebc229e63a174093518dbccafefd6bbb676411e00113ae8ac64cb545eea59afe3b5
+  checksum: 10c0/404ba21622ad1b39fd363265bff73f510604a2ac204c972fa1a107eec70df95f0990de4991b6b3f0f41c29b1386daebb5f3fa43241f2d37d5207d946022e87d1
   languageName: node
   linkType: hard
 
@@ -5082,7 +5094,7 @@ __metadata:
     eslint: "npm:^9.19.0"
     eslint-config-prettier: "npm:^10.0.1"
     globals: "npm:^15.14.0"
-    htsget-lambda: "npm:^0.8.7"
+    htsget-lambda: "npm:^0.9.0"
     jest: "npm:^29.7.0"
     jest-junit: "npm:^16.0.0"
     prettier: "npm:^3.4.2"


### PR DESCRIPTION
### Changes
* Removes direct stack-based dependency on filemanager from htsget and fmannotator.
* Update htsget-rs construct dependency to support `IRole` instead of `Role`.

I need to remove this because otherwise when migrating filemanager to the new [repo](https://github.com/OrcaBus/service-filemanager), I can't update the new stack because CloudFormation expects that the FileManager stack exports variables for the domain name and ingest role. This way, the dependency is more loosely coupled (with constants/parameters) so it won't refuse to update in CloudFormation.

This shouldn't result in any changes to the behaviour of the services.