### PR TITLE
fix: remove filemanager and fmannotator tests from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ test-stateful-app-suite:
 
 test-stateless-app-suite:
 	@(cd lib/workload/stateless/stacks/metadata-manager && $(MAKE) test)
-	@(cd lib/workload/stateless/stacks/filemanager && $(MAKE) test)
-	@(cd lib/workload/stateless/stacks/fmannotator && $(MAKE) test)
+#	@(cd lib/workload/stateless/stacks/filemanager && $(MAKE) test)
+#	@(cd lib/workload/stateless/stacks/fmannotator && $(MAKE) test)
 	@(cd lib/workload/stateless/stacks/bclconvert-manager && $(MAKE) test)
 
 # The default outer `test` target run all test in this repo


### PR DESCRIPTION
### Changes
* Removes the filemanager and fmannotator tests as they are no longer needed.