### PR TITLE
Added ora reference support to WGTS QC pipeline

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -338,7 +338,7 @@ External resources required by the wgtsqc Stack
 */
 
 // Deployed under dev/stg/prod
-export const wgtsQcIcav2PipelineIdSSMParameterPath = '/icav2/umccr-prod/wgts_qc_4.2.4_pipeline_id'; // 03689516-b7f8-4dca-bba9-8405b85fae45
+export const wgtsQcIcav2PipelineIdSSMParameterPath = '/icav2/umccr-prod/wgts_qc_4.2.4_pipeline_id'; // ca2b75a0-76c5-417f-a357-9a1a7b3fc796
 
 export const wgtsQcIcav2PipelineWorkflowType = 'wgts-qc';
 export const wgtsQcIcav2PipelineWorkflowTypeVersion = '4.2.4';

--- a/lib/workload/stateless/stacks/wgts-alignment-qc-pipeline-manager/step_functions_templates/set_wgts_alignment_qc_cwl_inputs_sfn.asl.json
+++ b/lib/workload/stateless/stacks/wgts-alignment-qc-pipeline-manager/step_functions_templates/set_wgts_alignment_qc_cwl_inputs_sfn.asl.json
@@ -185,6 +185,10 @@
           "reference_tar": {
             "class": "File",
             "location.$": "$.configure_inputs_step.reference_uri"
+          },
+          "ora_reference_tar": {
+            "class": "File",
+            "location": "s3://pipeline-prod-cache-503977275616-ap-southeast-2/byob-icav2/reference-data/dragen-ora/v2/ora_reference_v2.tar.gz"
           }
         }
       },


### PR DESCRIPTION
Bit of a hacky PR (since we're not bringing wgts-qc forward), to add in the ora reference tarball into the icav2 workflow inputs.  

Only an issue now since BCLConvert now outputs ORA files