### PR TITLE
Detach primary data services

### DIFF
--- a/lib/workload/stateful/statefulStackCollectionClass.ts
+++ b/lib/workload/stateful/statefulStackCollectionClass.ts
@@ -194,15 +194,15 @@ export class StatefulStackCollection {
       ...statefulConfiguration.icaEventPipeStackProps,
     });
 
-    this.bclconvertInteropQcIcav2PipelineTableStack =
-      new BclconvertInteropQcIcav2PipelineTableStack(
-        scope,
-        'BclconvertInteropQcIcav2PipelineTableStack',
-        {
-          ...this.createTemplateProps(env, 'BclconvertInteropQcIcav2PipelineTable'),
-          ...statefulConfiguration.bclconvertInteropQcIcav2PipelineTableStackProps,
-        }
-      );
+    // this.bclconvertInteropQcIcav2PipelineTableStack =
+    //   new BclconvertInteropQcIcav2PipelineTableStack(
+    //     scope,
+    //     'BclconvertInteropQcIcav2PipelineTableStack',
+    //     {
+    //       ...this.createTemplateProps(env, 'BclconvertInteropQcIcav2PipelineTable'),
+    //       ...statefulConfiguration.bclconvertInteropQcIcav2PipelineTableStackProps,
+    //     }
+    //   );
 
     this.cttsov2Icav2PipelineTableStack = new Cttsov2Icav2PipelineTable(
       scope,

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/handy-pal/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/handy-pal/index.ts
@@ -33,7 +33,7 @@ export class OncoanalyserGlueHandlerConstruct extends NestedStack {
     /*
       Part 1
 
-      Input Event Source: `orcabus.instrumentrunmanager`
+      Input Event Source: `orcabus.fastqglue`
       Input Event DetailType: `SamplesheetMetadataUnion`
       Input Event status: `LibraryInSamplesheet`
 
@@ -52,8 +52,8 @@ export class OncoanalyserGlueHandlerConstruct extends NestedStack {
     /*
         Part 2
 
-        Input Event Source: `orcabus.instrumentrunmanager`
-        Input Event DetailType: `FastqListRowStateChange`
+        Input Event Source: `orcabus.fastqglue`
+        Input Event DetailType: `StackyFastqListRowStateChange`
         Input Event status: `newFastqListRow`
 
         * Populate the fastq list row attributes for the rgid for this workflow
@@ -70,8 +70,8 @@ export class OncoanalyserGlueHandlerConstruct extends NestedStack {
     /*
         Part 3
 
-        Input Event Source: `orcabus.instrumentrunmanager`
-        Input Event DetailType: `FastqListRowStateChange`
+        Input Event Source: `orcabus.fastqglue`
+        Input Event DetailType: `StackyFastqListRowStateChange`
         Input Event status: `FastqListRowEventShowerComplete`
 
         Output Event source: `orcabus.oncoanalyserinputeventglue`

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/handy-pal/part_1/initialise-wts-and-wgs-libraries/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/handy-pal/part_1/initialise-wts-and-wgs-libraries/index.ts
@@ -12,7 +12,7 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 2
 
-Input Event Source: `orcabus.instrumentrunmanager`
+Input Event Source: `orcabus.fastqglue`
 Input Event DetailType: `SamplesheetMetadataUnion`
 Input Event status: `LibraryInSamplesheet`
 
@@ -32,7 +32,7 @@ export class OncoanalyserInitialiseLibraryAndFastqListRowConstruct extends Const
       library: 'library',
       fastqListRow: 'fastq_list_row',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerSampleType: {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/handy-pal/part_2/populate-fastq-list-rows/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/handy-pal/part_2/populate-fastq-list-rows/index.ts
@@ -20,9 +20,9 @@ export class OncoanalyserPopulateFastqListRowConstruct extends Construct {
   public readonly OncoanalyserPopulateFastqListRowRunDbRowMap = {
     prefix: 'handypal-populate-fqlr-row',
     tablePartition: 'fastq_list_row',
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'newFastqListRow',
-    triggerDetailType: 'FastqListRowStateChange',
+    triggerDetailType: 'StackyFastqListRowStateChange',
   };
 
   constructor(

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/index.ts
@@ -5,9 +5,9 @@ import * as ssm from 'aws-cdk-lib/aws-ssm';
 import * as cdk from 'aws-cdk-lib';
 import * as secretsManager from 'aws-cdk-lib/aws-secretsmanager';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
-import { showerGlueHandlerConstruct } from './clag';
-import { BclconvertToBsshFastqCopyEventHandlerConstruct } from './elmer';
-import { BsshFastqCopyToBclconvertInteropQcConstruct } from './gorilla';
+// import { showerGlueHandlerConstruct } from './clag';
+// import { BclconvertToBsshFastqCopyEventHandlerConstruct } from './elmer';
+// import { BsshFastqCopyToBclconvertInteropQcConstruct } from './gorilla';
 import { Cttsov2GlueHandlerConstruct } from './jb-weld';
 import { WgtsQcGlueHandlerConstruct } from './kwik';
 import { TnGlueHandlerConstruct } from './loctite';
@@ -63,40 +63,40 @@ export class GlueConstruct extends Construct {
     /*
     Part A: Send 'showered' events if a new samplesheet arrives or new fastq list rows arrive
     */
-    const clag = new showerGlueHandlerConstruct(this, 'clag', {
-      /* Event Bus */
-      eventBusObj: props.eventBusObj,
-      /* Tables */
-      instrumentRunTableObj: props.instrumentRunTableObj,
-      /* Secrets */
-      icav2AccessTokenSecretObj: props.icav2AccessTokenSecretObj,
-    });
+    // const clag = new showerGlueHandlerConstruct(this, 'clag', {
+    //   /* Event Bus */
+    //   eventBusObj: props.eventBusObj,
+    //   /* Tables */
+    //   instrumentRunTableObj: props.instrumentRunTableObj,
+    //   /* Secrets */
+    //   icav2AccessTokenSecretObj: props.icav2AccessTokenSecretObj,
+    // });
 
     /*
     Part B: Copy the fastq list rows by connecting the bclconvert manager completion with the bsshfastqcopy manager
     */
-    const elmer = new BclconvertToBsshFastqCopyEventHandlerConstruct(this, 'elmer', {
-      /* Event Bus */
-      eventBusObj: props.eventBusObj,
-      /* SSM Parameters */
-      bsshOutputFastqCopyUriSsmParameterObj: props.bsshOutputFastqCopyOutputUriSsmParameterObj,
-      /* Secrets */
-      icav2AccessTokenSecretObj: props.icav2AccessTokenSecretObj,
-    });
+    // const elmer = new BclconvertToBsshFastqCopyEventHandlerConstruct(this, 'elmer', {
+    //   /* Event Bus */
+    //   eventBusObj: props.eventBusObj,
+    //   /* SSM Parameters */
+    //   bsshOutputFastqCopyUriSsmParameterObj: props.bsshOutputFastqCopyOutputUriSsmParameterObj,
+    //   /* Secrets */
+    //   icav2AccessTokenSecretObj: props.icav2AccessTokenSecretObj,
+    // });
 
     /*
     Part C: Connect the bclconvert interop qc
     */
-    const gorilla = new BsshFastqCopyToBclconvertInteropQcConstruct(this, 'gorilla', {
-      /* Event Objects */
-      eventBusObj: props.eventBusObj,
-      /* SSM Parameter Objects */
-      analysisLogsUriSsmParameterObj: props.analysisLogsUriSsmParameterObj,
-      analysisOutputUriSsmParameterObj: props.analysisOutputUriSsmParameterObj,
-      icav2ProjectIdSsmParameterObj: props.icav2ProjectIdSsmParameterObj,
-      /* Secrets */
-      icav2AccessTokenSecretObj: props.icav2AccessTokenSecretObj,
-    });
+    // const gorilla = new BsshFastqCopyToBclconvertInteropQcConstruct(this, 'gorilla', {
+    //   /* Event Objects */
+    //   eventBusObj: props.eventBusObj,
+    //   /* SSM Parameter Objects */
+    //   analysisLogsUriSsmParameterObj: props.analysisLogsUriSsmParameterObj,
+    //   analysisOutputUriSsmParameterObj: props.analysisOutputUriSsmParameterObj,
+    //   icav2ProjectIdSsmParameterObj: props.icav2ProjectIdSsmParameterObj,
+    //   /* Secrets */
+    //   icav2AccessTokenSecretObj: props.icav2AccessTokenSecretObj,
+    // });
 
     /*
     Part D: Plumber-up the oncoanalyser services

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/index.ts
@@ -34,7 +34,7 @@ export class Cttsov2GlueHandlerConstruct extends NestedStack {
     /*
         Part 1
 
-        Input Event Source: `orcabus.instrumentrunmanager`
+        Input Event Source: `orcabus.fastqglue`
         Input Event DetailType: `SamplesheetMetadataUnion`
         Input Event status: `LibraryInSamplesheet`
 
@@ -53,8 +53,8 @@ export class Cttsov2GlueHandlerConstruct extends NestedStack {
     /*
         Part 2
 
-        Input Event Source: `orcabus.instrumentrunmanager`
-        Input Event DetailType: `FastqListRowStateChange`
+        Input Event Source: `orcabus.fastqglue`
+        Input Event DetailType: `StackyFastqListRowStateChange`
         Input Event status: `newFastqListRow`
 
         * Populate the fastq list row attributes for the rgid for this workflow
@@ -71,8 +71,8 @@ export class Cttsov2GlueHandlerConstruct extends NestedStack {
     /*
         Part 3
 
-        Input Event Source: `orcabus.instrumentrunmanager`
-        Input Event DetailType: `FastqListRowStateChange`
+        Input Event Source: `orcabus.fastqglue`
+        Input Event DetailType: `StackyFastqListRowStateChange`
         Input Event status: `FastqListRowEventShowerComplete`
 
         Output Event source: `orcabus.cttsov2inputeventglue`

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/part_1/initialise-cttsov2-library-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/part_1/initialise-cttsov2-library-dbs/index.ts
@@ -8,7 +8,7 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 2
 
-Input Event Source: `orcabus.instrumentrunmanager`
+Input Event Source: `orcabus.fastqglue`
 Input Event DetailType: `SamplesheetMetadataUnion`
 Input Event status: `LibraryInSamplesheet`
 
@@ -29,7 +29,7 @@ export class Cttsov2InitialiseLibraryAndFastqListRowConstruct extends Construct 
       bclconvertDataRow: 'bclconvert_data',
       fastqListRow: 'fastq_list_row',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerSampleType: 'ctdna',

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/part_2/populate-fastq-list-row-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/part_2/populate-fastq-list-row-dbs/index.ts
@@ -8,8 +8,8 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 3
 
-Input Event Source: `orcabus.instrumentrunmanager`
-Input Event DetailType: `FastqListRowStateChange`
+Input Event Source: `orcabus.fastqglue`
+Input Event DetailType: `StackyFastqListRowStateChange`
 Input Event status: `newFastqListRow`
 
 * Populate the fastq list row attributes for the rgid for this workflow
@@ -24,9 +24,9 @@ export class Cttsov2PopulateFastqListRowConstruct extends Construct {
   public readonly Cttsov2PopulateFastqListRowRunDbRowMap = {
     prefix: 'jbweld-populate-fqlr-row',
     tablePartition: 'fastq_list_row',
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'newFastqListRow',
-    triggerDetailType: 'FastqListRowStateChange',
+    triggerDetailType: 'StackyFastqListRowStateChange',
   };
 
   constructor(

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/part_3/fastq-list-row-event-shower-complete-to-cttsov2-ready/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/jb-weld/part_3/fastq-list-row-event-shower-complete-to-cttsov2-ready/index.ts
@@ -17,8 +17,8 @@ import { NagSuppressions } from 'cdk-nag';
 /*
 Part 4
 
-Input Event Source: `orcabus.instrumentrunmanager`
-Input Event DetailType: `FastqListRowStateChange`
+Input Event Source: `orcabus.fastqglue`
+Input Event DetailType: `FastqListRowShowerStateChange`
 Input Event status: `FastqListRowEventShowerComplete`
 
 Output Event source: `orcabus.cttsov2inputeventglue`
@@ -57,7 +57,7 @@ export class Cttsov2FastqListRowShowerCompleteToWorkflowDraftConstruct extends C
     },
     portalRunPartitionName: 'portal_run', // For workflow table
     /* Input Event Settings */
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'FastqListRowEventShowerComplete',
     triggerDetailType: 'FastqListRowShowerStateChange',
     /* Output Event Settings */

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/index.ts
@@ -36,7 +36,7 @@ export class WgtsQcGlueHandlerConstruct extends NestedStack {
     /*
     Part 1
 
-    Input Event Source: `orcabus.instrumentrunmanager`
+    Input Event Source: `orcabus.fastqglue`
     Input Event DetailType: `SamplesheetMetadataUnion`
     Input Event status: `LibraryInSamplesheet`
 
@@ -55,8 +55,8 @@ export class WgtsQcGlueHandlerConstruct extends NestedStack {
     /*
     Part 2
 
-    Input Event Source: `orcabus.instrumentrunmanager`
-    Input Event DetailType: `FastqListRowStateChange`
+    Input Event Source: `orcabus.fastqglue`
+    Input Event DetailType: `StackyFastqListRowStateChange`
     Input Event status: `newFastqListRow`
 
     * Populate the fastq list row attributes for the rgid for this workflow
@@ -73,8 +73,8 @@ export class WgtsQcGlueHandlerConstruct extends NestedStack {
     /*
     Part 3
 
-    Input Event Source: `orcabus.instrumentrunmanager`
-    Input Event DetailType: `FastqListRowStateChange`
+    Input Event Source: `orcabus.fastqglue`
+    Input Event DetailType: `FastqListRowShowerStateChange`
     Input Event status: `FastqListRowEventShowerComplete`
 
     Output Event source: `orcabus.wgtsqcinputeventglue`
@@ -115,7 +115,7 @@ export class WgtsQcGlueHandlerConstruct extends NestedStack {
     Input Event WorkflowName: `wgts_qc`
 
     Output Event Source: `orcabus.wgtsqcinputeventglue`
-    Output Event DetailType: `FastqListRowStateChange`
+    Output Event DetailType: `StackyFastqListRowStateChange`
     Output Event status: `QcComplete`
 
     * Subscribe to workflow run state change events, map the fastq list row id from the portal run id in the data base
@@ -135,7 +135,7 @@ export class WgtsQcGlueHandlerConstruct extends NestedStack {
     Part 5
 
     Input Event Source: `orcabus.wgtsqcinputeventglue`
-    Input Event DetailType: `FastqListRowStateChange`
+    Input Event DetailType: `StackyFastqListRowStateChange`
     Input Event status: `QcComplete`
 
     Output Event Source: `orcabus.wgtsqcinputeventglue`

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_1/initialise-wgts-library-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_1/initialise-wgts-library-dbs/index.ts
@@ -8,7 +8,7 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 2
 
-Input Event Source: `orcabus.instrumentrunmanager`
+Input Event Source: `orcabus.fastqglue`
 Input Event DetailType: `SamplesheetMetadataUnion`
 Input Event status: `LibraryInSamplesheet`
 
@@ -30,7 +30,7 @@ export class WgtsQcInitialiseLibraryAndFastqListRowConstruct extends Construct {
       library: 'library',
       fastqListRow: 'fastq_list_row',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerSampleType: {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_2/populate-fastq-list-row-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_2/populate-fastq-list-row-dbs/index.ts
@@ -8,8 +8,8 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 3
 
-Input Event Source: `orcabus.instrumentrunmanager`
-Input Event DetailType: `FastqListRowStateChange`
+Input Event Source: `orcabus.fastqglue`
+Input Event DetailType: `StackyFastqListRowStateChange`
 Input Event status: `newFastqListRow`
 
 * Populate the fastq list row attributes for the rgid for this workflow
@@ -24,9 +24,9 @@ export class WgtsQcPopulateFastqListRowConstruct extends Construct {
   public readonly WgtsQcPopulateFastqListRowRunDbRowMap = {
     prefix: 'kwik-populate-fqlr-row',
     tablePartition: 'fastq_list_row',
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'newFastqListRow',
-    triggerDetailType: 'FastqListRowStateChange',
+    triggerDetailType: 'StackyFastqListRowStateChange',
   };
 
   constructor(

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_3/fastq-list-rows-shower-complete-to-wgts-qc/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_3/fastq-list-rows-shower-complete-to-wgts-qc/index.ts
@@ -17,8 +17,8 @@ import { NagSuppressions } from 'cdk-nag';
 /*
 Part 3
 
-Input Event Source: `orcabus.instrumentrunmanager`
-Input Event DetailType: `FastqListRowStateChange`
+Input Event Source: `orcabus.fastqglue`
+Input Event DetailType: `FastqListRowShowerStateChange`
 Input Event status: `FastqListRowEventShowerComplete`
 
 Output Event source: `orcabus.wgtsinputeventglue`
@@ -55,7 +55,7 @@ export class WgtsQcFastqListRowShowerCompleteToWorkflowReadyConstruct extends Co
     },
     portalRunPartitionName: 'portal_run',
     /* Input Event Settings */
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'FastqListRowEventShowerComplete',
     triggerDetailType: 'FastqListRowShowerStateChange',
     /* Output Source */

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_4/push-fastq-list-row-qc-complete-event/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_4/push-fastq-list-row-qc-complete-event/index.ts
@@ -19,7 +19,7 @@ Input Event status: `succeeded`
 Input Event WorkflowName: `wgts_qc`
 
 Output Event Source: `orcabus.wgtsqcinputeventglue`
-Output Event DetailType: `FastqListRowStateChange`
+Output Event DetailType: `StackyFastqListRowStateChange`
 Output Event status: `QcComplete`
 
 * Subscribe to workflow run state change events, map the fastq list row id from the portal run id in the database
@@ -42,7 +42,7 @@ export class FastqListRowQcCompleteConstruct extends Construct {
     triggerDetailType: 'WorkflowRunStateChange',
     triggerWorkflowName: 'wgts-qc',
     outputSource: 'orcabus.wgtsqcinputeventglue',
-    outputDetailType: 'FastqListRowStateChange',
+    outputDetailType: 'StackyFastqListRowStateChange',
     outputStatus: 'QC_COMPLETE',
     payloadVersion: '2024.05.24',
   };

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_5/library-qc-complete-event/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/kwik/part_5/library-qc-complete-event/index.ts
@@ -11,7 +11,7 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 Part 7
 
 Input Event Source: `orcabus.wgtsqcinputeventglue`
-Input Event DetailType: `FastqListRowStateChange`
+Input Event DetailType: `StackyFastqListRowStateChange`
 Input Event status: `QcComplete`
 
 Output Event Source: `orcabus.wgtsqcinputeventglue`
@@ -38,7 +38,7 @@ export class WgtsQcLibraryQcCompleteConstruct extends Construct {
     payloadVersion: '2024.07.16',
     triggerSource: 'orcabus.wgtsqcinputeventglue',
     triggerStatus: 'QC_COMPLETE',
-    triggerDetailType: 'FastqListRowStateChange',
+    triggerDetailType: 'StackyFastqListRowStateChange',
     outputSource: 'orcabus.wgtsqcinputeventglue',
     outputDetailType: 'LibraryStateChange',
     outputStatus: 'QC_COMPLETE',

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/loctite/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/loctite/index.ts
@@ -33,7 +33,7 @@ export class TnGlueHandlerConstruct extends NestedStack {
     /*
         Part 1
 
-        Input Event Source: `orcabus.instrumentrunmanager`
+        Input Event Source: `orcabus.fastqglue`
         Input Event DetailType: `SamplesheetMetadataUnion`
         Input Event status: `LibraryInSamplesheet`
 
@@ -51,8 +51,8 @@ export class TnGlueHandlerConstruct extends NestedStack {
     /*
         Part 2
 
-        Input Event Source: `orcabus.instrumentrunmanager`
-        Input Event DetailType: `FastqListRowStateChange`
+        Input Event Source: `orcabus.fastqglue`
+        Input Event DetailType: `StackyFastqListRowStateChange`
         Input Event status: `newFastqListRow`
 
         * Populate the fastq list row attributes for the rgid for this workflow

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/loctite/part_1/initialise-tn-library-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/loctite/part_1/initialise-tn-library-dbs/index.ts
@@ -8,7 +8,7 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 2
 
-Input Event Source: `orcabus.instrumentrunmanager`
+Input Event Source: `orcabus.fastqglue`
 Input Event DetailType: `SamplesheetMetadataUnion`
 Input Event status: `LibraryInSamplesheet`
 
@@ -28,7 +28,7 @@ export class TnInitialiseLibraryAndFastqListRowConstruct extends Construct {
       library: 'library',
       fastqListRow: 'fastq_list_row',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerSampleType: {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/loctite/part_2/update-fastq-list-rows-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/loctite/part_2/update-fastq-list-rows-dbs/index.ts
@@ -8,8 +8,8 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 3
 
-Input Event Source: `orcabus.instrumentrunmanager`
-Input Event DetailType: `FastqListRowStateChange`
+Input Event Source: `orcabus.fastqglue`
+Input Event DetailType: `StackyFastqListRowStateChange`
 Input Event status: `newFastqListRow`
 
 * Populate the fastq list row attributes for the rgid for this workflow
@@ -24,9 +24,9 @@ export class TnPopulateFastqListRowConstruct extends Construct {
   public readonly TnPopulateFastqListRowDbRowMap = {
     prefix: 'loctite-populate-fqlr-row',
     tablePartition: 'fastq_list_row',
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'newFastqListRow',
-    triggerDetailType: 'FastqListRowStateChange',
+    triggerDetailType: 'StackyFastqListRowStateChange',
   };
 
   constructor(scope: Construct, id: string, props: TnPopulateFastqListRowDbRowConstructProps) {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/mod-podge/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/mod-podge/index.ts
@@ -33,7 +33,7 @@ export class WtsGlueHandlerConstruct extends NestedStack {
     /*
     Part 1
 
-    Input Event Source: `orcabus.instrumentrunmanager`
+    Input Event Source: `orcabus.fastqglue`
     Input Event DetailType: `SamplesheetMetadataUnion`
     Input Event status: `LibraryInSamplesheet`
 
@@ -51,8 +51,8 @@ export class WtsGlueHandlerConstruct extends NestedStack {
     /*
     Part 2
 
-    Input Event Source: `orcabus.instrumentrunmanager`
-    Input Event DetailType: `FastqListRowStateChange`
+    Input Event Source: `orcabus.fastqglue`
+    Input Event DetailType: `StackyFastqListRowStateChange`
     Input Event status: `newFastqListRow`
 
     * Populate the fastq list row attributes for the rgid for this workflow

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/mod-podge/part_1/initialise-wts-library-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/mod-podge/part_1/initialise-wts-library-dbs/index.ts
@@ -8,7 +8,7 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 1
 
-Input Event Source: `orcabus.instrumentrunmanager`
+Input Event Source: `orcabus.fastqglue`
 Input Event DetailType: `SamplesheetMetadataUnion`
 Input Event status: `LibraryInSamplesheet`
 
@@ -27,7 +27,7 @@ export class WtsInitialiseLibraryAndFastqListRowConstruct extends Construct {
       library: 'library',
       fastqListRow: 'fastq_list_row',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerSampleType: {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/mod-podge/part_2/update-fastq-list-rows-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/mod-podge/part_2/update-fastq-list-rows-dbs/index.ts
@@ -8,8 +8,8 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 2
 
-Input Event Source: `orcabus.instrumentrunmanager`
-Input Event DetailType: `FastqListRowStateChange`
+Input Event Source: `orcabus.fastqglue`
+Input Event DetailType: `StackyFastqListRowStateChange`
 Input Event status: `newFastqListRow`
 
 * Populate the fastq list row attributes for the rgid for this workflow
@@ -24,9 +24,9 @@ export class WtsPopulateFastqListRowConstruct extends Construct {
   public readonly WtsPopulateFastqListRowDbRowMap = {
     prefix: 'modpodge-update-fqlr',
     tablePartition: 'fastq_list_row',
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'newFastqListRow',
-    triggerDetailType: 'FastqListRowStateChange',
+    triggerDetailType: 'StackyFastqListRowStateChange',
   };
 
   constructor(scope: Construct, id: string, props: WtsPopulateFastqListRowDbRowConstructProps) {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/index.ts
@@ -38,7 +38,7 @@ export class PieriandxGlueHandlerConstruct extends NestedStack {
     /*
     Part 1
 
-    Input Event Source: `orcabus.instrumentrunmanager`
+    Input Event Source: `orcabus.fastqglue`
     Input Event DetailType: `SamplesheetMetadataUnion`
     Input Event status: `LibraryInSamplesheet`
 

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_1/initialise-library-db/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/nails/part_1/initialise-library-db/index.ts
@@ -33,7 +33,7 @@ export class PieriandxInitialiseLibraryConstruct extends Construct {
     tablePartition: {
       library: 'library',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerAssayType: {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/pva/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/pva/index.ts
@@ -31,7 +31,7 @@ export class UmccriseGlueHandlerConstruct extends NestedStack {
     /*
     Part 1
 
-    Input Event Source: `orcabus.instrumentrunmanager`
+    Input Event Source: `orcabus.fastqglue`
     Input Event DetailType: `SamplesheetMetadataUnion`
     Input Event status: `LibraryInSamplesheet`
 

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/pva/part_1/initialise-umccrise-library-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/pva/part_1/initialise-umccrise-library-dbs/index.ts
@@ -8,7 +8,7 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 2
 
-Input Event Source: `orcabus.instrumentrunmanager`
+Input Event Source: `orcabus.fastqglue`
 Input Event DetailType: `SamplesheetMetadataUnion`
 Input Event status: `LibraryInSamplesheet`
 
@@ -26,7 +26,7 @@ export class UmccriseInitialiseLibraryConstruct extends Construct {
     tablePartition: {
       library: 'library',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerSampleType: {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/roket/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/roket/index.ts
@@ -32,7 +32,7 @@ export class RnasumGlueHandlerConstruct extends NestedStack {
 
     /*
     Part 1
-    Input Event Source: `orcabus.instrumentrunmanager`
+    Input Event Source: `orcabus.fastqglue`
     Input Event DetailType: `SamplesheetMetadataUnion`
     Input Event status: `LibraryInSamplesheet`
 

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/roket/part_1/initialise-rnasum-library-dbs/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/roket/part_1/initialise-rnasum-library-dbs/index.ts
@@ -8,7 +8,7 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 2
 
-Input Event Source: `orcabus.instrumentrunmanager`
+Input Event Source: `orcabus.fastqglue`
 Input Event DetailType: `SamplesheetMetadataUnion`
 Input Event status: `LibraryInSamplesheet`
 
@@ -26,7 +26,7 @@ export class RnasumInitialiseLibraryConstruct extends Construct {
     tablePartition: {
       library: 'library',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerSampleType: {

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/t-rex/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/t-rex/index.ts
@@ -36,7 +36,7 @@ export class OncoanalyserBothSashGlueHandlerConstruct extends NestedStack {
     /*
       Part 1
 
-      Input Event Source: `orcabus.instrumentrunmanager`
+      Input Event Source: `orcabus.fastqglue`
       Input Event DetailType: `SamplesheetMetadataUnion`
       Input Event status: `LibraryInSamplesheet`
 

--- a/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/t-rex/part_1/initialise-wts-wgs-libraries/index.ts
+++ b/lib/workload/stateless/stacks/stacky-mcstackface/glue-constructs/t-rex/part_1/initialise-wts-wgs-libraries/index.ts
@@ -12,7 +12,7 @@ import * as eventsTargets from 'aws-cdk-lib/aws-events-targets';
 /*
 Part 2
 
-Input Event Source: `orcabus.instrumentrunmanager`
+Input Event Source: `orcabus.fastqglue`
 Input Event DetailType: `SamplesheetMetadataUnion`
 Input Event status: `LibraryInSamplesheet`
 
@@ -32,7 +32,7 @@ export class OncoanalyserBothInitialiseLibraryAndFastqListRowConstruct extends C
       library: 'library',
       fastqListRow: 'fastq_list_row',
     },
-    triggerSource: 'orcabus.instrumentrunmanager',
+    triggerSource: 'orcabus.fastqglue',
     triggerStatus: 'LibraryInSamplesheet',
     triggerDetailType: 'SamplesheetMetadataUnion',
     triggerSampleType: {

--- a/lib/workload/stateless/statelessStackCollectionClass.ts
+++ b/lib/workload/stateless/statelessStackCollectionClass.ts
@@ -179,6 +179,30 @@ export class StatelessStackCollection {
     //   ...statelessConfiguration.fileManagerStackProps,
     // });
 
+    // this.bsshIcav2FastqCopyManagerStack = new BsshIcav2FastqCopyManagerStack(
+    //   scope,
+    //   'BsshIcav2FastqCopyManagerStack',
+    //   {
+    //     ...this.createTemplateProps(env, 'BsshIcav2FastqCopyManagerStack'),
+    //     ...statelessConfiguration.bsshIcav2FastqCopyManagerStackProps,
+    //   }
+    // );
+
+    // this.bclconvertInteropQcIcav2PipelineManagerStack =
+    //   new BclconvertInteropQcIcav2PipelineManagerStack(
+    //     scope,
+    //     'BclconvertInteropQcIcav2PipelineManagerStack',
+    //     {
+    //       ...this.createTemplateProps(env, 'BclconvertInteropQcIcav2PipelineManagerStack'),
+    //       ...statelessConfiguration.bclconvertInteropQcIcav2PipelineManagerStackProps,
+    //     }
+    //   );
+
+    //     this.fastqGlueStack = new FastqGlueStack(scope, 'FastqGlueStack', {
+    //   ...this.createTemplateProps(env, 'FastqGlueStack'),
+    //   ...statelessConfiguration.fastqGlueStackProps,
+    // });
+
     this.eventSchemaStack = new SchemaStack(scope, 'EventSchemaStack', {
       ...this.createTemplateProps(env, 'EventSchemaStack'),
       ...statelessConfiguration.eventSchemaStackProps,
@@ -188,25 +212,6 @@ export class StatelessStackCollection {
       ...this.createTemplateProps(env, 'DataSchemaStack'),
       ...statelessConfiguration.dataSchemaStackProps,
     });
-
-    this.bsshIcav2FastqCopyManagerStack = new BsshIcav2FastqCopyManagerStack(
-      scope,
-      'BsshIcav2FastqCopyManagerStack',
-      {
-        ...this.createTemplateProps(env, 'BsshIcav2FastqCopyManagerStack'),
-        ...statelessConfiguration.bsshIcav2FastqCopyManagerStackProps,
-      }
-    );
-
-    this.bclconvertInteropQcIcav2PipelineManagerStack =
-      new BclconvertInteropQcIcav2PipelineManagerStack(
-        scope,
-        'BclconvertInteropQcIcav2PipelineManagerStack',
-        {
-          ...this.createTemplateProps(env, 'BclconvertInteropQcIcav2PipelineManagerStack'),
-          ...statelessConfiguration.bclconvertInteropQcIcav2PipelineManagerStackProps,
-        }
-      );
 
     this.cttsov2Icav2PipelineManagerStack = new Cttsov2Icav2PipelineManagerStack(
       scope,
@@ -362,10 +367,6 @@ export class StatelessStackCollection {
     this.dataSharingStack = new DataSharingStack(scope, 'DataSharingStack', {
       ...this.createTemplateProps(env, 'DataSharingStack'),
       ...statelessConfiguration.dataSharingStackProps,
-    });
-    this.fastqGlueStack = new FastqGlueStack(scope, 'FastqGlueStack', {
-      ...this.createTemplateProps(env, 'FastqGlueStack'),
-      ...statelessConfiguration.fastqGlueStackProps,
     });
   }
 


### PR DESCRIPTION
Clag services now part of the fastq glue stack
* Update downstream stacky services to listen to new events from fastqglue stack instead.
* Renamed FastqListRowStateChange events to StackyFastqListRowStateChange events
* Deprecate the following stacks:
  * bsshIcav2FastqCopyManagerStack - replaced by bssh-fastq-to-aws-s3 copy manager stack in new repo
  * bclconvertInteropQcIcav2PipelineManagerStack - replaced by bclconvert-interop-qc-stack in new repo
  * fastqGlueStack - replaced by fastq-glue stack in new repo